### PR TITLE
Fix receipt RLP marshaling logic

### DIFF
--- a/types/rlp_marshal.go
+++ b/types/rlp_marshal.go
@@ -130,7 +130,8 @@ func (r *Receipt) MarshalRLPTo(dst []byte) []byte {
 func (r *Receipt) MarshalRLPWith(a *fastrlp.Arena) *fastrlp.Value {
 	vv := a.NewArray()
 
-	if r.Status != nil {
+	if r.Status != nil &&
+		(len(r.Root) == 0 || r.Root == ZeroHash) {
 		vv.Set(a.NewUint(uint64(*r.Status)))
 	} else {
 		vv.Set(a.NewCopyBytes(r.Root[:]))

--- a/types/rlp_unmarshal.go
+++ b/types/rlp_unmarshal.go
@@ -286,7 +286,7 @@ func (r *Receipt) unmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) error {
 	}
 
 	switch size := len(buf); size {
-	case 32:
+	case HashLength:
 		// root
 		copy(r.Root[:], buf[:])
 	case 1:


### PR DESCRIPTION
# Description

Receipt status should be marshaled only if `Root` is not present, otherwise, receipt root should be marshaled.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
