### PR TITLE
Fixing stRandom/randomStatetest649.json test

### DIFF
--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -855,6 +855,10 @@ func opCodeCopy(c *state) {
 	dataOffset := c.pop()
 	length := c.pop()
 
+	if length.Uint64() <= 0 {
+		return
+	}
+
 	if !c.allocateMemory(memOffset, length) {
 		return
 	}

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -1129,8 +1129,9 @@ func TestCallDataCopy(t *testing.T) {
 
 func TestCodeCopyLenZero(t *testing.T) {
 	s, cancelFn := getState(&chain.ForksInTime{})
-	var expectedGas = s.gas
 	defer cancelFn()
+
+	var expectedGas = s.gas
 
 	s.push(big.NewInt(0)) //length
 	s.push(big.NewInt(0)) //dataOffset

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -1141,7 +1141,7 @@ func TestCodeCopyLenZero(t *testing.T) {
 
 	// We check that no gas was spent and there was no error
 	assert.Equal(t, expectedGas, s.gas)
-	assert.Equal(t, s.err, nil)
+	assert.NoError(t, s.err)
 }
 
 func TestCodeCopy(t *testing.T) {

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -1127,6 +1127,22 @@ func TestCallDataCopy(t *testing.T) {
 	assert.Equal(t, big.NewInt(1).FillBytes(make([]byte, 32)), s.memory)
 }
 
+func TestCodeCopyLenZero(t *testing.T) {
+	s, cancelFn := getState(&chain.ForksInTime{})
+	var expectedGas = s.gas
+	defer cancelFn()
+
+	s.push(big.NewInt(0)) //length
+	s.push(big.NewInt(0)) //dataOffset
+	s.push(big.NewInt(0)) //memOffset
+
+	opCodeCopy(s)
+
+	// We check that no gas was spent and there was no error
+	assert.Equal(t, expectedGas, s.gas)
+	assert.Equal(t, s.err, nil)
+}
+
 func TestCodeCopy(t *testing.T) {
 	s, cancelFn := getState(&chain.ForksInTime{})
 	defer cancelFn()


### PR DESCRIPTION
opCodeCopy instruction tried to allocate memory even when length was zero. Since this specific test used invalid memory offset, allocation failed  causing rollback and eventually test failure.

# Description

Please provide a detailed description of what was done in this PR

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [X] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually
