### PR TITLE
GeneralStateTests/stMemoryTest/bufferSrcOffset.json test fix

### DIFF
--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -819,8 +819,7 @@ func opReturnDataCopy(c *state) {
 	}
 
 	// Check if sum of dataOffset and length overflows uint64
-	var end = new(big.Int)
-	end.Add(dataOffset, length)
+	end := new(big.Int).Add(dataOffset, length)
 	if !end.IsUint64() {
 		c.exit(errReturnDataOutOfBounds)
 		return

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -1726,7 +1726,7 @@ func TestCreate(t *testing.T) {
 func Test_opReturnDataCopy(t *testing.T) {
 	t.Parallel()
 
-	// Positive number that does not fit in uint64
+	// Positive number that does not fit in uint64 (math.MaxUint64 + 1)
 	largeNumber := "18446744073709551616"
 	bigIntValue := new(big.Int)
 	bigIntValue.SetString(largeNumber, 10)

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -1726,6 +1726,16 @@ func TestCreate(t *testing.T) {
 func Test_opReturnDataCopy(t *testing.T) {
 	t.Parallel()
 
+	// Positive number that does not fit in uint64
+	largeNumber := "18446744073709551616"
+	bigIntValue := new(big.Int)
+	bigIntValue.SetString(largeNumber, 10)
+
+	// Positive number that does fit in uint64 but multiplied by two does not
+	largeNumber2 := "18446744073709551615"
+	bigIntValue2 := new(big.Int)
+	bigIntValue2.SetString(largeNumber2, 10)
+
 	tests := []struct {
 		name        string
 		config      *chain.ForksInTime
@@ -1755,7 +1765,8 @@ func Test_opReturnDataCopy(t *testing.T) {
 					big.NewInt(0),  // dataOffset
 					big.NewInt(-1), // memOffset
 				},
-				sp: 3,
+				sp:         3,
+				returnData: []byte{0xff},
 			},
 			resultState: &state{
 				config: &allEnabledForks,
@@ -1764,9 +1775,10 @@ func Test_opReturnDataCopy(t *testing.T) {
 					big.NewInt(0),
 					big.NewInt(-1),
 				},
-				sp:   0,
-				stop: true,
-				err:  errReturnDataOutOfBounds,
+				sp:         0,
+				returnData: []byte{0xff},
+				stop:       true,
+				err:        errReturnDataOutOfBounds,
 			},
 		},
 		{
@@ -1800,21 +1812,23 @@ func Test_opReturnDataCopy(t *testing.T) {
 			initState: &state{
 				stack: []*big.Int{
 					big.NewInt(-1), // length
-					big.NewInt(0),  // dataOffset
+					big.NewInt(2),  // dataOffset
 					big.NewInt(0),  // memOffset
 				},
-				sp: 3,
+				sp:         3,
+				returnData: []byte{0xff},
 			},
 			resultState: &state{
 				config: &allEnabledForks,
 				stack: []*big.Int{
 					big.NewInt(-1),
-					big.NewInt(0),
+					big.NewInt(2),
 					big.NewInt(0),
 				},
-				sp:   0,
-				stop: true,
-				err:  errReturnDataOutOfBounds,
+				sp:         0,
+				returnData: []byte{0xff},
+				stop:       true,
+				err:        errReturnDataOutOfBounds,
 			},
 		},
 		{
@@ -1849,41 +1863,6 @@ func Test_opReturnDataCopy(t *testing.T) {
 			},
 		},
 		{
-			name:   "should expand memory and copy data returnData",
-			config: &allEnabledForks,
-			initState: &state{
-				stack: []*big.Int{
-					big.NewInt(5), // length
-					big.NewInt(1), // dataOffset
-					big.NewInt(2), // memOffset
-				},
-				sp:         3,
-				returnData: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
-				memory:     []byte{0x11, 0x22},
-				gas:        20,
-			},
-			resultState: &state{
-				config: &allEnabledForks,
-				stack: []*big.Int{
-					big.NewInt(6), // updated for end index
-					big.NewInt(1),
-					big.NewInt(2),
-				},
-				sp:         0,
-				returnData: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
-				memory: append(
-					// 1 word (32 bytes)
-					[]byte{0x11, 0x22, 0x02, 0x03, 0x04, 0x05, 0x06},
-					make([]byte, 25)...,
-				),
-				gas:                14,
-				lastGasCost:        3,
-				currentConsumedGas: 6,
-				stop:               false,
-				err:                nil,
-			},
-		},
-		{
 			// this test case also verifies that code does not panic when the length is 0 and memOffset > len(memory)
 			name:   "should not copy data if length is zero",
 			config: &allEnabledForks,
@@ -1909,6 +1888,109 @@ func Test_opReturnDataCopy(t *testing.T) {
 				memory:     []byte{0x02},
 				stop:       false,
 				err:        nil,
+			},
+		},
+		{
+			name:   "should return error if data offset overflows uint64",
+			config: &allEnabledForks,
+			initState: &state{
+				stack: []*big.Int{
+					big.NewInt(1),  // length
+					bigIntValue,    // dataOffset
+					big.NewInt(-1), // memOffset
+				},
+				sp: 3,
+			},
+			resultState: &state{
+				config: &allEnabledForks,
+				stack: []*big.Int{
+					big.NewInt(1),
+					bigIntValue,
+					big.NewInt(-1),
+				},
+				sp:   0,
+				stop: true,
+				err:  errReturnDataOutOfBounds,
+			},
+		},
+		{
+			name:   "should return error if sum of data offset and lenght overflows uint64",
+			config: &allEnabledForks,
+			initState: &state{
+				stack: []*big.Int{
+					bigIntValue2,   // length
+					bigIntValue2,   // dataOffset
+					big.NewInt(-1), // memOffset
+				},
+				sp: 3,
+			},
+			resultState: &state{
+				config: &allEnabledForks,
+				stack: []*big.Int{
+					bigIntValue2,
+					bigIntValue2,
+					big.NewInt(-1),
+				},
+				sp:   0,
+				stop: true,
+				err:  errReturnDataOutOfBounds,
+			},
+		},
+		{
+			name:   "should return error if the length of return data does not have enough space to receive offset + length bytes",
+			config: &allEnabledForks,
+			initState: &state{
+				stack: []*big.Int{
+					big.NewInt(2), // length
+					big.NewInt(0), // dataOffset
+					big.NewInt(0), // memOffset
+				},
+				sp:         3,
+				returnData: []byte{0xff},
+				memory:     []byte{0x0},
+			},
+			resultState: &state{
+				config: &allEnabledForks,
+				stack: []*big.Int{
+					big.NewInt(2),
+					big.NewInt(0),
+					big.NewInt(0),
+				},
+				sp:         0,
+				returnData: []byte{0xff},
+				memory:     []byte{0x0},
+				stop:       true,
+				err:        errReturnDataOutOfBounds,
+			},
+		},
+		{
+			name:   "should return error if there is no gas",
+			config: &allEnabledForks,
+			initState: &state{
+				stack: []*big.Int{
+					big.NewInt(1), // length
+					big.NewInt(0), // dataOffset
+					big.NewInt(0), // memOffset
+				},
+				sp:         3,
+				returnData: []byte{0xff},
+				memory:     []byte{0x0},
+				gas:        0,
+			},
+			resultState: &state{
+				config: &allEnabledForks,
+				stack: []*big.Int{
+					big.NewInt(1),
+					big.NewInt(0),
+					big.NewInt(0),
+				},
+				sp:                 0,
+				returnData:         []byte{0xff},
+				memory:             []byte{0x0},
+				gas:                0,
+				currentConsumedGas: 3,
+				stop:               true,
+				err:                errOutOfGas,
 			},
 		},
 	}

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -1914,7 +1914,7 @@ func Test_opReturnDataCopy(t *testing.T) {
 			},
 		},
 		{
-			name:   "should return error if sum of data offset and lenght overflows uint64",
+			name:   "should return error if sum of data offset and length overflows uint64",
 			config: &allEnabledForks,
 			initState: &state{
 				stack: []*big.Int{


### PR DESCRIPTION
ReturnDataCopy did not treat as error when return address did not have enough space to receive the data, eventually not initiating rollback in a test.

# Description

Covering error handling when there is not enough space to receive the data with minor ReturnDataCopy refactoring and writing unit tests.

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [X] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually
