### PR TITLE
Underpriced transaction check for dynamic transactions

### DIFF
--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -297,17 +297,7 @@ func TestEth_GasPrice_WithLondonFork(t *testing.T) {
 	// not using newTestEthEndpoint as we need to set priceLimit
 	eth := newTestEthEndpointWithPriceLimit(store, priceLimit)
 
-	t.Run("returns price limit flag value when it is larger than MaxPriorityFee+BaseFee", func(t *testing.T) {
-		store.baseFee = 0
-
-		res, err := eth.GasPrice()
-
-		assert.NoError(t, err)
-		assert.NotNil(t, res)
-		assert.Equal(t, argUint64(priceLimit), res)
-	})
-
-	t.Run("returns MaxPriorityFee+BaseFee when it is larger than set price limit flag", func(t *testing.T) {
+	t.Run("returns MaxPriorityFee+BaseFee", func(t *testing.T) {
 		store.baseFee = baseFee
 
 		res, err := eth.GasPrice()

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -388,7 +388,7 @@ func (e *Eth) getGasPrice() (uint64, error) {
 			return 0, err
 		}
 
-		return common.Max(e.priceLimit, priorityFee.Uint64()+e.store.GetBaseFee()), nil
+		return priorityFee.Uint64() + e.store.GetBaseFee(), nil
 	}
 
 	// Fetch average gas price in uint64

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -665,20 +665,22 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 
 			return ErrUnderpriced
 		}
-	} else {
-		// Legacy approach to check if the given tx is not underpriced when london hardfork is enabled
-		if forks.London && tx.GasPrice.Cmp(new(big.Int).SetUint64(baseFee)) < 0 {
-			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
+	} else { // check if legacy transaction is underpriced
+		if forks.London {
+			// Legacy approach to check if the given tx is not underpriced when london hardfork is enabled
+			if tx.GasPrice.Cmp(new(big.Int).SetUint64(baseFee)) < 0 {
+				metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
 
-			return ErrUnderpriced
+				return ErrUnderpriced
+			}
+		} else {
+			// Check if the given tx is not underpriced in legacy approach without london hardfork enabled
+			if tx.GetGasPrice(baseFee).Cmp(new(big.Int).SetUint64(p.priceLimit)) < 0 {
+				metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
+
+				return ErrUnderpriced
+			}
 		}
-	}
-
-	// Check if the given tx is not underpriced
-	if tx.GetGasPrice(baseFee).Cmp(new(big.Int).SetUint64(p.priceLimit)) < 0 {
-		metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
-
-		return ErrUnderpriced
 	}
 
 	// Check nonce ordering

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -665,17 +665,20 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 
 			return ErrUnderpriced
 		}
-	} else { // check if legacy transaction is underpriced
+	} else {
+		// Check if legacy transactions are underpriced
+		gasPrice := tx.GetGasPrice(baseFee)
 		if forks.London {
-			// Legacy approach to check if the given tx is not underpriced when london hardfork is enabled
-			if tx.GasPrice.Cmp(new(big.Int).SetUint64(baseFee)) < 0 {
+			// When London hardfork is enabled, compare gas price with base fee
+			if gasPrice.Cmp(new(big.Int).SetUint64(baseFee)) < 0 {
 				metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
 
 				return ErrUnderpriced
 			}
 		} else {
-			// Check if the given tx is not underpriced in legacy approach without london hardfork enabled
-			if tx.GetGasPrice(baseFee).Cmp(new(big.Int).SetUint64(p.priceLimit)) < 0 {
+			// When London hardfork is not enabled, compare gas price with price limit
+			// configured for the txpool
+			if gasPrice.Cmp(new(big.Int).SetUint64(p.priceLimit)) < 0 {
 				metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
 
 				return ErrUnderpriced

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -232,10 +232,25 @@ func TestAddTxErrors(t *testing.T) {
 		)
 	})
 
-	t.Run("ErrUnderpriced", func(t *testing.T) {
+	t.Run("ErrUnderpriced with london fork enabled", func(t *testing.T) {
 		t.Parallel()
 		pool := setupPool()
-		pool.priceLimit = 1000000
+		pool.baseFee = 10
+
+		tx := newTx(defaultAddr, 0, 1) // gasPrice == 1
+		tx = signTx(tx)
+
+		assert.ErrorIs(t,
+			pool.addTx(local, tx),
+			ErrUnderpriced,
+		)
+	})
+
+	t.Run("ErrUnderpriced without london fork", func(t *testing.T) {
+		t.Parallel()
+		pool := setupPool()
+		pool.forks.RemoveFork("london")
+		pool.priceLimit = 100_000
 
 		tx := newTx(defaultAddr, 0, 1) // gasPrice == 1
 		tx = signTx(tx)


### PR DESCRIPTION
# Description

There was an issue when sending a dynamic (EIP-1559) transaction where even though London fork was enabled, it checked price limit on the transaction pool.

Price limit should only be checked when London fork is not enabled, since EIP-1559 tx is never free, and they are checked based on the block base fee, checking the price limit is not needed nor correct here.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually