### PR TITLE
Bridge relayer that executes events for both way transfers

### DIFF
--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -38,7 +38,6 @@ type exitParams struct {
 	exitID            uint64
 	rootJSONRPCAddr   string
 	childJSONRPCAddr  string
-	isTestMode        bool
 }
 
 var (
@@ -89,15 +88,7 @@ func GetCommand() *cobra.Command {
 		"the JSON RPC child chain endpoint",
 	)
 
-	exitCmd.Flags().BoolVar(
-		&ep.isTestMode,
-		helper.TestModeFlag,
-		false,
-		"test indicates whether exit transaction sender is hardcoded test account",
-	)
-
 	_ = exitCmd.MarkFlagRequired(exitHelperFlag)
-	exitCmd.MarkFlagsMutuallyExclusive(helper.TestModeFlag, common.SenderKeyFlag)
 
 	return exitCmd
 }

--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -2,10 +2,7 @@ package exit
 
 import (
 	"bytes"
-	"encoding/hex"
-	"errors"
 	"fmt"
-	"math/big"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -16,6 +13,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	"github.com/0xPolygon/polygon-edge/command/bridge/helper"
 	cmdHelper "github.com/0xPolygon/polygon-edge/command/helper"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -160,36 +158,21 @@ func run(cmd *cobra.Command, _ []string) {
 // createExitTxn encodes parameters for exit function on root chain ExitHelper contract
 func createExitTxn(sender ethgo.Address, proof types.Proof) (*ethgo.Transaction,
 	*contractsapi.L2StateSyncedEvent, error) {
-	leafIndex, ok := proof.Metadata["LeafIndex"].(float64)
-	if !ok {
-		return nil, nil, errors.New("failed to convert proof leaf index")
-	}
-
-	checkpointBlock, ok := proof.Metadata["CheckpointBlock"].(float64)
-	if !ok {
-		return nil, nil, errors.New("failed to convert proof checkpoint block")
-	}
-
-	exitEventHex, ok := proof.Metadata["ExitEvent"].(string)
-	if !ok {
-		return nil, nil, errors.New("failed to convert exit event")
-	}
-
-	exitEventEncoded, err := hex.DecodeString(exitEventHex)
+	exitInput, err := polybft.GetExitInputFromProof(proof)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to decode hex-encoded exit event '%s': %w", exitEventHex, err)
+		return nil, nil, err
 	}
 
 	exitEvent := new(contractsapi.L2StateSyncedEvent)
-	if err := exitEvent.Decode(exitEventEncoded); err != nil {
+	if err := exitEvent.Decode(exitInput.UnhashedLeaf); err != nil {
 		return nil, nil, fmt.Errorf("failed to decode exit event: %w", err)
 	}
 
 	exitFn := &contractsapi.ExitExitHelperFn{
-		BlockNumber:  new(big.Int).SetUint64(uint64(checkpointBlock)),
-		LeafIndex:    new(big.Int).SetUint64(uint64(leafIndex)),
-		UnhashedLeaf: exitEventEncoded,
-		Proof:        proof.Data,
+		BlockNumber:  exitInput.BlockNumber,
+		LeafIndex:    exitInput.LeafIndex,
+		UnhashedLeaf: exitInput.UnhashedLeaf,
+		Proof:        exitInput.Proof,
 	}
 
 	input, err := exitFn.EncodeAbi()

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -1,0 +1,284 @@
+package polybft
+
+import (
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/0xPolygon/polygon-edge/consensus"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
+	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/txrelayer"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/Ethernal-Tech/blockchain-event-tracker/store"
+	"github.com/Ethernal-Tech/blockchain-event-tracker/tracker"
+	hcf "github.com/hashicorp/go-hclog"
+	"github.com/umbracle/ethgo"
+)
+
+var (
+	stateSyncEventSig           = new(contractsapi.StateSyncedEvent).Sig()
+	checkpointSubmittedEventSig = new(contractsapi.CheckpointSubmittedEvent).Sig()
+)
+
+// BridgeBackend is an interface that defines functions required by bridge components
+type BridgeBackend interface {
+	Runtime
+	StateSyncProofRetriever
+	EventProofRetriever
+}
+
+// eventTrackerConfig is a struct that holds the event tracker configuration
+type eventTrackerConfig struct {
+	consensus.EventTracker
+
+	jsonrpcAddr           string
+	startBlock            uint64
+	stateSenderAddr       types.Address
+	checkpointManagerAddr types.Address
+	trackerPollInterval   time.Duration
+}
+
+// bridgeManager is a struct that manages different bridge components
+// such as handling and executing bridge events
+type bridgeManager struct {
+	checkpointManager CheckpointManager
+	stateSyncManager  StateSyncManager
+	stateSyncRelayer  StateSyncRelayer
+	exitEventRelayer  ExitRelayer
+
+	eventTrackerConfig *eventTrackerConfig
+	logger             hcf.Logger
+
+	isBridgeEnabled bool
+}
+
+// newBridgeManager creates a new instance of bridgeManager
+func newBridgeManager(
+	bridgeBackend BridgeBackend,
+	runtimeConfig *runtimeConfig,
+	eventProvider *EventProvider,
+	logger hcf.Logger) (*bridgeManager, error) {
+	stateSenderAddr := runtimeConfig.GenesisConfig.Bridge.StateSenderAddr
+	bridgeManager := &bridgeManager{
+		logger:          logger.Named("bridge-manager"),
+		isBridgeEnabled: runtimeConfig.GenesisConfig.IsBridgeEnabled(),
+		eventTrackerConfig: &eventTrackerConfig{
+			EventTracker:          *runtimeConfig.eventTracker,
+			stateSenderAddr:       stateSenderAddr,
+			checkpointManagerAddr: runtimeConfig.GenesisConfig.Bridge.CheckpointManagerAddr,
+			jsonrpcAddr:           runtimeConfig.GenesisConfig.Bridge.JSONRPCEndpoint,
+			startBlock:            runtimeConfig.GenesisConfig.Bridge.EventTrackerStartBlocks[stateSenderAddr],
+			trackerPollInterval:   runtimeConfig.GenesisConfig.BlockTrackerPollInterval.Duration,
+		},
+	}
+
+	if err := bridgeManager.initStateSyncManager(bridgeBackend, runtimeConfig, logger); err != nil {
+		return nil, err
+	}
+
+	if err := bridgeManager.initCheckpointManager(eventProvider, runtimeConfig, logger); err != nil {
+		return nil, err
+	}
+
+	if err := bridgeManager.initStateSyncRelayer(bridgeBackend, eventProvider, runtimeConfig, logger); err != nil {
+		return nil, err
+	}
+
+	if err := bridgeManager.initExitRelayer(bridgeBackend, runtimeConfig, logger); err != nil {
+		return nil, err
+	}
+
+	if bridgeManager.isBridgeEnabled {
+		if err := bridgeManager.initTracker(runtimeConfig); err != nil {
+			return nil, fmt.Errorf("failed to init event tracker. Error: %w", err)
+		}
+	}
+
+	return bridgeManager, nil
+}
+
+// PostBlock is a function executed on every block finalization (either by consensus or syncer)
+func (b *bridgeManager) PostBlock(req *PostBlockRequest) error {
+	if err := b.stateSyncManager.PostBlock(req); err != nil {
+		return fmt.Errorf("failed to execute post block in state sync manager. Err: %w", err)
+	}
+
+	if err := b.stateSyncRelayer.PostBlock(req); err != nil {
+		return fmt.Errorf("failed to execute post block in state sync relayer. Err: %w", err)
+	}
+
+	if err := b.exitEventRelayer.PostBlock(req); err != nil {
+		return fmt.Errorf("failed to execute post block in exit event relayer. Err: %w", err)
+	}
+
+	return nil
+}
+
+// close stops ongoing go routines in the manager
+func (b *bridgeManager) close() {
+	b.stateSyncRelayer.Close()
+}
+
+// initStateSyncManager initializes state sync manager
+// if bridge is not enabled, then a dummy state sync manager will be used
+func (b *bridgeManager) initStateSyncManager(
+	bridgeBackend BridgeBackend,
+	runtimeConfig *runtimeConfig,
+	logger hcf.Logger) error {
+	if b.isBridgeEnabled {
+		stateSyncManager := newStateSyncManager(
+			logger.Named("state-sync-manager"),
+			runtimeConfig.State,
+			&stateSyncConfig{
+				key:               runtimeConfig.Key,
+				dataDir:           runtimeConfig.DataDir,
+				topic:             runtimeConfig.bridgeTopic,
+				maxCommitmentSize: maxCommitmentSize,
+			},
+			bridgeBackend,
+		)
+
+		b.stateSyncManager = stateSyncManager
+	} else {
+		b.stateSyncManager = &dummyStateSyncManager{}
+	}
+
+	return b.stateSyncManager.Init()
+}
+
+// initCheckpointManager initializes checkpoint manager
+// if bridge is not enabled, then a dummy checkpoint manager will be used
+func (b *bridgeManager) initCheckpointManager(
+	eventProvider *EventProvider,
+	runtimeConfig *runtimeConfig,
+	logger hcf.Logger) error {
+	if b.isBridgeEnabled {
+		// enable checkpoint manager
+		txRelayer, err := txrelayer.NewTxRelayer(
+			txrelayer.WithIPAddress(runtimeConfig.GenesisConfig.Bridge.JSONRPCEndpoint),
+			txrelayer.WithWriter(logger.StandardWriter(&hcf.StandardLoggerOptions{})))
+		if err != nil {
+			return err
+		}
+
+		b.checkpointManager = newCheckpointManager(
+			wallet.NewEcdsaSigner(runtimeConfig.Key),
+			runtimeConfig.GenesisConfig.Bridge.CheckpointManagerAddr,
+			txRelayer,
+			runtimeConfig.blockchain,
+			runtimeConfig.polybftBackend,
+			logger.Named("checkpoint_manager"),
+			runtimeConfig.State)
+	} else {
+		b.checkpointManager = &dummyCheckpointManager{}
+	}
+
+	eventProvider.Subscribe(b.checkpointManager)
+
+	return nil
+}
+
+// initStateSyncRelayer initializes state sync relayer
+// if not enabled, then a dummy state sync relayer will be used
+func (b *bridgeManager) initStateSyncRelayer(
+	bridgeBackend BridgeBackend,
+	eventProvider *EventProvider,
+	runtimeConfig *runtimeConfig,
+	logger hcf.Logger) error {
+	if b.isBridgeEnabled && runtimeConfig.consensusConfig.IsRelayer {
+		txRelayer, err := getBridgeTxRelayer(runtimeConfig.consensusConfig.RPCEndpoint, logger)
+		if err != nil {
+			return err
+		}
+
+		b.stateSyncRelayer = newStateSyncRelayer(
+			txRelayer,
+			contracts.StateReceiverContract,
+			runtimeConfig.State.StateSyncStore,
+			bridgeBackend,
+			runtimeConfig.blockchain,
+			wallet.NewEcdsaSigner(runtimeConfig.Key),
+			nil,
+			logger.Named("state_sync_relayer"))
+	} else {
+		b.stateSyncRelayer = &dummyStateSyncRelayer{}
+	}
+
+	eventProvider.Subscribe(b.stateSyncRelayer)
+
+	return b.stateSyncRelayer.Init()
+}
+
+// initStateSyncRelayer initializes exit event relayer
+// if not enabled, then a dummy exit event relayer will be used
+func (b *bridgeManager) initExitRelayer(
+	bridgeBackend BridgeBackend,
+	runtimeConfig *runtimeConfig,
+	logger hcf.Logger) error {
+	if b.isBridgeEnabled && runtimeConfig.consensusConfig.IsRelayer {
+		txRelayer, err := getBridgeTxRelayer(runtimeConfig.consensusConfig.RPCEndpoint, logger)
+		if err != nil {
+			return err
+		}
+
+		b.exitEventRelayer = newExitRelayer(
+			txRelayer,
+			wallet.NewEcdsaSigner(runtimeConfig.Key),
+			bridgeBackend,
+			runtimeConfig.blockchain,
+			runtimeConfig.State.CheckpointStore,
+			logger.Named("state_sync_relayer"))
+	} else {
+		b.exitEventRelayer = &dummyExitRelayer{}
+	}
+
+	return nil
+}
+
+// initTracker starts a new event tracker (to receive new state sync events)
+func (b *bridgeManager) initTracker(
+	runtimeConfig *runtimeConfig) error {
+	store, err := store.NewBoltDBEventTrackerStore(path.Join(runtimeConfig.DataDir, "/bridge.db"))
+	if err != nil {
+		return err
+	}
+
+	eventTracker, err := tracker.NewEventTracker(
+		&tracker.EventTrackerConfig{
+			EventSubscriber:        b,
+			Logger:                 b.logger,
+			RPCEndpoint:            b.eventTrackerConfig.jsonrpcAddr,
+			SyncBatchSize:          b.eventTrackerConfig.EventTracker.SyncBatchSize,
+			NumBlockConfirmations:  b.eventTrackerConfig.EventTracker.NumBlockConfirmations,
+			NumOfBlocksToReconcile: b.eventTrackerConfig.EventTracker.NumOfBlocksToReconcile,
+			PollInterval:           b.eventTrackerConfig.trackerPollInterval,
+			LogFilter: map[ethgo.Address][]ethgo.Hash{
+				ethgo.Address(b.eventTrackerConfig.stateSenderAddr):       {stateSyncEventSig},
+				ethgo.Address(b.eventTrackerConfig.checkpointManagerAddr): {checkpointSubmittedEventSig},
+			},
+		},
+		store, b.eventTrackerConfig.startBlock,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return eventTracker.Start()
+}
+
+// AddLog saves the received log from event tracker if it matches a state sync event ABI
+func (b *bridgeManager) AddLog(eventLog *ethgo.Log) error {
+	switch eventLog.Topics[0] {
+	case stateSyncEventSig:
+		return b.stateSyncManager.AddLog(eventLog)
+	case checkpointSubmittedEventSig:
+		return b.exitEventRelayer.AddLog(eventLog)
+	default:
+		b.logger.Error("Unknown event log receiver from event tracker")
+
+		return nil
+	}
+}

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -264,6 +264,7 @@ func (b *bridgeManager) PostEpoch(req *PostEpochRequest) error {
 // close stops ongoing go routines in the manager
 func (b *bridgeManager) Close() {
 	b.stateSyncRelayer.Close()
+	b.exitEventRelayer.Close()
 }
 
 // initStateSyncManager initializes state sync manager

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -92,9 +92,6 @@ type relayerEventsProcessor struct {
 // ProcessEvents processes all relayer events that were either successfully or unsuccessfully executed
 // and executes all the events that can be executed in regards to relayerConfig
 func (r relayerEventsProcessor) processEvents() {
-	r.logger.Debug("processing relayer events on PostBlock")
-	defer r.logger.Debug("processing relayer events on PostBlock finished")
-
 	// we need twice as batch size because events from first batch are possible already sent maxAttemptsToSend times
 	events, err := r.state.GetAllAvailableRelayerEvents(int(r.config.maxEventsPerBatch) * 2)
 	if err != nil {
@@ -128,10 +125,6 @@ func (r relayerEventsProcessor) processEvents() {
 			}
 		}
 	}
-
-	r.logger.Debug("processing relayer events on PostBlock",
-		"sendingEvents", len(sendingEvents),
-		"eventsToRemove", len(removedEventIDs))
 
 	// update state only if needed
 	if len(sendingEvents)+len(removedEventIDs) > 0 {

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -347,6 +347,7 @@ func (b *bridgeManager) initCheckpointManager(
 	runtimeConfig *runtimeConfig,
 	logger hclog.Logger) error {
 	log := logger.Named("checkpoint_manager")
+
 	txRelayer, err := txrelayer.NewTxRelayer(
 		txrelayer.WithIPAddress(runtimeConfig.GenesisConfig.Bridge.JSONRPCEndpoint),
 		txrelayer.WithWriter(log.StandardWriter(&hclog.StandardLoggerOptions{})))

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -65,6 +65,7 @@ type relayerConfig struct {
 	maxBlocksToWaitForResend uint64
 	maxAttemptsToSend        uint64
 	maxEventsPerBatch        uint64
+	eventExecutionAddr       types.Address
 }
 
 // eventTrackerConfig is a struct that holds the event tracker configuration
@@ -375,12 +376,16 @@ func (b *bridgeManager) initStateSyncRelayer(
 
 		b.stateSyncRelayer = newStateSyncRelayer(
 			txRelayer,
-			contracts.StateReceiverContract,
 			runtimeConfig.State.StateSyncStore,
 			bridgeBackend,
 			runtimeConfig.blockchain,
 			wallet.NewEcdsaSigner(runtimeConfig.Key),
-			nil,
+			&relayerConfig{
+				maxBlocksToWaitForResend: defaultMaxBlocksToWaitForResend,
+				maxAttemptsToSend:        defaultMaxAttemptsToSend,
+				maxEventsPerBatch:        defaultMaxEventsPerBatch,
+				eventExecutionAddr:       contracts.StateReceiverContract,
+			},
 			logger.Named("state_sync_relayer"))
 	} else {
 		b.stateSyncRelayer = &dummyStateSyncRelayer{}
@@ -409,8 +414,12 @@ func (b *bridgeManager) initExitRelayer(
 			bridgeBackend,
 			runtimeConfig.blockchain,
 			runtimeConfig.State.ExitStore,
-			nil,
-			runtimeConfig.GenesisConfig.Bridge.ExitHelperAddr,
+			&relayerConfig{
+				maxBlocksToWaitForResend: defaultMaxBlocksToWaitForResend,
+				maxAttemptsToSend:        defaultMaxAttemptsToSend,
+				maxEventsPerBatch:        defaultMaxEventsPerBatch,
+				eventExecutionAddr:       runtimeConfig.GenesisConfig.Bridge.ExitHelperAddr,
+			},
 			logger.Named("exit_relayer"))
 	} else {
 		b.exitEventRelayer = &dummyExitRelayer{}

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -228,8 +228,8 @@ func (b *bridgeManager) initExitRelayer(
 			wallet.NewEcdsaSigner(runtimeConfig.Key),
 			bridgeBackend,
 			runtimeConfig.blockchain,
-			runtimeConfig.State.CheckpointStore,
-			logger.Named("state_sync_relayer"))
+			runtimeConfig.State.ExitStore,
+			logger.Named("exit_relayer"))
 	} else {
 		b.exitEventRelayer = &dummyExitRelayer{}
 	}

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Ethernal-Tech/blockchain-event-tracker/store"
 	"github.com/Ethernal-Tech/blockchain-event-tracker/tracker"
 	"github.com/hashicorp/go-hclog"
-	hcf "github.com/hashicorp/go-hclog"
 	"github.com/umbracle/ethgo"
 	bolt "go.etcd.io/bbolt"
 )
@@ -193,7 +192,7 @@ type bridgeManager struct {
 	exitEventRelayer  ExitRelayer
 
 	eventTrackerConfig *eventTrackerConfig
-	logger             hcf.Logger
+	logger             hclog.Logger
 }
 
 // newBridgeManager creates a new instance of bridgeManager
@@ -201,7 +200,7 @@ func newBridgeManager(
 	bridgeBackend BridgeBackend,
 	runtimeConfig *runtimeConfig,
 	eventProvider *EventProvider,
-	logger hcf.Logger) (BridgeManager, error) {
+	logger hclog.Logger) (BridgeManager, error) {
 	if !runtimeConfig.GenesisConfig.IsBridgeEnabled() {
 		return &dummyBridgeManager{}, nil
 	}
@@ -279,7 +278,7 @@ func (b *bridgeManager) Close() {
 func (b *bridgeManager) initStateSyncManager(
 	bridgeBackend BridgeBackend,
 	runtimeConfig *runtimeConfig,
-	logger hcf.Logger) error {
+	logger hclog.Logger) error {
 	stateSyncManager := newStateSyncManager(
 		logger.Named("state-sync-manager"),
 		runtimeConfig.State,
@@ -302,10 +301,10 @@ func (b *bridgeManager) initStateSyncManager(
 func (b *bridgeManager) initCheckpointManager(
 	eventProvider *EventProvider,
 	runtimeConfig *runtimeConfig,
-	logger hcf.Logger) error {
+	logger hclog.Logger) error {
 	txRelayer, err := txrelayer.NewTxRelayer(
 		txrelayer.WithIPAddress(runtimeConfig.GenesisConfig.Bridge.JSONRPCEndpoint),
-		txrelayer.WithWriter(logger.StandardWriter(&hcf.StandardLoggerOptions{})))
+		txrelayer.WithWriter(logger.StandardWriter(&hclog.StandardLoggerOptions{})))
 	if err != nil {
 		return err
 	}
@@ -330,7 +329,7 @@ func (b *bridgeManager) initStateSyncRelayer(
 	bridgeBackend BridgeBackend,
 	eventProvider *EventProvider,
 	runtimeConfig *runtimeConfig,
-	logger hcf.Logger) error {
+	logger hclog.Logger) error {
 	if runtimeConfig.consensusConfig.IsRelayer {
 		txRelayer, err := getBridgeTxRelayer(runtimeConfig.consensusConfig.RPCEndpoint, logger)
 		if err != nil {
@@ -360,7 +359,7 @@ func (b *bridgeManager) initStateSyncRelayer(
 func (b *bridgeManager) initExitRelayer(
 	bridgeBackend BridgeBackend,
 	runtimeConfig *runtimeConfig,
-	logger hcf.Logger) error {
+	logger hclog.Logger) error {
 	if runtimeConfig.consensusConfig.IsRelayer {
 		txRelayer, err := getBridgeTxRelayer(runtimeConfig.GenesisConfig.Bridge.JSONRPCEndpoint, logger)
 		if err != nil {

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -441,6 +441,11 @@ func (c *checkpointManager) ProcessLog(header *types.Header, log *ethgo.Log, dbT
 		return nil
 	}
 
+	c.logger.Debug("An exit event happened",
+		"exitEventID", exitEvent.ID,
+		"epoch", exitEvent.EpochNumber,
+		"blockNumber", exitEvent.BlockNumber)
+
 	return c.state.ExitStore.insertExitEvent(exitEvent, dbTx)
 }
 

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -27,7 +27,7 @@ var (
 
 type CheckpointManager interface {
 	EventSubscriber
-	PostBlock(req *PostBlockRequest) error
+	PostBlock(req *PostBlockRequest)
 	BuildEventRoot(epoch uint64) (types.Hash, error)
 	GenerateExitProof(exitID uint64) (types.Proof, error)
 }
@@ -36,7 +36,7 @@ var _ CheckpointManager = (*dummyCheckpointManager)(nil)
 
 type dummyCheckpointManager struct{}
 
-func (d *dummyCheckpointManager) PostBlock(req *PostBlockRequest) error { return nil }
+func (d *dummyCheckpointManager) PostBlock(req *PostBlockRequest) {}
 func (d *dummyCheckpointManager) BuildEventRoot(epoch uint64) (types.Hash, error) {
 	return types.ZeroHash, nil
 }
@@ -277,7 +277,7 @@ func (c *checkpointManager) isCheckpointBlock(blockNumber, checkpointsOffset uin
 
 // PostBlock is called on every insert of finalized block (either from consensus or syncer)
 // It sends a checkpoint if given block is checkpoint block and block proposer is given validator
-func (c *checkpointManager) PostBlock(req *PostBlockRequest) error {
+func (c *checkpointManager) PostBlock(req *PostBlockRequest) {
 	if c.isCheckpointBlock(req.FullBlock.Block.Header.Number,
 		req.CurrentClientConfig.CheckpointInterval, req.IsEpochEndingBlock) &&
 		bytes.Equal(c.key.Address().Bytes(), req.FullBlock.Block.Header.Miner) {
@@ -292,8 +292,6 @@ func (c *checkpointManager) PostBlock(req *PostBlockRequest) error {
 
 		c.lastSentBlock = req.FullBlock.Block.Number()
 	}
-
-	return nil
 }
 
 // BuildEventRoot returns an exit event root hash for exit tree of given epoch

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -298,7 +298,7 @@ func (c *checkpointManager) PostBlock(req *PostBlockRequest) error {
 
 // BuildEventRoot returns an exit event root hash for exit tree of given epoch
 func (c *checkpointManager) BuildEventRoot(epoch uint64) (types.Hash, error) {
-	exitEvents, err := c.state.CheckpointStore.getExitEventsByEpoch(epoch)
+	exitEvents, err := c.state.ExitStore.getExitEventsByEpoch(epoch)
 	if err != nil {
 		return types.ZeroHash, err
 	}
@@ -319,7 +319,7 @@ func (c *checkpointManager) BuildEventRoot(epoch uint64) (types.Hash, error) {
 func (c *checkpointManager) GenerateExitProof(exitID uint64) (types.Proof, error) {
 	c.logger.Debug("Generating proof for exit", "exitID", exitID)
 
-	exitEvent, err := c.state.CheckpointStore.getExitEvent(exitID)
+	exitEvent, err := c.state.ExitStore.getExitEvent(exitID)
 	if err != nil {
 		return types.Proof{}, err
 	}
@@ -381,7 +381,7 @@ func (c *checkpointManager) GenerateExitProof(exitID uint64) (types.Proof, error
 		return types.Proof{}, err
 	}
 
-	exitEvents, err := c.state.CheckpointStore.getExitEventsForProof(exitEvent.EpochNumber, checkpointBlock.Uint64())
+	exitEvents, err := c.state.ExitStore.getExitEventsForProof(exitEvent.EpochNumber, checkpointBlock.Uint64())
 	if err != nil {
 		return types.Proof{}, err
 	}
@@ -441,7 +441,7 @@ func (c *checkpointManager) ProcessLog(header *types.Header, log *ethgo.Log, dbT
 		return nil
 	}
 
-	return c.state.CheckpointStore.insertExitEvent(exitEvent, dbTx)
+	return c.state.ExitStore.insertExitEvent(exitEvent, dbTx)
 }
 
 // createExitTree creates an exit event merkle tree from provided exit events

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -372,8 +372,6 @@ func (c *consensusRuntime) OnBlockInserted(fullBlock *types.FullBlock) {
 	c.epoch = epoch
 	c.lastBuiltBlock = fullBlock.Block.Header
 
-	c.bridgeManager.PostBlockAsync(postBlock)
-
 	endTime := time.Now().UTC()
 
 	c.logger.Debug("OnBlockInserted finished", "elapsedTime", endTime.Sub(startTime),
@@ -413,7 +411,7 @@ func (c *consensusRuntime) FSM() error {
 
 	valSet := validator.NewValidatorSet(epoch.Validators, c.logger)
 
-	exitRootHash, err := c.bridgeManager.BuildEventRoot(epoch.Number)
+	exitRootHash, err := c.bridgeManager.BuildExitEventRoot(epoch.Number)
 	if err != nil {
 		return fmt.Errorf("could not build exit root hash for fsm: %w", err)
 	}

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -18,7 +18,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/forkmanager"
-	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	bolt "go.etcd.io/bbolt"
 
@@ -116,22 +115,16 @@ type consensusRuntime struct {
 	// activeValidatorFlag indicates whether the given node is amongst currently active validator set
 	activeValidatorFlag atomic.Bool
 
-	// checkpointManager represents abstraction for checkpoint submission
-	checkpointManager CheckpointManager
-
 	// proposerCalculator is the object which manipulates with ProposerSnapshot
 	proposerCalculator *ProposerCalculator
-
-	// manager for state sync bridge transactions
-	stateSyncManager StateSyncManager
 
 	// manager for handling validator stake change and updating validator set
 	stakeManager StakeManager
 
 	eventProvider *EventProvider
 
-	// stateSyncRelayer is relayer for commitment events
-	stateSyncRelayer StateSyncRelayer
+	// bridgeManager handles storing, processing and executing bridge events
+	bridgeManager *bridgeManager
 
 	// governanceManager is used for handling governance events gotten from proposals execution
 	// also handles updating client configuration based on governance proposals
@@ -164,19 +157,14 @@ func newConsensusRuntime(log hcf.Logger, config *runtimeConfig) (*consensusRunti
 		eventProvider:      NewEventProvider(config.blockchain),
 	}
 
-	if err := runtime.initStateSyncManager(log); err != nil {
+	bridgeManager, err := newBridgeManager(runtime, config, runtime.eventProvider, log)
+	if err != nil {
 		return nil, err
 	}
 
-	if err := runtime.initCheckpointManager(log); err != nil {
-		return nil, err
-	}
+	runtime.bridgeManager = bridgeManager
 
 	if err := runtime.initStakeManager(log, dbTx); err != nil {
-		return nil, err
-	}
-
-	if err := runtime.initStateSyncRelayer(log); err != nil {
 		return nil, err
 	}
 
@@ -199,96 +187,7 @@ func newConsensusRuntime(log hcf.Logger, config *runtimeConfig) (*consensusRunti
 
 // close is used to tear down allocated resources
 func (c *consensusRuntime) close() {
-	c.stateSyncRelayer.Close()
-	c.stateSyncManager.Close()
-}
-
-// initStateSyncManager initializes state sync manager
-// if bridge is not enabled, then a dummy state sync manager will be used
-func (c *consensusRuntime) initStateSyncManager(logger hcf.Logger) error {
-	if c.IsBridgeEnabled() {
-		stateSenderAddr := c.config.GenesisConfig.Bridge.StateSenderAddr
-		stateSyncManager := newStateSyncManager(
-			logger.Named("state-sync-manager"),
-			c.config.State,
-			&stateSyncConfig{
-				key:               c.config.Key,
-				dataDir:           c.config.DataDir,
-				topic:             c.config.bridgeTopic,
-				maxCommitmentSize: maxCommitmentSize,
-				eventTrackerConfig: &eventTrackerConfig{
-					jsonrpcAddr:           c.config.GenesisConfig.Bridge.JSONRPCEndpoint,
-					stateSenderAddr:       stateSenderAddr,
-					stateSenderStartBlock: c.config.GenesisConfig.Bridge.EventTrackerStartBlocks[stateSenderAddr],
-					trackerPollInterval:   c.config.GenesisConfig.BlockTrackerPollInterval.Duration,
-					EventTracker:          *c.config.eventTracker,
-				},
-			},
-			c,
-		)
-
-		c.stateSyncManager = stateSyncManager
-	} else {
-		c.stateSyncManager = &dummyStateSyncManager{}
-	}
-
-	return c.stateSyncManager.Init()
-}
-
-// initCheckpointManager initializes checkpoint manager
-// if bridge is not enabled, then a dummy checkpoint manager will be used
-func (c *consensusRuntime) initCheckpointManager(logger hcf.Logger) error {
-	if c.IsBridgeEnabled() {
-		// enable checkpoint manager
-		txRelayer, err := txrelayer.NewTxRelayer(
-			txrelayer.WithIPAddress(c.config.GenesisConfig.Bridge.JSONRPCEndpoint),
-			txrelayer.WithWriter(logger.StandardWriter(&hcf.StandardLoggerOptions{})))
-		if err != nil {
-			return err
-		}
-
-		c.checkpointManager = newCheckpointManager(
-			wallet.NewEcdsaSigner(c.config.Key),
-			c.config.GenesisConfig.Bridge.CheckpointManagerAddr,
-			txRelayer,
-			c.config.blockchain,
-			c.config.polybftBackend,
-			logger.Named("checkpoint_manager"),
-			c.state)
-	} else {
-		c.checkpointManager = &dummyCheckpointManager{}
-	}
-
-	c.eventProvider.Subscribe(c.checkpointManager)
-
-	return nil
-}
-
-// initStateSyncRelayer initializes state sync relayer
-// if not enabled, then a dummy state sync relayer will be used
-func (c *consensusRuntime) initStateSyncRelayer(logger hcf.Logger) error {
-	if c.IsBridgeEnabled() && c.config.consensusConfig.IsRelayer {
-		txRelayer, err := getStateSyncTxRelayer(c.config.consensusConfig.RPCEndpoint, logger)
-		if err != nil {
-			return err
-		}
-
-		c.stateSyncRelayer = NewStateSyncRelayer(
-			txRelayer,
-			contracts.StateReceiverContract,
-			c.state.StateSyncStore,
-			c,
-			c.config.blockchain,
-			wallet.NewEcdsaSigner(c.config.Key),
-			nil,
-			logger.Named("state_sync_relayer"))
-	} else {
-		c.stateSyncRelayer = &dummyStateSyncRelayer{}
-	}
-
-	c.eventProvider.Subscribe(c.stateSyncRelayer)
-
-	return c.stateSyncRelayer.Init()
+	c.bridgeManager.close()
 }
 
 // initStakeManager initializes stake manager
@@ -421,12 +320,6 @@ func (c *consensusRuntime) OnBlockInserted(fullBlock *types.FullBlock) {
 		Forks:               c.config.Forks,
 	}
 
-	if err := c.stateSyncManager.PostBlock(postBlock); err != nil {
-		c.logger.Error("failed to post block state sync", "err", err)
-
-		return
-	}
-
 	// update proposer priorities
 	if err := c.proposerCalculator.PostBlock(postBlock); err != nil {
 		c.logger.Error("Could not update proposer calculator", "err", err)
@@ -441,9 +334,11 @@ func (c *consensusRuntime) OnBlockInserted(fullBlock *types.FullBlock) {
 		return
 	}
 
-	// handle state sync relayer events that happened in block
-	if err := c.stateSyncRelayer.PostBlock(postBlock); err != nil {
-		c.logger.Error("post block callback failed in state sync relayer", "err", err)
+	// handle bridge events
+	if err := c.bridgeManager.PostBlock(postBlock); err != nil {
+		c.logger.Error("failed to post block in bridge manager", "err", err)
+
+		return
 	}
 
 	// handle governance events that happened in block
@@ -479,7 +374,7 @@ func (c *consensusRuntime) OnBlockInserted(fullBlock *types.FullBlock) {
 
 	// we will do PostBlock on checkpoint manager at the end, because it only
 	// sends a checkpoint in a separate routine. It doesn't do any db operations
-	if err := c.checkpointManager.PostBlock(postBlock); err != nil {
+	if err := c.bridgeManager.checkpointManager.PostBlock(postBlock); err != nil {
 		c.logger.Error("failed to post block in checkpoint manager", "err", err)
 	}
 
@@ -522,7 +417,7 @@ func (c *consensusRuntime) FSM() error {
 
 	valSet := validator.NewValidatorSet(epoch.Validators, c.logger)
 
-	exitRootHash, err := c.checkpointManager.BuildEventRoot(epoch.Number)
+	exitRootHash, err := c.bridgeManager.checkpointManager.BuildEventRoot(epoch.Number)
 	if err != nil {
 		return fmt.Errorf("could not build exit root hash for fsm: %w", err)
 	}
@@ -545,7 +440,7 @@ func (c *consensusRuntime) FSM() error {
 	}
 
 	if isEndOfSprint {
-		commitment, err := c.stateSyncManager.Commitment(pendingBlockNumber)
+		commitment, err := c.bridgeManager.stateSyncManager.Commitment(pendingBlockNumber)
 		if err != nil {
 			return err
 		}
@@ -646,7 +541,7 @@ func (c *consensusRuntime) restartEpoch(header *types.Header, dbTx *bolt.Tx) (*e
 		Forks:             c.config.Forks,
 	}
 
-	if err := c.stateSyncManager.PostEpoch(reqObj); err != nil {
+	if err := c.bridgeManager.stateSyncManager.PostEpoch(reqObj); err != nil {
 		return nil, err
 	}
 
@@ -812,12 +707,12 @@ func (c *consensusRuntime) calculateDistributeRewardsInput(
 
 // GenerateExitProof generates proof of exit and is a bridge endpoint store function
 func (c *consensusRuntime) GenerateExitProof(exitID uint64) (types.Proof, error) {
-	return c.checkpointManager.GenerateExitProof(exitID)
+	return c.bridgeManager.checkpointManager.GenerateExitProof(exitID)
 }
 
 // GetStateSyncProof returns the proof for the state sync
 func (c *consensusRuntime) GetStateSyncProof(stateSyncID uint64) (types.Proof, error) {
-	return c.stateSyncManager.GetStateSyncProof(stateSyncID)
+	return c.bridgeManager.stateSyncManager.GetStateSyncProof(stateSyncID)
 }
 
 // setIsActiveValidator updates the activeValidatorFlag field

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -234,12 +234,15 @@ func TestConsensusRuntime_OnBlockInserted_EndOfEpoch(t *testing.T) {
 			FirstBlockInEpoch:   header.Number - epochSize + 1,
 			CurrentClientConfig: config.GenesisConfig,
 		},
-		lastBuiltBlock:    &types.Header{Number: header.Number - 1},
-		stateSyncManager:  &dummyStateSyncManager{},
-		checkpointManager: &dummyCheckpointManager{},
-		stakeManager:      &dummyStakeManager{},
-		eventProvider:     NewEventProvider(blockchainMock),
-		stateSyncRelayer:  &dummyStateSyncRelayer{},
+		lastBuiltBlock: &types.Header{Number: header.Number - 1},
+		bridgeManager: &bridgeManager{
+			stateSyncManager:  &dummyStateSyncManager{},
+			checkpointManager: &dummyCheckpointManager{},
+			stateSyncRelayer:  &dummyStateSyncRelayer{},
+			exitEventRelayer:  &dummyExitRelayer{},
+		},
+		stakeManager:  &dummyStakeManager{},
+		eventProvider: NewEventProvider(blockchainMock),
 		governanceManager: &dummyGovernanceManager{
 			getClientConfigFn: func() (*chain.Params, error) {
 				return config.genesisParams, nil
@@ -366,10 +369,12 @@ func TestConsensusRuntime_FSM_NotEndOfEpoch_NotEndOfSprint(t *testing.T) {
 			FirstBlockInEpoch:   1,
 			CurrentClientConfig: config.GenesisConfig,
 		},
-		lastBuiltBlock:    lastBlock,
-		state:             newTestState(t),
-		stateSyncManager:  &dummyStateSyncManager{},
-		checkpointManager: &dummyCheckpointManager{},
+		lastBuiltBlock: lastBlock,
+		state:          newTestState(t),
+		bridgeManager: &bridgeManager{
+			stateSyncManager:  &dummyStateSyncManager{},
+			checkpointManager: &dummyCheckpointManager{},
+		},
 	}
 	runtime.setIsActiveValidator(true)
 
@@ -436,9 +441,11 @@ func TestConsensusRuntime_FSM_EndOfEpoch_BuildCommitEpoch(t *testing.T) {
 		epoch:              metadata,
 		config:             config,
 		lastBuiltBlock:     &types.Header{Number: 9},
-		stateSyncManager:   &dummyStateSyncManager{},
-		checkpointManager:  &dummyCheckpointManager{},
 		stakeManager:       &dummyStakeManager{},
+		bridgeManager: &bridgeManager{
+			stateSyncManager:  &dummyStateSyncManager{},
+			checkpointManager: &dummyCheckpointManager{},
+		},
 	}
 
 	err := runtime.FSM()

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -235,14 +235,9 @@ func TestConsensusRuntime_OnBlockInserted_EndOfEpoch(t *testing.T) {
 			CurrentClientConfig: config.GenesisConfig,
 		},
 		lastBuiltBlock: &types.Header{Number: header.Number - 1},
-		bridgeManager: &bridgeManager{
-			stateSyncManager:  &dummyStateSyncManager{},
-			checkpointManager: &dummyCheckpointManager{},
-			stateSyncRelayer:  &dummyStateSyncRelayer{},
-			exitEventRelayer:  &dummyExitRelayer{},
-		},
-		stakeManager:  &dummyStakeManager{},
-		eventProvider: NewEventProvider(blockchainMock),
+		bridgeManager:  &dummyBridgeManager{},
+		stakeManager:   &dummyStakeManager{},
+		eventProvider:  NewEventProvider(blockchainMock),
 		governanceManager: &dummyGovernanceManager{
 			getClientConfigFn: func() (*chain.Params, error) {
 				return config.genesisParams, nil

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -371,10 +371,7 @@ func TestConsensusRuntime_FSM_NotEndOfEpoch_NotEndOfSprint(t *testing.T) {
 		},
 		lastBuiltBlock: lastBlock,
 		state:          newTestState(t),
-		bridgeManager: &bridgeManager{
-			stateSyncManager:  &dummyStateSyncManager{},
-			checkpointManager: &dummyCheckpointManager{},
-		},
+		bridgeManager:  &dummyBridgeManager{},
 	}
 	runtime.setIsActiveValidator(true)
 
@@ -442,10 +439,7 @@ func TestConsensusRuntime_FSM_EndOfEpoch_BuildCommitEpoch(t *testing.T) {
 		config:             config,
 		lastBuiltBlock:     &types.Header{Number: 9},
 		stakeManager:       &dummyStakeManager{},
-		bridgeManager: &bridgeManager{
-			stateSyncManager:  &dummyStateSyncManager{},
-			checkpointManager: &dummyCheckpointManager{},
-		},
+		bridgeManager:      &dummyBridgeManager{},
 	}
 
 	err := runtime.FSM()

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -95,8 +95,11 @@ func main() {
 			[]string{
 				"initialize",
 				"exit",
+				"batchExit",
 			},
-			[]string{},
+			[]string{
+				"ExitProcessed",
+			},
 		},
 		{
 			"ChildERC20Predicate",

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -84,7 +84,9 @@ func main() {
 				"initialize",
 				"getCheckpointBlock",
 			},
-			[]string{},
+			[]string{
+				"CheckpointSubmitted",
+			},
 		},
 		{
 			"ExitHelper",

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -397,6 +397,65 @@ func (e *ExitExitHelperFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(ExitHelper.Abi.Methods["exit"], buf, e)
 }
 
+type BatchExitInput struct {
+	BlockNumber  *big.Int     `abi:"blockNumber"`
+	LeafIndex    *big.Int     `abi:"leafIndex"`
+	UnhashedLeaf []byte       `abi:"unhashedLeaf"`
+	Proof        []types.Hash `abi:"proof"`
+}
+
+var BatchExitInputABIType = abi.MustNewType("tuple(uint256 blockNumber,uint256 leafIndex,bytes unhashedLeaf,bytes32[] proof)")
+
+func (b *BatchExitInput) EncodeAbi() ([]byte, error) {
+	return BatchExitInputABIType.Encode(b)
+}
+
+func (b *BatchExitInput) DecodeAbi(buf []byte) error {
+	return decodeStruct(BatchExitInputABIType, buf, &b)
+}
+
+type BatchExitExitHelperFn struct {
+	Inputs []*BatchExitInput `abi:"inputs"`
+}
+
+func (b *BatchExitExitHelperFn) Sig() []byte {
+	return ExitHelper.Abi.Methods["batchExit"].ID()
+}
+
+func (b *BatchExitExitHelperFn) EncodeAbi() ([]byte, error) {
+	return ExitHelper.Abi.Methods["batchExit"].Encode(b)
+}
+
+func (b *BatchExitExitHelperFn) DecodeAbi(buf []byte) error {
+	return decodeMethod(ExitHelper.Abi.Methods["batchExit"], buf, b)
+}
+
+type ExitProcessedEvent struct {
+	ID         *big.Int `abi:"id"`
+	Success    bool     `abi:"success"`
+	ReturnData []byte   `abi:"returnData"`
+}
+
+func (*ExitProcessedEvent) Sig() ethgo.Hash {
+	return ExitHelper.Abi.Events["ExitProcessed"].ID()
+}
+
+func (e *ExitProcessedEvent) Encode() ([]byte, error) {
+	return ExitHelper.Abi.Events["ExitProcessed"].Inputs.Encode(e)
+}
+
+func (e *ExitProcessedEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !ExitHelper.Abi.Events["ExitProcessed"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(ExitHelper.Abi.Events["ExitProcessed"], log, e)
+}
+
+func (e *ExitProcessedEvent) Decode(input []byte) error {
+	return ExitHelper.Abi.Events["ExitProcessed"].Inputs.DecodeStruct(input, &e)
+}
+
 type InitializeChildERC20PredicateFn struct {
 	NewL2StateSender          types.Address `abi:"newL2StateSender"`
 	NewStateReceiver          types.Address `abi:"newStateReceiver"`

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -336,6 +336,32 @@ func (g *GetCheckpointBlockCheckpointManagerFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(CheckpointManager.Abi.Methods["getCheckpointBlock"], buf, g)
 }
 
+type CheckpointSubmittedEvent struct {
+	Epoch       *big.Int   `abi:"epoch"`
+	BlockNumber *big.Int   `abi:"blockNumber"`
+	EventRoot   types.Hash `abi:"eventRoot"`
+}
+
+func (*CheckpointSubmittedEvent) Sig() ethgo.Hash {
+	return CheckpointManager.Abi.Events["CheckpointSubmitted"].ID()
+}
+
+func (c *CheckpointSubmittedEvent) Encode() ([]byte, error) {
+	return CheckpointManager.Abi.Events["CheckpointSubmitted"].Inputs.Encode(c)
+}
+
+func (c *CheckpointSubmittedEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !CheckpointManager.Abi.Events["CheckpointSubmitted"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(CheckpointManager.Abi.Events["CheckpointSubmitted"], log, c)
+}
+
+func (c *CheckpointSubmittedEvent) Decode(input []byte) error {
+	return CheckpointManager.Abi.Events["CheckpointSubmitted"].Inputs.DecodeStruct(input, &c)
+}
+
 type InitializeExitHelperFn struct {
 	NewCheckpointManager types.Address `abi:"newCheckpointManager"`
 }

--- a/consensus/polybft/exit_relayer.go
+++ b/consensus/polybft/exit_relayer.go
@@ -129,7 +129,8 @@ func (e *exitRelayer) PostBlock(req *PostBlockRequest) error {
 	return nil
 }
 
-// AddLog saves the received log from event tracker if it matches a checkpoint submitted event ABI
+// AddLog handles the received log from event tracker if it matches
+// a checkpoint submitted event ABI, or exit processed event ABI
 func (e *exitRelayer) AddLog(eventLog *ethgo.Log) error {
 	var (
 		checkpointSubmittedEvent contractsapi.CheckpointSubmittedEvent
@@ -202,7 +203,7 @@ func (e *exitRelayer) AddLog(eventLog *ethgo.Log) error {
 			return e.state.UpdateRelayerEvents(nil, []uint64{eventID}, nil)
 		}
 
-		e.logger.Debug("exit processed event failed to be handled",
+		e.logger.Debug("exit event was not successfully executed",
 			"eventID", eventID, "reason", string(exitProcessedEvent.ReturnData))
 
 		return nil

--- a/consensus/polybft/exit_relayer.go
+++ b/consensus/polybft/exit_relayer.go
@@ -114,11 +114,6 @@ func (e *exitRelayer) Init() error {
 	return nil
 }
 
-// processEvents processes and executes non-executed exit events
-func (e *exitRelayer) processEvents() {
-	e.relayerEventsProcessor.processEvents()
-}
-
 // Close closes the running go routine
 func (e *exitRelayer) Close() {
 	close(e.closeCh)

--- a/consensus/polybft/exit_relayer.go
+++ b/consensus/polybft/exit_relayer.go
@@ -161,6 +161,15 @@ func (e *exitRelayer) AddLog(eventLog *ethgo.Log) error {
 			checkpointSubmittedEvent.Epoch.Uint64(),
 			checkpointSubmittedEvent.BlockNumber.Uint64(),
 		)
+		if err != nil {
+			e.logger.Error("could not get exit events for checkpoint",
+				"err", err,
+				"epoch", checkpointSubmittedEvent.Epoch.Uint64(),
+				"checkpointBlockNumber", checkpointSubmittedEvent.BlockNumber.Uint64(),
+			)
+
+			return err
+		}
 
 		if len(exitEvents) == 0 {
 			e.logger.Debug("There are no exit events that happened in given given checkpoint")

--- a/consensus/polybft/exit_relayer.go
+++ b/consensus/polybft/exit_relayer.go
@@ -51,8 +51,6 @@ type exitRelayer struct {
 
 	notifyCh chan struct{}
 	closeCh  chan struct{}
-
-	exitHelperAddr types.Address
 }
 
 // newExitRelayer creates a new instance of exitRelayer
@@ -63,23 +61,13 @@ func newExitRelayer(
 	blockchain blockchainBackend,
 	exitStore *ExitStore,
 	config *relayerConfig,
-	exitHelperAddr types.Address,
 	logger hclog.Logger) *exitRelayer {
-	if config == nil {
-		config = &relayerConfig{
-			maxBlocksToWaitForResend: defaultMaxBlocksToWaitForResend,
-			maxAttemptsToSend:        defaultMaxAttemptsToSend,
-			maxEventsPerBatch:        defaultMaxEventsPerBatch,
-		}
-	}
-
 	relayer := &exitRelayer{
 		key:            key,
 		logger:         logger,
 		exitStore:      exitStore,
 		txRelayer:      txRelayer,
 		proofRetriever: proofRetriever,
-		exitHelperAddr: exitHelperAddr,
 		closeCh:        make(chan struct{}),
 		notifyCh:       make(chan struct{}, 1),
 		relayerEventsProcessor: &relayerEventsProcessor{
@@ -241,7 +229,7 @@ func (e *exitRelayer) sendTx(events []*RelayerEventMetaData) error {
 	// send batchExecute exit events
 	_, err = e.txRelayer.SendTransaction(&ethgo.Transaction{
 		From:  e.key.Address(),
-		To:    (*ethgo.Address)(&e.exitHelperAddr),
+		To:    (*ethgo.Address)(&e.config.eventExecutionAddr),
 		Input: input,
 	}, e.key)
 

--- a/consensus/polybft/exit_relayer.go
+++ b/consensus/polybft/exit_relayer.go
@@ -1,0 +1,68 @@
+package polybft
+
+import (
+	"github.com/0xPolygon/polygon-edge/txrelayer"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/hashicorp/go-hclog"
+	"github.com/umbracle/ethgo"
+)
+
+type ExitRelayer interface {
+	AddLog(eventLog *ethgo.Log) error
+	PostBlock(req *PostBlockRequest) error
+}
+
+var _ ExitRelayer = (*dummyExitRelayer)(nil)
+
+type dummyExitRelayer struct{}
+
+func (d *dummyExitRelayer) AddLog(eventLog *ethgo.Log) error      { return nil }
+func (d *dummyExitRelayer) PostBlock(req *PostBlockRequest) error { return nil }
+
+// EventProofRetriever is an interface that exposes function for retrieving exit proof
+type EventProofRetriever interface {
+	GenerateExitProof(exitID uint64) (types.Proof, error)
+}
+
+var _ ExitRelayer = (*exitRelayer)(nil)
+
+type exitRelayer struct {
+	key            ethgo.Key
+	state          *CheckpointStore
+	blockchain     blockchainBackend
+	proofRetriever EventProofRetriever
+	txRelayer      txrelayer.TxRelayer
+	logger         hclog.Logger
+
+	notifyCh chan struct{}
+	closeCh  chan struct{}
+}
+
+func newExitRelayer(
+	txRelayer txrelayer.TxRelayer,
+	key ethgo.Key,
+	proofRetriever EventProofRetriever,
+	blockchain blockchainBackend,
+	state *CheckpointStore,
+	logger hclog.Logger) *exitRelayer {
+	return &exitRelayer{
+		key:            key,
+		state:          state,
+		logger:         logger,
+		txRelayer:      txRelayer,
+		blockchain:     blockchain,
+		proofRetriever: proofRetriever,
+		closeCh:        make(chan struct{}),
+		notifyCh:       make(chan struct{}, 1),
+	}
+}
+
+func (e *exitRelayer) PostBlock(req *PostBlockRequest) error {
+	return nil
+}
+
+func (e *exitRelayer) AddLog(log *ethgo.Log) error {
+	e.logger.Info("Received CheckpointSubmittedEvent")
+
+	return nil
+}

--- a/consensus/polybft/exit_relayer_test.go
+++ b/consensus/polybft/exit_relayer_test.go
@@ -82,7 +82,7 @@ func TestExitRelayer_FullWorkflow(t *testing.T) {
 				Metadata: map[string]interface{}{
 					"ExitEvent":       hex.EncodeToString(encodedEvent),
 					"CheckpointBlock": big.NewInt(10),
-					"LeafIndex":       big.NewInt(0),
+					"LeafIndex":       uint64(0),
 				},
 			}, nil
 		},

--- a/consensus/polybft/exit_relayer_test.go
+++ b/consensus/polybft/exit_relayer_test.go
@@ -98,8 +98,8 @@ func TestExitRelayer_FullWorkflow(t *testing.T) {
 			maxAttemptsToSend:        6,
 			maxBlocksToWaitForResend: 1,
 			maxEventsPerBatch:        2,
+			eventExecutionAddr:       exitHelperAddr,
 		},
-		exitHelperAddr,
 		hclog.Default(),
 	)
 

--- a/consensus/polybft/exit_relayer_test.go
+++ b/consensus/polybft/exit_relayer_test.go
@@ -1,0 +1,235 @@
+package polybft
+
+import (
+	"encoding/hex"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/helper/common"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/umbracle/ethgo"
+	"github.com/umbracle/ethgo/abi"
+)
+
+func TestExitRelayer_FullWorkflow(t *testing.T) {
+	t.Parallel()
+
+	testKey := createTestKey(t)
+	exitHelperAddr := types.StringToAddress("0xExitHelper")
+
+	resultLogs := []*types.Log{
+		createTestLogForExitProcessedEvent(t, 1, exitHelperAddr), createTestLogForExitProcessedEvent(t, 2, exitHelperAddr),
+		createTestLogForExitProcessedEvent(t, 3, exitHelperAddr), createTestLogForExitProcessedEvent(t, 4, exitHelperAddr),
+	}
+	checkpointSubmittedLogs := []*types.Log{
+		createTestLogForCheckpointSubmittedEvent(t, exitHelperAddr, 1, 10, types.StringToHash("0x2")),
+		createTestLogForCheckpointSubmittedEvent(t, exitHelperAddr, 2, 20, types.StringToHash("0x2")),
+	}
+
+	blockhainMock := &blockchainMock{}
+	dummyTxRelayer := newDummyStakeTxRelayer(t, nil)
+	state := newTestState(t)
+
+	insertTestExitEvent := func(exitEventID, epoch, block uint64) {
+		require.NoError(t, state.ExitStore.insertExitEvent(
+			&ExitEvent{
+				L2StateSyncedEvent: &contractsapi.L2StateSyncedEvent{
+					ID:       big.NewInt(int64(exitEventID)),
+					Sender:   types.StringToAddress("0xffee"),
+					Receiver: types.StringToAddress("0xeeff"),
+				},
+				EpochNumber: epoch,
+				BlockNumber: block,
+			},
+			nil,
+		))
+	}
+
+	// insert exit events for epoch 1
+	insertTestExitEvent(1, 1, 10)
+	insertTestExitEvent(2, 1, 10)
+
+	// insert exit events for epoch 2
+	insertTestExitEvent(3, 2, 20)
+	insertTestExitEvent(4, 2, 20)
+
+	headers := []*types.Header{
+		{Number: 11}, {Number: 12}, {Number: 13},
+	}
+
+	for _, h := range headers {
+		blockhainMock.On("CurrentHeader").Return(h).Once()
+	}
+
+	proofMock := &mockExitProofRetriever{
+		fn: func(exitEventID uint64) (types.Proof, error) {
+			mockEvent := &contractsapi.L2StateSyncedEvent{
+				ID:       big.NewInt(int64(exitEventID)),
+				Sender:   types.StringToAddress("0xffee"),
+				Receiver: types.StringToAddress("0xeeff"),
+			}
+			encodedEvent, err := mockEvent.Encode()
+			require.NoError(t, err)
+
+			return types.Proof{
+				Data: []types.Hash{types.StringToHash("0x1122334455")},
+				Metadata: map[string]interface{}{
+					"ExitEvent":       hex.EncodeToString(encodedEvent),
+					"CheckpointBlock": big.NewInt(10),
+					"LeafIndex":       big.NewInt(0),
+				},
+			}, nil
+		},
+	}
+
+	exitRelayer := newExitRelayer(
+		dummyTxRelayer,
+		testKey,
+		proofMock,
+		blockhainMock,
+		state.ExitStore,
+		&relayerConfig{
+			maxAttemptsToSend:        6,
+			maxBlocksToWaitForResend: 1,
+			maxEventsPerBatch:        2,
+		},
+		exitHelperAddr,
+		hclog.Default(),
+	)
+
+	// send first two events without errors
+	dummyTxRelayer.On("SendTransaction", mock.Anything, testKey).Return((*ethgo.Receipt)(nil), nil).Once()
+	// fail 3rd time
+	dummyTxRelayer.On("SendTransaction", mock.Anything, testKey).Return(
+		(*ethgo.Receipt)(nil), errors.New("e")).Once()
+	// send 2 events all at once at the end
+	dummyTxRelayer.On("SendTransaction", mock.Anything, testKey).Return((*ethgo.Receipt)(nil), nil).Once()
+
+	require.NoError(t, exitRelayer.Init())
+
+	// post 1st block
+	require.NoError(t, exitRelayer.AddLog(convertLog(checkpointSubmittedLogs[0])))
+	require.NoError(t, exitRelayer.AddLog(convertLog(checkpointSubmittedLogs[1])))
+	require.NoError(t, exitRelayer.PostBlock(&PostBlockRequest{}))
+
+	time.Sleep(time.Second * 2) // wait for some time
+
+	events, err := state.ExitStore.GetAllAvailableRelayerEvents(0)
+
+	require.NoError(t, err)
+	require.Len(t, events, 4)
+	require.Equal(t, uint64(1), events[0].EventID)
+	// first two events should be executed
+	require.True(t, events[0].SentStatus)
+	require.True(t, events[1].SentStatus)
+	require.False(t, events[2].SentStatus)
+	require.False(t, events[3].SentStatus)
+
+	// post 2nd block
+	// send exit processed events for the two executed events
+	require.NoError(t, exitRelayer.AddLog(convertLog(resultLogs[0])))
+	require.NoError(t, exitRelayer.AddLog(convertLog(resultLogs[1])))
+	require.NoError(t, exitRelayer.PostBlock(&PostBlockRequest{}))
+
+	time.Sleep(time.Second * 2) // wait for some time
+
+	events, err = state.ExitStore.GetAllAvailableRelayerEvents(0)
+
+	require.NoError(t, err)
+	// should only have two since first two were successfully executed
+	require.Len(t, events, 2)
+	require.True(t, events[0].SentStatus)
+	require.True(t, events[1].SentStatus)
+	require.Equal(t, uint64(3), events[0].EventID)
+	require.Equal(t, uint64(4), events[1].EventID)
+
+	// since sending of second batch failed
+	// we do post 3rd block to see if they are sent in this one
+	require.NoError(t, exitRelayer.PostBlock(&PostBlockRequest{}))
+
+	time.Sleep(time.Second * 2) // wait for some time
+
+	events, err = state.ExitStore.GetAllAvailableRelayerEvents(0)
+
+	require.NoError(t, err)
+	// should only have two since first two were successfully executed
+	require.Len(t, events, 2)
+	require.True(t, events[0].SentStatus)
+	require.True(t, events[1].SentStatus)
+	require.Equal(t, uint64(3), events[0].EventID)
+	require.Equal(t, uint64(4), events[1].EventID)
+
+	// send exit processed events for the two executed events
+	require.NoError(t, exitRelayer.AddLog(convertLog(resultLogs[2])))
+	require.NoError(t, exitRelayer.AddLog(convertLog(resultLogs[3])))
+
+	time.Sleep(time.Second * 2) // wait for some time
+
+	events, err = state.ExitStore.GetAllAvailableRelayerEvents(0)
+
+	require.NoError(t, err)
+	// should have no events since all of them were executed successfully
+	require.Len(t, events, 0)
+
+	exitRelayer.Close()
+	time.Sleep(time.Second)
+
+	blockhainMock.AssertExpectations(t)
+	dummyTxRelayer.AssertExpectations(t)
+}
+
+type mockExitProofRetriever struct {
+	fn func(uint64) (types.Proof, error)
+}
+
+func (m *mockExitProofRetriever) GenerateExitProof(exitEventID uint64) (types.Proof, error) {
+	if m.fn != nil {
+		return m.fn(exitEventID)
+	}
+
+	return types.Proof{}, nil
+}
+
+func createTestLogForExitProcessedEvent(t *testing.T, exitEventID uint64, exitHelperAddr types.Address) *types.Log {
+	t.Helper()
+
+	topics := make([]types.Hash, 3)
+	topics[0] = types.Hash(new(contractsapi.ExitProcessedEvent).Sig())
+	topics[1] = types.BytesToHash(common.EncodeUint64ToBytes(exitEventID))
+	topics[2] = types.BytesToHash(common.EncodeUint64ToBytes(1)) // Success = true
+	someType := abi.MustNewType("tuple(string field1, string field2)")
+	encodedData, err := someType.Encode(map[string]string{"field1": "value1", "field2": "value2"})
+	require.NoError(t, err)
+
+	return &types.Log{
+		Address: exitHelperAddr,
+		Topics:  topics,
+		Data:    encodedData,
+	}
+}
+
+func createTestLogForCheckpointSubmittedEvent(
+	t *testing.T,
+	exitHelperAddr types.Address,
+	epoch uint64,
+	checkpointBlockNumber uint64,
+	exitRootHash types.Hash) *types.Log {
+	t.Helper()
+
+	topics := make([]types.Hash, 3)
+	topics[0] = types.Hash(new(contractsapi.CheckpointSubmittedEvent).Sig())
+	topics[1] = types.BytesToHash(common.EncodeUint64ToBytes(epoch))
+	topics[2] = types.BytesToHash(common.EncodeUint64ToBytes(checkpointBlockNumber))
+
+	return &types.Log{
+		Address: exitHelperAddr,
+		Topics:  topics,
+		Data:    exitRootHash[:],
+	}
+}

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -215,8 +215,10 @@ func TestPolybft_Close(t *testing.T) {
 		closeCh: make(chan struct{}),
 		syncer:  syncer,
 		runtime: &consensusRuntime{
-			stateSyncManager: &dummyStateSyncManager{},
-			stateSyncRelayer: &dummyStateSyncRelayer{},
+			bridgeManager: &bridgeManager{
+				stateSyncManager: &dummyStateSyncManager{},
+				stateSyncRelayer: &dummyStateSyncRelayer{},
+			},
 		},
 	}
 

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -215,10 +215,7 @@ func TestPolybft_Close(t *testing.T) {
 		closeCh: make(chan struct{}),
 		syncer:  syncer,
 		runtime: &consensusRuntime{
-			bridgeManager: &bridgeManager{
-				stateSyncManager: &dummyStateSyncManager{},
-				stateSyncRelayer: &dummyStateSyncRelayer{},
-			},
+			bridgeManager: &dummyBridgeManager{},
 		},
 	}
 

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -96,24 +96,6 @@ func (s *State) initStorages() error {
 			return fmt.Errorf("failed to create bucket=%s: %w", string(edgeEventsLastProcessedBlockBucket), err)
 		}
 
-		lastProcessedBlock, err := s.getLastProcessedEventsBlock(tx)
-		if err != nil {
-			return fmt.Errorf("failed to get last processed block: %w", err)
-		}
-
-		if lastProcessedBlock == 0 {
-			// we do this for already existing chains, which just updated their Edge binary,
-			// to not get events from scratch, but start from what other stores have
-			lastSaved, err := s.ExitStore.getLastSaved(tx)
-			if err != nil {
-				return fmt.Errorf("could not initialize last processed block bucket: %w", err)
-			}
-
-			if lastSaved > 0 {
-				return s.insertLastProcessedEventsBlock(lastSaved, tx)
-			}
-		}
-
 		return s.GovernanceStore.initialize(tx)
 	})
 }

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -39,7 +39,7 @@ type State struct {
 	close chan struct{}
 
 	StateSyncStore        *StateSyncStore
-	CheckpointStore       *CheckpointStore
+	ExitStore             *ExitStore
 	EpochStore            *EpochStore
 	ProposerSnapshotStore *ProposerSnapshotStore
 	StakeStore            *StakeStore
@@ -57,7 +57,7 @@ func newState(path string, logger hclog.Logger, closeCh chan struct{}) (*State, 
 		db:                    db,
 		close:                 closeCh,
 		StateSyncStore:        &StateSyncStore{db: db},
-		CheckpointStore:       &CheckpointStore{db: db},
+		ExitStore:             &ExitStore{db: db},
 		EpochStore:            &EpochStore{db: db},
 		ProposerSnapshotStore: &ProposerSnapshotStore{db: db},
 		StakeStore:            &StakeStore{db: db},
@@ -78,7 +78,7 @@ func (s *State) initStorages() error {
 		if err := s.StateSyncStore.initialize(tx); err != nil {
 			return err
 		}
-		if err := s.CheckpointStore.initialize(tx); err != nil {
+		if err := s.ExitStore.initialize(tx); err != nil {
 			return err
 		}
 		if err := s.EpochStore.initialize(tx); err != nil {
@@ -104,7 +104,7 @@ func (s *State) initStorages() error {
 		if lastProcessedBlock == 0 {
 			// we do this for already existing chains, which just updated their Edge binary,
 			// to not get events from scratch, but start from what other stores have
-			lastSaved, err := s.CheckpointStore.getLastSaved(tx)
+			lastSaved, err := s.ExitStore.getLastSaved(tx)
 			if err != nil {
 				return fmt.Errorf("could not initialize last processed block bucket: %w", err)
 			}

--- a/consensus/polybft/state_store_exit.go
+++ b/consensus/polybft/state_store_exit.go
@@ -196,7 +196,7 @@ func (s *ExitStore) getExitEvents(epoch uint64, filter func(exitEvent *ExitEvent
 }
 
 // getAllAvailableRelayerEvents retrieves all Exit RelayerEventData that should be sent as a transactions
-func (s *ExitStore) GetAllAvailableRelayerEvents(limit int) (result []*RelayerEventData, err error) {
+func (s *ExitStore) GetAllAvailableRelayerEvents(limit int) (result []*RelayerEventMetaData, err error) {
 	if err = s.db.View(func(tx *bolt.Tx) error {
 		result, err = getAvailableRelayerEvents(limit, exitRelayerEventsBucket, tx)
 		if err != nil {
@@ -213,7 +213,7 @@ func (s *ExitStore) GetAllAvailableRelayerEvents(limit int) (result []*RelayerEv
 
 // updateRelayerEvents updates/remove desired exit relayer events
 func (s *ExitStore) UpdateRelayerEvents(
-	events []*RelayerEventData, removeIDs []uint64, dbTx *bolt.Tx) error {
+	events []*RelayerEventMetaData, removeIDs []uint64, dbTx *bolt.Tx) error {
 	return updateRelayerEvents(exitRelayerEventsBucket, events, removeIDs, s.db, dbTx)
 }
 

--- a/consensus/polybft/state_store_exit.go
+++ b/consensus/polybft/state_store_exit.go
@@ -51,12 +51,12 @@ exit events/
 |--> (exitEventID) -> epochNumber
 |--> (lastProcessedBlockKey) -> block number
 */
-type CheckpointStore struct {
+type ExitStore struct {
 	db *bolt.DB
 }
 
 // initialize creates necessary buckets in DB if they don't already exist
-func (s *CheckpointStore) initialize(tx *bolt.Tx) error {
+func (s *ExitStore) initialize(tx *bolt.Tx) error {
 	if _, err := tx.CreateBucketIfNotExists(exitEventsBucket); err != nil {
 		return fmt.Errorf("failed to create bucket=%s: %w", string(exitEventsBucket), err)
 	}
@@ -77,7 +77,7 @@ func (s *CheckpointStore) initialize(tx *bolt.Tx) error {
 }
 
 // insertExitEventWithTx inserts an exit event to db
-func (s *CheckpointStore) insertExitEvent(exitEvent *ExitEvent, dbTx *bolt.Tx) error {
+func (s *ExitStore) insertExitEvent(exitEvent *ExitEvent, dbTx *bolt.Tx) error {
 	insertFn := func(tx *bolt.Tx) error {
 		raw, err := json.Marshal(exitEvent)
 		if err != nil {
@@ -106,7 +106,7 @@ func (s *CheckpointStore) insertExitEvent(exitEvent *ExitEvent, dbTx *bolt.Tx) e
 }
 
 // getExitEvent returns exit event with given id, which happened in given epoch and given block number
-func (s *CheckpointStore) getExitEvent(exitEventID uint64) (*ExitEvent, error) {
+func (s *ExitStore) getExitEvent(exitEventID uint64) (*ExitEvent, error) {
 	var exitEvent *ExitEvent
 
 	err := s.db.View(func(tx *bolt.Tx) error {
@@ -138,7 +138,7 @@ func (s *CheckpointStore) getExitEvent(exitEventID uint64) (*ExitEvent, error) {
 }
 
 // getExitEventsByEpoch returns all exit events that happened in the given epoch
-func (s *CheckpointStore) getExitEventsByEpoch(epoch uint64) ([]*ExitEvent, error) {
+func (s *ExitStore) getExitEventsByEpoch(epoch uint64) ([]*ExitEvent, error) {
 	return s.getExitEvents(epoch, func(exitEvent *ExitEvent) bool {
 		return exitEvent.EpochNumber == epoch
 	})
@@ -146,14 +146,14 @@ func (s *CheckpointStore) getExitEventsByEpoch(epoch uint64) ([]*ExitEvent, erro
 
 // getExitEventsForProof returns all exit events that happened in and prior to the given checkpoint block number
 // with respect to the epoch in which block is added
-func (s *CheckpointStore) getExitEventsForProof(epoch, checkpointBlock uint64) ([]*ExitEvent, error) {
+func (s *ExitStore) getExitEventsForProof(epoch, checkpointBlock uint64) ([]*ExitEvent, error) {
 	return s.getExitEvents(epoch, func(exitEvent *ExitEvent) bool {
 		return exitEvent.EpochNumber == epoch && exitEvent.BlockNumber <= checkpointBlock
 	})
 }
 
 // getExitEvents returns exit events for given epoch and provided filter
-func (s *CheckpointStore) getExitEvents(epoch uint64, filter func(exitEvent *ExitEvent) bool) ([]*ExitEvent, error) {
+func (s *ExitStore) getExitEvents(epoch uint64, filter func(exitEvent *ExitEvent) bool) ([]*ExitEvent, error) {
 	var events []*ExitEvent
 
 	err := s.db.View(func(tx *bolt.Tx) error {
@@ -183,7 +183,7 @@ func (s *CheckpointStore) getExitEvents(epoch uint64, filter func(exitEvent *Exi
 }
 
 // updateLastSaved saves the last block processed for exit events
-func (s *CheckpointStore) getLastSaved(dbTx *bolt.Tx) (uint64, error) {
+func (s *ExitStore) getLastSaved(dbTx *bolt.Tx) (uint64, error) {
 	var (
 		lastSavedBlock uint64
 		err            error

--- a/consensus/polybft/state_store_exit.go
+++ b/consensus/polybft/state_store_exit.go
@@ -195,28 +195,6 @@ func (s *ExitStore) getExitEvents(epoch uint64, filter func(exitEvent *ExitEvent
 	return events, err
 }
 
-// removeStateSyncEventsAndProofs removes state sync events and their proofs from the buckets in db
-func (s *ExitStore) removeExitEvents(exitEventIDs []uint64, dbTx *bolt.Tx) error {
-	return s.db.Update(func(tx *bolt.Tx) error {
-		eventsBucket := tx.Bucket(exitEventsBucket)
-
-		for _, exitEventID := range exitEventIDs {
-			exitEvent, err := getExitEventSingle(exitEventID, tx)
-			if err != nil {
-				return err
-			}
-
-			key := generateExitEventKey(exitEvent.ID.Uint64(), exitEvent.EpochNumber, exitEvent.BlockNumber)
-
-			if err := eventsBucket.Delete(key); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	})
-}
-
 // getAllAvailableRelayerEvents retrieves all Exit RelayerEventData that should be sent as a transactions
 func (s *ExitStore) GetAllAvailableRelayerEvents(limit int) (result []*RelayerEventData, err error) {
 	if err = s.db.View(func(tx *bolt.Tx) error {

--- a/consensus/polybft/state_store_exit_test.go
+++ b/consensus/polybft/state_store_exit_test.go
@@ -213,40 +213,36 @@ func TestState_ExitRelayerDataAndEvents(t *testing.T) {
 	// update
 	require.NoError(t, state.ExitStore.UpdateRelayerEvents([]*RelayerEventData{
 		{EventID: 1},
-		{EventID: 2},
-		{EventID: 3, SentStatus: true, BlockNumber: 10},
+		{EventID: 2, SentStatus: true, BlockNumber: 10},
 	}, []uint64{}, nil))
 
 	// get available events
 	events, err := state.ExitStore.GetAllAvailableRelayerEvents(0)
 
 	require.NoError(t, err)
-	require.Len(t, events, 3)
+	require.Len(t, events, 2)
 	require.Equal(t, uint64(1), events[0].EventID)
 	require.Equal(t, uint64(2), events[1].EventID)
-	require.Equal(t, uint64(3), events[2].EventID)
 
 	// update again
 	require.NoError(t, state.ExitStore.UpdateRelayerEvents(
 		[]*RelayerEventData{
+			{EventID: 3},
 			{EventID: 4},
-			{EventID: 5},
-			{EventID: 6},
 		},
 		[]uint64{1, 2},
 		nil,
 	))
 
 	// get available events
-	events, err = state.ExitStore.GetAllAvailableRelayerEvents(1000)
+	events, err = state.ExitStore.GetAllAvailableRelayerEvents(10)
 
 	require.NoError(t, err)
-	require.Len(t, events, 4)
+	require.Len(t, events, 2)
 	require.Equal(t, uint64(3), events[0].EventID)
 	require.Equal(t, uint64(4), events[1].EventID)
+	require.Equal(t, false, events[0].SentStatus)
 	require.Equal(t, false, events[1].SentStatus)
-	require.Equal(t, uint64(5), events[2].EventID)
-	require.Equal(t, uint64(6), events[3].EventID)
 
 	events[1].SentStatus = true
 	require.NoError(t, state.ExitStore.UpdateRelayerEvents(events[1:2], []uint64{3}, nil))
@@ -255,8 +251,7 @@ func TestState_ExitRelayerDataAndEvents(t *testing.T) {
 	events, err = state.ExitStore.GetAllAvailableRelayerEvents(2)
 
 	require.NoError(t, err)
-	require.Len(t, events, 2)
+	require.Len(t, events, 1)
 	require.Equal(t, uint64(4), events[0].EventID)
 	require.Equal(t, true, events[0].SentStatus)
-	require.Equal(t, uint64(5), events[1].EventID)
 }

--- a/consensus/polybft/state_store_exit_test.go
+++ b/consensus/polybft/state_store_exit_test.go
@@ -25,14 +25,14 @@ func TestState_Insert_And_Get_ExitEvents_PerEpoch(t *testing.T) {
 	insertTestExitEvents(t, state, numOfEpochs, numOfBlocksPerEpoch, numOfEventsPerBlock)
 
 	t.Run("Get events for existing epoch", func(t *testing.T) {
-		events, err := state.CheckpointStore.getExitEventsByEpoch(1)
+		events, err := state.ExitStore.getExitEventsByEpoch(1)
 
 		assert.NoError(t, err)
 		assert.Len(t, events, numOfBlocksPerEpoch*numOfEventsPerBlock)
 	})
 
 	t.Run("Get events for non-existing epoch", func(t *testing.T) {
-		events, err := state.CheckpointStore.getExitEventsByEpoch(12)
+		events, err := state.ExitStore.getExitEventsByEpoch(12)
 
 		assert.NoError(t, err)
 		assert.Len(t, events, 0)
@@ -65,7 +65,7 @@ func TestState_Insert_And_Get_ExitEvents_ForProof(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		events, err := state.CheckpointStore.getExitEventsForProof(c.epoch, c.checkpointBlockNumber)
+		events, err := state.ExitStore.getExitEventsForProof(c.epoch, c.checkpointBlockNumber)
 
 		assert.NoError(t, err)
 		assert.Len(t, events, c.expectedNumberOfEvents)
@@ -78,7 +78,7 @@ func TestState_Insert_And_Get_ExitEvents_ForProof_NoEvents(t *testing.T) {
 	state := newTestState(t)
 	insertTestExitEvents(t, state, 1, 10, 1)
 
-	events, err := state.CheckpointStore.getExitEventsForProof(2, 11)
+	events, err := state.ExitStore.getExitEventsForProof(2, 11)
 
 	assert.NoError(t, err)
 	assert.Nil(t, events)
@@ -96,7 +96,7 @@ func TestState_NoEpochForExitEventInLookup(t *testing.T) {
 	state := newTestState(t)
 	insertTestExitEvents(t, state, 3, 10, 1)
 
-	exitEventFromDB, err := state.CheckpointStore.getExitEvent(exitToTest)
+	exitEventFromDB, err := state.ExitStore.getExitEvent(exitToTest)
 	require.NoError(t, err)
 	require.Equal(t, exitToTest, exitEventFromDB.ID.Uint64())
 	require.Equal(t, epochToMatch, exitEventFromDB.EpochNumber)
@@ -109,7 +109,7 @@ func TestState_NoEpochForExitEventInLookup(t *testing.T) {
 
 	require.NoError(t, err)
 
-	_, err = state.CheckpointStore.getExitEvent(exitToTest)
+	_, err = state.ExitStore.getExitEvent(exitToTest)
 	require.ErrorContains(t, err, "epoch was not found in lookup table")
 }
 
@@ -147,7 +147,7 @@ func TestState_decodeExitEvent(t *testing.T) {
 	require.Equal(t, uint64(epoch), event.EpochNumber)
 	require.Equal(t, uint64(blockNumber), event.BlockNumber)
 
-	require.NoError(t, state.CheckpointStore.insertExitEvent(event, nil))
+	require.NoError(t, state.ExitStore.insertExitEvent(event, nil))
 }
 
 func TestState_decodeExitEvent_NotAnExitEvent(t *testing.T) {
@@ -199,7 +199,7 @@ func insertTestExitEvents(t *testing.T, state *State,
 	}
 
 	for _, ee := range exitEvents {
-		require.NoError(t, state.CheckpointStore.insertExitEvent(ee, nil))
+		require.NoError(t, state.ExitStore.insertExitEvent(ee, nil))
 	}
 
 	return exitEvents

--- a/consensus/polybft/state_store_exit_test.go
+++ b/consensus/polybft/state_store_exit_test.go
@@ -204,3 +204,59 @@ func insertTestExitEvents(t *testing.T, state *State,
 
 	return exitEvents
 }
+
+func TestState_ExitRelayerDataAndEvents(t *testing.T) {
+	t.Parallel()
+
+	state := newTestState(t)
+
+	// update
+	require.NoError(t, state.ExitStore.UpdateRelayerEvents([]*RelayerEventData{
+		{EventID: 2},
+		{EventID: 4},
+		{EventID: 7, SentStatus: true, BlockNumber: 100},
+	}, []uint64{}, nil))
+
+	// get available events
+	events, err := state.ExitStore.GetAllAvailableRelayerEvents(0)
+
+	require.NoError(t, err)
+	require.Len(t, events, 3)
+	require.Equal(t, uint64(2), events[0].EventID)
+	require.Equal(t, uint64(4), events[1].EventID)
+	require.Equal(t, uint64(7), events[2].EventID)
+
+	// update again
+	require.NoError(t, state.ExitStore.UpdateRelayerEvents(
+		[]*RelayerEventData{
+			{EventID: 10},
+			{EventID: 12},
+			{EventID: 11},
+		},
+		[]uint64{4, 7},
+		nil,
+	))
+
+	// get available events
+	events, err = state.ExitStore.GetAllAvailableRelayerEvents(1000)
+
+	require.NoError(t, err)
+	require.Len(t, events, 4)
+	require.Equal(t, uint64(2), events[0].EventID)
+	require.Equal(t, uint64(10), events[1].EventID)
+	require.Equal(t, false, events[1].SentStatus)
+	require.Equal(t, uint64(11), events[2].EventID)
+	require.Equal(t, uint64(12), events[3].EventID)
+
+	events[1].SentStatus = true
+	require.NoError(t, state.ExitStore.UpdateRelayerEvents(events[1:2], []uint64{2}, nil))
+
+	// get available events with limit
+	events, err = state.ExitStore.GetAllAvailableRelayerEvents(2)
+
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	require.Equal(t, uint64(10), events[0].EventID)
+	require.Equal(t, true, events[0].SentStatus)
+	require.Equal(t, uint64(11), events[1].EventID)
+}

--- a/consensus/polybft/state_store_exit_test.go
+++ b/consensus/polybft/state_store_exit_test.go
@@ -211,7 +211,7 @@ func TestState_ExitRelayerDataAndEvents(t *testing.T) {
 	state := newTestState(t)
 
 	// update
-	require.NoError(t, state.ExitStore.UpdateRelayerEvents([]*RelayerEventData{
+	require.NoError(t, state.ExitStore.UpdateRelayerEvents([]*RelayerEventMetaData{
 		{EventID: 1},
 		{EventID: 2, SentStatus: true, BlockNumber: 10},
 	}, []uint64{}, nil))
@@ -226,7 +226,7 @@ func TestState_ExitRelayerDataAndEvents(t *testing.T) {
 
 	// update again
 	require.NoError(t, state.ExitStore.UpdateRelayerEvents(
-		[]*RelayerEventData{
+		[]*RelayerEventMetaData{
 			{EventID: 3},
 			{EventID: 4},
 		},

--- a/consensus/polybft/state_store_exit_test.go
+++ b/consensus/polybft/state_store_exit_test.go
@@ -212,9 +212,9 @@ func TestState_ExitRelayerDataAndEvents(t *testing.T) {
 
 	// update
 	require.NoError(t, state.ExitStore.UpdateRelayerEvents([]*RelayerEventData{
+		{EventID: 1},
 		{EventID: 2},
-		{EventID: 4},
-		{EventID: 7, SentStatus: true, BlockNumber: 100},
+		{EventID: 3, SentStatus: true, BlockNumber: 10},
 	}, []uint64{}, nil))
 
 	// get available events
@@ -222,18 +222,18 @@ func TestState_ExitRelayerDataAndEvents(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, events, 3)
-	require.Equal(t, uint64(2), events[0].EventID)
-	require.Equal(t, uint64(4), events[1].EventID)
-	require.Equal(t, uint64(7), events[2].EventID)
+	require.Equal(t, uint64(1), events[0].EventID)
+	require.Equal(t, uint64(2), events[1].EventID)
+	require.Equal(t, uint64(3), events[2].EventID)
 
 	// update again
 	require.NoError(t, state.ExitStore.UpdateRelayerEvents(
 		[]*RelayerEventData{
-			{EventID: 10},
-			{EventID: 12},
-			{EventID: 11},
+			{EventID: 4},
+			{EventID: 5},
+			{EventID: 6},
 		},
-		[]uint64{4, 7},
+		[]uint64{1, 2},
 		nil,
 	))
 
@@ -242,21 +242,21 @@ func TestState_ExitRelayerDataAndEvents(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, events, 4)
-	require.Equal(t, uint64(2), events[0].EventID)
-	require.Equal(t, uint64(10), events[1].EventID)
+	require.Equal(t, uint64(3), events[0].EventID)
+	require.Equal(t, uint64(4), events[1].EventID)
 	require.Equal(t, false, events[1].SentStatus)
-	require.Equal(t, uint64(11), events[2].EventID)
-	require.Equal(t, uint64(12), events[3].EventID)
+	require.Equal(t, uint64(5), events[2].EventID)
+	require.Equal(t, uint64(6), events[3].EventID)
 
 	events[1].SentStatus = true
-	require.NoError(t, state.ExitStore.UpdateRelayerEvents(events[1:2], []uint64{2}, nil))
+	require.NoError(t, state.ExitStore.UpdateRelayerEvents(events[1:2], []uint64{3}, nil))
 
 	// get available events with limit
 	events, err = state.ExitStore.GetAllAvailableRelayerEvents(2)
 
 	require.NoError(t, err)
 	require.Len(t, events, 2)
-	require.Equal(t, uint64(10), events[0].EventID)
+	require.Equal(t, uint64(4), events[0].EventID)
 	require.Equal(t, true, events[0].SentStatus)
-	require.Equal(t, uint64(11), events[1].EventID)
+	require.Equal(t, uint64(5), events[1].EventID)
 }

--- a/consensus/polybft/state_store_state_sync.go
+++ b/consensus/polybft/state_store_state_sync.go
@@ -20,7 +20,7 @@ var (
 	// bucket to store message votes (signatures)
 	messageVotesBucket = []byte("votes")
 	// bucket to store all state sync relayer events
-	stateSyncRelayerEventsBucket = []byte("relayerEvents")
+	stateSyncRelayerEventsBucket = []byte("stateSyncRelayerEvents")
 
 	// errNotEnoughStateSyncs error message
 	errNotEnoughStateSyncs = errors.New("there is either a gap or not enough sync events")
@@ -43,7 +43,7 @@ stateSyncProofs/
 |--> stateSyncProof.StateSync.Id -> *StateSyncProof (json marshalled)
 
 relayerEvents/
-|--> StateSyncRelayerEventData.EventID -> *StateSyncRelayerEventData (json marshalled)
+|--> RelayerEventData.EventID -> *RelayerEventData (json marshalled)
 */
 
 type StateSyncStore struct {
@@ -375,62 +375,18 @@ func (s *StateSyncStore) getStateSyncProof(stateSyncID uint64) (*StateSyncProof,
 	return ssp, err
 }
 
-// updateStateSyncRelayerEvents updates/remove desired events
-func (s *StateSyncStore) updateStateSyncRelayerEvents(
-	events []*StateSyncRelayerEventData, removeIDs []uint64, dbTx *bolt.Tx) error {
-	updateFn := func(tx *bolt.Tx) error {
-		relayerEventsBucket := tx.Bucket(stateSyncRelayerEventsBucket)
-
-		for _, evnt := range events {
-			raw, err := json.Marshal(evnt)
-			if err != nil {
-				return err
-			}
-
-			key := common.EncodeUint64ToBytes(evnt.EventID)
-
-			if err := relayerEventsBucket.Put(key, raw); err != nil {
-				return err
-			}
-		}
-
-		for _, stateSyncEventID := range removeIDs {
-			stateSyncEventIDKey := common.EncodeUint64ToBytes(stateSyncEventID)
-
-			if err := relayerEventsBucket.Delete(stateSyncEventIDKey); err != nil {
-				return fmt.Errorf("failed to remove state sync relayer event (ID=%d): %w", stateSyncEventID, err)
-			}
-		}
-
-		return nil
-	}
-
-	if dbTx == nil {
-		return s.db.Update(func(tx *bolt.Tx) error {
-			return updateFn(tx)
-		})
-	}
-
-	return updateFn(dbTx)
+// updateRelayerEvents updates/remove desired state sync relayer events
+func (s *StateSyncStore) UpdateRelayerEvents(
+	events []*RelayerEventData, removeIDs []uint64, dbTx *bolt.Tx) error {
+	return updateRelayerEvents(stateSyncRelayerEventsBucket, events, removeIDs, s.db, dbTx)
 }
 
-// getAllAvailableEvents retrieves all StateSyncRelayerEventData that should be sent as a transactions
-func (s *StateSyncStore) getAllAvailableEvents(limit int) (result []*StateSyncRelayerEventData, err error) {
+// getAllAvailableRelayerEvents retrieves all StateSync RelayerEventData that should be sent as a transactions
+func (s *StateSyncStore) GetAllAvailableRelayerEvents(limit int) (result []*RelayerEventData, err error) {
 	if err = s.db.View(func(tx *bolt.Tx) error {
-		cursor := tx.Bucket(stateSyncRelayerEventsBucket).Cursor()
-
-		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
-			var event *StateSyncRelayerEventData
-
-			if err := json.Unmarshal(v, &event); err != nil {
-				return err
-			}
-
-			result = append(result, event)
-
-			if limit > 0 && len(result) >= limit {
-				break
-			}
+		result, err = getAvailableRelayerEvents(limit, stateSyncRelayerEventsBucket, tx)
+		if err != nil {
+			return err
 		}
 
 		return nil
@@ -439,4 +395,68 @@ func (s *StateSyncStore) getAllAvailableEvents(limit int) (result []*StateSyncRe
 	}
 
 	return result, nil
+}
+
+// getAvailableRelayerEvents retrieves all relayer that should be sent as a transactions
+func getAvailableRelayerEvents(limit int, bucket []byte, tx *bolt.Tx) (result []*RelayerEventData, err error) {
+	cursor := tx.Bucket(bucket).Cursor()
+
+	for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
+		var event *RelayerEventData
+
+		if err = json.Unmarshal(v, &event); err != nil {
+			return
+		}
+
+		result = append(result, event)
+
+		if limit > 0 && len(result) >= limit {
+			break
+		}
+	}
+
+	return
+}
+
+// updateRelayerEvents updates/remove desired relayer events
+func updateRelayerEvents(
+	bucket []byte,
+	events []*RelayerEventData,
+	removeIDs []uint64,
+	db *bolt.DB,
+	openedTx *bolt.Tx) error {
+	updateFn := func(tx *bolt.Tx) error {
+		relayerEventsBucket := tx.Bucket(bucket)
+
+		for _, event := range events {
+			raw, err := json.Marshal(event)
+			if err != nil {
+				return err
+			}
+
+			key := common.EncodeUint64ToBytes(event.EventID)
+
+			if err := relayerEventsBucket.Put(key, raw); err != nil {
+				return err
+			}
+		}
+
+		for _, eventID := range removeIDs {
+			eventIDKey := common.EncodeUint64ToBytes(eventID)
+
+			if err := relayerEventsBucket.Delete(eventIDKey); err != nil {
+				return fmt.Errorf("failed to remove relayer event (ID=%d): %w", eventID, err)
+			}
+		}
+
+		return nil
+	}
+
+	if openedTx == nil {
+		return db.Update(func(tx *bolt.Tx) error {
+			return updateFn(tx)
+		})
+	}
+
+	return updateFn(openedTx)
 }

--- a/consensus/polybft/state_store_state_sync.go
+++ b/consensus/polybft/state_store_state_sync.go
@@ -377,12 +377,12 @@ func (s *StateSyncStore) getStateSyncProof(stateSyncID uint64) (*StateSyncProof,
 
 // updateRelayerEvents updates/remove desired state sync relayer events
 func (s *StateSyncStore) UpdateRelayerEvents(
-	events []*RelayerEventData, removeIDs []uint64, dbTx *bolt.Tx) error {
+	events []*RelayerEventMetaData, removeIDs []uint64, dbTx *bolt.Tx) error {
 	return updateRelayerEvents(stateSyncRelayerEventsBucket, events, removeIDs, s.db, dbTx)
 }
 
 // getAllAvailableRelayerEvents retrieves all StateSync RelayerEventData that should be sent as a transactions
-func (s *StateSyncStore) GetAllAvailableRelayerEvents(limit int) (result []*RelayerEventData, err error) {
+func (s *StateSyncStore) GetAllAvailableRelayerEvents(limit int) (result []*RelayerEventMetaData, err error) {
 	if err = s.db.View(func(tx *bolt.Tx) error {
 		result, err = getAvailableRelayerEvents(limit, stateSyncRelayerEventsBucket, tx)
 		if err != nil {
@@ -398,11 +398,11 @@ func (s *StateSyncStore) GetAllAvailableRelayerEvents(limit int) (result []*Rela
 }
 
 // getAvailableRelayerEvents retrieves all relayer that should be sent as a transactions
-func getAvailableRelayerEvents(limit int, bucket []byte, tx *bolt.Tx) (result []*RelayerEventData, err error) {
+func getAvailableRelayerEvents(limit int, bucket []byte, tx *bolt.Tx) (result []*RelayerEventMetaData, err error) {
 	cursor := tx.Bucket(bucket).Cursor()
 
 	for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
-		var event *RelayerEventData
+		var event *RelayerEventMetaData
 
 		if err = json.Unmarshal(v, &event); err != nil {
 			return
@@ -421,7 +421,7 @@ func getAvailableRelayerEvents(limit int, bucket []byte, tx *bolt.Tx) (result []
 // updateRelayerEvents updates/remove desired relayer events
 func updateRelayerEvents(
 	bucket []byte,
-	events []*RelayerEventData,
+	events []*RelayerEventMetaData,
 	removeIDs []uint64,
 	db *bolt.DB,
 	openedTx *bolt.Tx) error {

--- a/consensus/polybft/state_store_state_sync_test.go
+++ b/consensus/polybft/state_store_state_sync_test.go
@@ -304,7 +304,7 @@ func TestState_StateSync_StateSyncRelayerDataAndEvents(t *testing.T) {
 	state := newTestState(t)
 
 	// update
-	require.NoError(t, state.StateSyncStore.UpdateRelayerEvents([]*RelayerEventData{
+	require.NoError(t, state.StateSyncStore.UpdateRelayerEvents([]*RelayerEventMetaData{
 		{EventID: 2},
 		{EventID: 4},
 		{EventID: 7, SentStatus: true, BlockNumber: 100},
@@ -321,7 +321,7 @@ func TestState_StateSync_StateSyncRelayerDataAndEvents(t *testing.T) {
 
 	// update again
 	require.NoError(t, state.StateSyncStore.UpdateRelayerEvents(
-		[]*RelayerEventData{
+		[]*RelayerEventMetaData{
 			{EventID: 10},
 			{EventID: 12},
 			{EventID: 11},

--- a/consensus/polybft/state_store_state_sync_test.go
+++ b/consensus/polybft/state_store_state_sync_test.go
@@ -304,14 +304,14 @@ func TestState_StateSync_StateSyncRelayerDataAndEvents(t *testing.T) {
 	state := newTestState(t)
 
 	// update
-	require.NoError(t, state.StateSyncStore.updateStateSyncRelayerEvents([]*StateSyncRelayerEventData{
+	require.NoError(t, state.StateSyncStore.UpdateRelayerEvents([]*RelayerEventData{
 		{EventID: 2},
 		{EventID: 4},
 		{EventID: 7, SentStatus: true, BlockNumber: 100},
 	}, []uint64{}, nil))
 
 	// get available events
-	events, err := state.StateSyncStore.getAllAvailableEvents(0)
+	events, err := state.StateSyncStore.GetAllAvailableRelayerEvents(0)
 
 	require.NoError(t, err)
 	require.Len(t, events, 3)
@@ -320,8 +320,8 @@ func TestState_StateSync_StateSyncRelayerDataAndEvents(t *testing.T) {
 	require.Equal(t, uint64(7), events[2].EventID)
 
 	// update again
-	require.NoError(t, state.StateSyncStore.updateStateSyncRelayerEvents(
-		[]*StateSyncRelayerEventData{
+	require.NoError(t, state.StateSyncStore.UpdateRelayerEvents(
+		[]*RelayerEventData{
 			{EventID: 10},
 			{EventID: 12},
 			{EventID: 11},
@@ -331,7 +331,7 @@ func TestState_StateSync_StateSyncRelayerDataAndEvents(t *testing.T) {
 	))
 
 	// get available events
-	events, err = state.StateSyncStore.getAllAvailableEvents(1000)
+	events, err = state.StateSyncStore.GetAllAvailableRelayerEvents(1000)
 
 	require.NoError(t, err)
 	require.Len(t, events, 4)
@@ -342,10 +342,10 @@ func TestState_StateSync_StateSyncRelayerDataAndEvents(t *testing.T) {
 	require.Equal(t, uint64(12), events[3].EventID)
 
 	events[1].SentStatus = true
-	require.NoError(t, state.StateSyncStore.updateStateSyncRelayerEvents(events[1:2], []uint64{2}, nil))
+	require.NoError(t, state.StateSyncStore.UpdateRelayerEvents(events[1:2], []uint64{2}, nil))
 
 	// get available events with limit
-	events, err = state.StateSyncStore.getAllAvailableEvents(2)
+	events, err = state.StateSyncStore.GetAllAvailableRelayerEvents(2)
 
 	require.NoError(t, err)
 	require.Len(t, events, 2)

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -35,10 +35,6 @@ func newTestStateSyncManager(t *testing.T, key *validator.TestValidator, runtime
 
 	s := newStateSyncManager(hclog.NewNullLogger(), state,
 		&stateSyncConfig{
-			eventTrackerConfig: &eventTrackerConfig{
-				stateSenderAddr: types.Address{},
-				jsonrpcAddr:     "",
-			},
 			dataDir:           tmpDir,
 			topic:             topic,
 			key:               key.Key(),
@@ -474,13 +470,6 @@ func TestStateSyncerManager_AddLog_BuildCommitments(t *testing.T) {
 		require.Equal(t, uint64(0), stateSyncs[0].ID.Uint64())
 		require.Len(t, s.pendingCommitments, 0)
 	})
-}
-
-func TestStateSyncManager_Close(t *testing.T) {
-	t.Parallel()
-
-	mgr := newTestStateSyncManager(t, validator.NewTestValidator(t, "A", 100), &mockRuntime{isActiveValidator: true})
-	require.NotPanics(t, func() { mgr.Close() })
 }
 
 func TestStateSyncManager_GetProofs(t *testing.T) {

--- a/consensus/polybft/state_sync_relayer.go
+++ b/consensus/polybft/state_sync_relayer.go
@@ -16,16 +16,6 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-const (
-	// defaultMaxBlocksToWaitForResend specifies how many blocks should be wait
-	// in order to try again to send transaction
-	defaultMaxBlocksToWaitForResend = uint64(30)
-	// defaultMaxAttemptsToSend specifies how many sending retries for one transaction
-	defaultMaxAttemptsToSend = uint64(15)
-	// defaultMaxEventsPerBatch specifies maximum events per one batchExecute tx
-	defaultMaxEventsPerBatch = uint64(10)
-)
-
 var (
 	errFailedToExecuteStateSync     = errors.New("failed to execute state sync")
 	errUnknownStateSyncRelayerEvent = errors.New("unknown event from state receiver contract")
@@ -53,9 +43,8 @@ var _ StateSyncRelayer = (*dummyStateSyncRelayer)(nil)
 type dummyStateSyncRelayer struct{}
 
 func (d *dummyStateSyncRelayer) PostBlock(req *PostBlockRequest) error { return nil }
-
-func (d *dummyStateSyncRelayer) Init() error { return nil }
-func (d *dummyStateSyncRelayer) Close()      {}
+func (d *dummyStateSyncRelayer) Init() error                           { return nil }
+func (d *dummyStateSyncRelayer) Close()                                {}
 
 // EventSubscriber implementation
 func (d *dummyStateSyncRelayer) GetLogFilters() map[types.Address][]types.Hash {
@@ -67,36 +56,16 @@ func (d *dummyStateSyncRelayer) ProcessLog(header *types.Header, log *ethgo.Log,
 
 var _ StateSyncRelayer = (*stateSyncRelayerImpl)(nil)
 
-// StateSyncRelayerEventData keeps information about an event
-type StateSyncRelayerEventData struct {
-	EventID     uint64 `json:"eventID"`
-	CountTries  uint64 `json:"countTries"`
-	BlockNumber uint64 `json:"blockNumber"` // block when state sync is sent
-	SentStatus  bool   `json:"sentStatus"`
-}
-
-func (ed StateSyncRelayerEventData) String() string {
-	return fmt.Sprintf("%d", ed.EventID)
-}
-
-type stateSyncRelayerConfig struct {
-	maxBlocksToWaitForResend uint64
-	maxAttemptsToSend        uint64
-	maxEventsPerBatch        uint64
-}
-
 type stateSyncRelayerImpl struct {
+	relayerEventsProcessor
+
 	txRelayer      txrelayer.TxRelayer
 	key            ethgo.Key
 	proofRetriever StateSyncProofRetriever
-	state          *StateSyncStore
 	logger         hclog.Logger
-	blockchain     blockchainBackend
 
 	notifyCh chan struct{}
 	closeCh  chan struct{}
-
-	config *stateSyncRelayerConfig
 }
 
 func newStateSyncRelayer(
@@ -106,28 +75,37 @@ func newStateSyncRelayer(
 	store StateSyncProofRetriever,
 	blockchain blockchainBackend,
 	key ethgo.Key,
-	config *stateSyncRelayerConfig,
+	config *relayerConfig,
 	logger hclog.Logger,
 ) *stateSyncRelayerImpl {
 	if config == nil {
-		config = &stateSyncRelayerConfig{
+		config = &relayerConfig{
 			maxBlocksToWaitForResend: defaultMaxBlocksToWaitForResend,
 			maxAttemptsToSend:        defaultMaxAttemptsToSend,
 			maxEventsPerBatch:        defaultMaxEventsPerBatch,
 		}
 	}
 
-	return &stateSyncRelayerImpl{
+	relayer := &stateSyncRelayerImpl{
 		txRelayer:      txRelayer,
 		key:            key,
 		proofRetriever: store,
-		state:          state,
 		closeCh:        make(chan struct{}),
 		notifyCh:       make(chan struct{}, 1),
-		blockchain:     blockchain,
-		config:         config,
 		logger:         logger,
 	}
+
+	relayerEventsProcessor := relayerEventsProcessor{
+		state:      state,
+		logger:     logger,
+		config:     config,
+		blockchain: blockchain,
+		sendTx:     relayer.sendTx,
+	}
+
+	relayer.relayerEventsProcessor = relayerEventsProcessor
+
+	return relayer
 }
 
 func (ssr *stateSyncRelayerImpl) Init() error {
@@ -159,64 +137,11 @@ func (ssr *stateSyncRelayerImpl) PostBlock(req *PostBlockRequest) error {
 	return nil
 }
 
-func (ssr *stateSyncRelayerImpl) processEvents() {
-	// we need twice as batch size because events from first batch are possible already sent maxAttemptsToSend times
-	events, err := ssr.state.getAllAvailableEvents(int(ssr.config.maxEventsPerBatch) * 2)
-	if err != nil {
-		ssr.logger.Error("retrieving events failed", "err", err)
-
-		return
-	}
-
-	removedEventIDs := []uint64{}
-	sendingEvents := []*StateSyncRelayerEventData{}
-	currentBlockNumber := ssr.blockchain.CurrentHeader().Number
-
-	// check already processed events
-	for _, event := range events {
-		// quit if we are still waiting for some old event confirmation (there is no parallelization right now!)
-		if event.SentStatus && event.BlockNumber+ssr.config.maxBlocksToWaitForResend > currentBlockNumber {
-			return
-		}
-
-		// remove event if it is processed too many times
-		if event.CountTries+1 > ssr.config.maxAttemptsToSend {
-			removedEventIDs = append(removedEventIDs, event.EventID)
-		} else {
-			event.CountTries++
-			event.BlockNumber = currentBlockNumber
-			event.SentStatus = true
-
-			sendingEvents = append(sendingEvents, event)
-			if len(sendingEvents) == int(ssr.config.maxEventsPerBatch) {
-				break
-			}
-		}
-	}
-
-	// update state only if needed
-	if len(sendingEvents)+len(removedEventIDs) > 0 {
-		ssr.logger.Info("sending events", "events", sendingEvents, "removed", removedEventIDs)
-
-		if err := ssr.state.updateStateSyncRelayerEvents(sendingEvents, removedEventIDs, nil); err != nil {
-			ssr.logger.Error("updating events failed",
-				"events", sendingEvents, "removed", removedEventIDs, "err", err)
-
-			return
-		}
-	}
-
-	// send tx only if needed
-	if len(sendingEvents) > 0 {
-		if err := ssr.sendTx(sendingEvents); err != nil {
-			ssr.logger.Error("failed to send tx", "block", currentBlockNumber, "events", sendingEvents, "err", err)
-		} else {
-			ssr.logger.Info("tx has been successfully sent", "block", currentBlockNumber, "events", sendingEvents)
-		}
-	}
+func (ssr stateSyncRelayerImpl) ProcessEvents() {
+	ssr.relayerEventsProcessor.processEvents()
 }
 
-func (ssr *stateSyncRelayerImpl) sendTx(events []*StateSyncRelayerEventData) error {
+func (ssr stateSyncRelayerImpl) sendTx(events []*RelayerEventData) error {
 	proofs := make([][]types.Hash, len(events))
 	objs := make([]*contractsapi.StateSync, len(events))
 
@@ -268,15 +193,10 @@ func (ssr *stateSyncRelayerImpl) sendTx(events []*StateSyncRelayerEventData) err
 // and the value is a slice of signatures of events we want to get.
 // This function is the implementation of EventSubscriber interface
 func (ssr *stateSyncRelayerImpl) GetLogFilters() map[types.Address][]types.Hash {
-	var (
-		stateSyncResultEvent contractsapi.StateSyncResultEvent
-		newCommitmentEvent   contractsapi.NewCommitmentEvent
-	)
-
 	return map[types.Address][]types.Hash{
 		contracts.StateReceiverContract: {
-			types.Hash(stateSyncResultEvent.Sig()),
-			types.Hash(newCommitmentEvent.Sig()),
+			types.Hash(new(contractsapi.StateSyncResultEvent).Sig()),
+			types.Hash(new(contractsapi.NewCommitmentEvent).Sig()),
 		},
 	}
 }
@@ -297,15 +217,19 @@ func (ssr *stateSyncRelayerImpl) ProcessLog(header *types.Header, log *ethgo.Log
 		}
 
 		firstID, lastID := commitEvent.StartID.Uint64(), commitEvent.EndID.Uint64()
-		newEvents := make([]*StateSyncRelayerEventData, lastID-firstID+1)
+		newEvents := make([]*RelayerEventData, lastID-firstID+1)
 
 		for eventID := firstID; eventID <= lastID; eventID++ {
-			newEvents[eventID-firstID] = &StateSyncRelayerEventData{EventID: eventID}
+			newEvents[eventID-firstID] = &RelayerEventData{EventID: eventID}
 		}
 
-		ssr.logger.Info("new events has been arrived", "block", header.Number, "events", newEvents)
+		ssr.logger.Debug("new commitment event has arrived",
+			"block", header.Number,
+			"commitmentStartID", commitEvent.StartID,
+			"commitmentEndID", commitEvent.EndID,
+			"events", newEvents)
 
-		return ssr.state.updateStateSyncRelayerEvents(newEvents, nil, dbTx)
+		return ssr.state.UpdateRelayerEvents(newEvents, nil, dbTx)
 
 	case stateSyncResultEventSignature:
 		_, err := stateSyncResultEvent.ParseLog(log)
@@ -316,13 +240,13 @@ func (ssr *stateSyncRelayerImpl) ProcessLog(header *types.Header, log *ethgo.Log
 		eventID := stateSyncResultEvent.Counter.Uint64()
 
 		if stateSyncResultEvent.Status {
-			ssr.logger.Info("event has been processed", "block", header.Number, "event", eventID)
+			ssr.logger.Debug("state sync result event has been processed", "block", header.Number, "stateSyncID", eventID)
 
-			return ssr.state.updateStateSyncRelayerEvents(nil, []uint64{eventID}, dbTx)
+			return ssr.state.UpdateRelayerEvents(nil, []uint64{eventID}, dbTx)
 		}
 
-		ssr.logger.Info("event has been failed to process", "block", header.Number,
-			"event", eventID, "reason", string(stateSyncResultEvent.Message))
+		ssr.logger.Debug("state sync result event failed to process", "block", header.Number,
+			"stateSyncID", eventID, "reason", string(stateSyncResultEvent.Message))
 
 		return nil
 

--- a/consensus/polybft/state_sync_relayer.go
+++ b/consensus/polybft/state_sync_relayer.go
@@ -137,10 +137,6 @@ func (ssr *stateSyncRelayerImpl) PostBlock(req *PostBlockRequest) error {
 	return nil
 }
 
-func (ssr stateSyncRelayerImpl) ProcessEvents() {
-	ssr.relayerEventsProcessor.processEvents()
-}
-
 func (ssr stateSyncRelayerImpl) sendTx(events []*RelayerEventData) error {
 	proofs := make([][]types.Hash, len(events))
 	objs := make([]*contractsapi.StateSync, len(events))

--- a/consensus/polybft/state_sync_relayer.go
+++ b/consensus/polybft/state_sync_relayer.go
@@ -70,7 +70,6 @@ type stateSyncRelayerImpl struct {
 
 func newStateSyncRelayer(
 	txRelayer txrelayer.TxRelayer,
-	stateReceiverAddr types.Address,
 	state *StateSyncStore,
 	store StateSyncProofRetriever,
 	blockchain blockchainBackend,
@@ -78,14 +77,6 @@ func newStateSyncRelayer(
 	config *relayerConfig,
 	logger hclog.Logger,
 ) *stateSyncRelayerImpl {
-	if config == nil {
-		config = &relayerConfig{
-			maxBlocksToWaitForResend: defaultMaxBlocksToWaitForResend,
-			maxAttemptsToSend:        defaultMaxAttemptsToSend,
-			maxEventsPerBatch:        defaultMaxEventsPerBatch,
-		}
-	}
-
 	relayer := &stateSyncRelayerImpl{
 		txRelayer:      txRelayer,
 		key:            key,
@@ -172,7 +163,7 @@ func (ssr stateSyncRelayerImpl) sendTx(events []*RelayerEventMetaData) error {
 	// send batchExecute state sync
 	_, err = ssr.txRelayer.SendTransaction(&ethgo.Transaction{
 		From:  ssr.key.Address(),
-		To:    (*ethgo.Address)(&contracts.StateReceiverContract),
+		To:    (*ethgo.Address)(&ssr.config.eventExecutionAddr),
 		Gas:   types.StateTransactionGasLimit,
 		Input: input,
 	}, ssr.key)

--- a/consensus/polybft/state_sync_relayer_test.go
+++ b/consensus/polybft/state_sync_relayer_test.go
@@ -55,7 +55,7 @@ func TestStateSyncRelayer_FullWorkflow(t *testing.T) {
 	dummyTxRelayer := newDummyStakeTxRelayer(t, nil)
 	state := newTestState(t)
 
-	stateSyncRelayer := NewStateSyncRelayer(
+	stateSyncRelayer := newStateSyncRelayer(
 		dummyTxRelayer,
 		stateSyncAddr,
 		state.StateSyncStore,

--- a/consensus/polybft/state_sync_relayer_test.go
+++ b/consensus/polybft/state_sync_relayer_test.go
@@ -33,7 +33,7 @@ func TestStateSyncRelayer_FullWorkflow(t *testing.T) {
 	}
 
 	headers := []*types.Header{
-		{Number: 2}, {Number: 3}, {Number: 4}, {Number: 5}, {Number: 5},
+		{Number: 2}, {Number: 3}, {Number: 4}, {Number: 5},
 	}
 
 	proofMock := &mockStateSyncProofRetriever{
@@ -144,9 +144,9 @@ func TestStateSyncRelayer_FullWorkflow(t *testing.T) {
 	require.True(t, events[0].SentStatus && events[1].SentStatus && events[2].SentStatus)
 
 	// post 5th block
-	require.NoError(t, stateSyncRelayer.ProcessLog(headers[4], convertLog(resultLogs[2]), nil))
-	require.NoError(t, stateSyncRelayer.ProcessLog(headers[4], convertLog(resultLogs[3]), nil))
-	require.NoError(t, stateSyncRelayer.ProcessLog(headers[4], convertLog(resultLogs[4]), nil))
+	require.NoError(t, stateSyncRelayer.ProcessLog(headers[3], convertLog(resultLogs[2]), nil))
+	require.NoError(t, stateSyncRelayer.ProcessLog(headers[3], convertLog(resultLogs[3]), nil))
+	require.NoError(t, stateSyncRelayer.ProcessLog(headers[3], convertLog(resultLogs[4]), nil))
 	require.NoError(t, stateSyncRelayer.PostBlock(&PostBlockRequest{}))
 
 	time.Sleep(time.Second * 2) // wait for some time

--- a/consensus/polybft/state_sync_relayer_test.go
+++ b/consensus/polybft/state_sync_relayer_test.go
@@ -62,7 +62,7 @@ func TestStateSyncRelayer_FullWorkflow(t *testing.T) {
 		proofMock,
 		blockhainMock,
 		testKey,
-		&stateSyncRelayerConfig{
+		&relayerConfig{
 			maxAttemptsToSend:        6,
 			maxBlocksToWaitForResend: 1,
 			maxEventsPerBatch:        1,
@@ -91,7 +91,7 @@ func TestStateSyncRelayer_FullWorkflow(t *testing.T) {
 
 	time.Sleep(time.Second * 2) // wait for some time
 
-	events, err := state.StateSyncStore.getAllAvailableEvents(0)
+	events, err := state.StateSyncStore.GetAllAvailableRelayerEvents(0)
 
 	require.NoError(t, err)
 	require.Len(t, events, 3)
@@ -107,7 +107,7 @@ func TestStateSyncRelayer_FullWorkflow(t *testing.T) {
 
 	time.Sleep(time.Second * 2) // wait for some time
 
-	events, err = state.StateSyncStore.getAllAvailableEvents(0)
+	events, err = state.StateSyncStore.GetAllAvailableRelayerEvents(0)
 
 	require.NoError(t, err)
 	require.Len(t, events, 4)
@@ -122,7 +122,7 @@ func TestStateSyncRelayer_FullWorkflow(t *testing.T) {
 
 	time.Sleep(time.Second * 2) // wait for some time
 
-	events, err = state.StateSyncStore.getAllAvailableEvents(0)
+	events, err = state.StateSyncStore.GetAllAvailableRelayerEvents(0)
 
 	require.NoError(t, err)
 	require.Len(t, events, 3)
@@ -137,7 +137,7 @@ func TestStateSyncRelayer_FullWorkflow(t *testing.T) {
 
 	time.Sleep(time.Second * 2) // wait for some time
 
-	events, err = state.StateSyncStore.getAllAvailableEvents(0)
+	events, err = state.StateSyncStore.GetAllAvailableRelayerEvents(0)
 
 	require.NoError(t, err)
 	require.Len(t, events, 3)
@@ -151,7 +151,7 @@ func TestStateSyncRelayer_FullWorkflow(t *testing.T) {
 
 	time.Sleep(time.Second * 2) // wait for some time
 
-	events, err = state.StateSyncStore.getAllAvailableEvents(0)
+	events, err = state.StateSyncStore.GetAllAvailableRelayerEvents(0)
 
 	require.NoError(t, err)
 	require.Len(t, events, 0)

--- a/consensus/polybft/state_sync_relayer_test.go
+++ b/consensus/polybft/state_sync_relayer_test.go
@@ -57,7 +57,6 @@ func TestStateSyncRelayer_FullWorkflow(t *testing.T) {
 
 	stateSyncRelayer := newStateSyncRelayer(
 		dummyTxRelayer,
-		stateSyncAddr,
 		state.StateSyncStore,
 		proofMock,
 		blockhainMock,
@@ -66,6 +65,7 @@ func TestStateSyncRelayer_FullWorkflow(t *testing.T) {
 			maxAttemptsToSend:        6,
 			maxBlocksToWaitForResend: 1,
 			maxEventsPerBatch:        1,
+			eventExecutionAddr:       stateSyncAddr,
 		},
 		hclog.Default(),
 	)

--- a/e2e-polybft/e2e/helpers_test.go
+++ b/e2e-polybft/e2e/helpers_test.go
@@ -345,3 +345,21 @@ func getLastExitEventID(t *testing.T, relayer txrelayer.TxRelayer) uint64 {
 
 	return exitEventID
 }
+
+func isExitEventProcessed(t *testing.T, exitHelperAddr types.Address,
+	relayer txrelayer.TxRelayer, exitEventID uint64) bool {
+	t.Helper()
+
+	processedExitsFn := contractsapi.ExitHelper.Abi.Methods["processedExits"]
+
+	input, err := processedExitsFn.Encode([]interface{}{exitEventID})
+	require.NoError(t, err)
+
+	isProcessedRaw, err := relayer.Call(ethgo.ZeroAddress, ethgo.Address(exitHelperAddr), input)
+	require.NoError(t, err)
+
+	isProcessedAsNumber, err := common.ParseUint64orHex(&isProcessedRaw)
+	require.NoError(t, err)
+
+	return isProcessedAsNumber == 1
+}

--- a/e2e-polybft/framework/test-bridge.go
+++ b/e2e-polybft/framework/test-bridge.go
@@ -291,7 +291,6 @@ func (t *TestBridge) SendExitTransaction(exitHelper types.Address, exitID uint64
 		"--exit-id", strconv.FormatUint(exitID, 10),
 		"--root-json-rpc", t.JSONRPCAddr(),
 		"--child-json-rpc", childJSONRPCAddr,
-		"--test",
 	)
 }
 


### PR DESCRIPTION
# Description

This PR adds an `exit relayer` that will automatically execute exit events for users once their checkpoint gets submitted on `rootchain`.

It follows the same logic as `state sync relayer`. Once a `CheckpointSubmitted` event gets emitted by the `CheckpointManager` contract on `root`, it will catch the event, and get the exit events ready to execute when a next block on `blade` gets finalized.

Exit events that can be executed are sent in batches, which will lower the gas cost to the relayer node.
It also implements the retry mechanism, if for some reason, some exit events are not executed correctly on `ExitHelper` contract on `root`.

### Changes in code

- A new interface is added, called `BridgeManager`, which is implemented by the `bridgeManager` struct. It handles everything in regards to bridge on `blade` client. `bridgeManager` has references to `checkpointManager`, `stateSyncManager`, `stateSyncRelayer` and `exitRelayer`, which are now removed from the `consensusRuntime`. Runtime now only holds a reference to `bridgeManager`, and has no knowledge about other structs required to manage bridge.
- A new relayer is added, called `exitRelayer`, which will automatically execute exit events once their checkpoints get submitted to `rootchain`. Basically, it will listen to `CheckpointSubmitted` event, emitted by `CheckpointManager` contract on `root` once a checkpoint is successfully submitted, and will get its exit events ready for execution. On finalization of each block on `blade` it will try to execute any exit events it can in a batch (an array of exit events will be sent in one transaction to be executed on `ExitHelper` contract on `root`). It also has a retry mechanism, where if some of the exit events fail to be executed, it will retry after a number of blocks on `blade` get finalized. If an exit event fails a number of times, it will not be resent for execution.
- Since `exitRelayer` has almost the same logic as `stateSyncRelayer`, their mutual code is extracted to a struct called `relyerEventProcessor`, which is used by both relayers.
- Written new UTs.
- Modified `bridge` `e2e` tests.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually