### PR TITLE
Use `btcec v2` lib for `ECDSA` keys manipulation

### DIFF
--- a/consensus/polybft/block_builder_test.go
+++ b/consensus/polybft/block_builder_test.go
@@ -1,12 +1,12 @@
 package polybft
 
 import (
+	"crypto/ecdsa"
 	"math/big"
 	"testing"
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/chain"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/state"
@@ -29,10 +29,21 @@ func TestBlockBuilder_BuildBlockTxOneFailedTxAndOneTakesTooMuchGas(t *testing.T)
 		chainID       = 100
 	)
 
-	accounts := [6]*wallet.Account{}
+	type account struct {
+		privKey *ecdsa.PrivateKey
+		address types.Address
+	}
+
+	accounts := [6]*account{}
 
 	for i := range accounts {
-		accounts[i] = generateTestAccount(t)
+		ecdsaKey, err := crypto.GenerateECDSAKey()
+		require.NoError(t, err)
+
+		accounts[i] = &account{
+			privKey: ecdsaKey,
+			address: crypto.PubKeyToAddress(&ecdsaKey.PublicKey),
+		}
 	}
 
 	forks := &chain.Forks{}
@@ -60,9 +71,7 @@ func TestBlockBuilder_BuildBlockTxOneFailedTxAndOneTakesTooMuchGas(t *testing.T)
 	for i, acc := range accounts {
 		// the third tx will fail because of insufficient balance
 		if i != 2 {
-			balanceMap[types.Address(acc.Ecdsa.Address())] = &chain.GenesisAccount{
-				Balance: ethgo.Ether(1),
-			}
+			balanceMap[acc.address] = &chain.GenesisAccount{Balance: ethgo.Ether(1)}
 		}
 	}
 
@@ -72,17 +81,12 @@ func TestBlockBuilder_BuildBlockTxOneFailedTxAndOneTakesTooMuchGas(t *testing.T)
 	require.NotEqual(t, types.ZeroHash, hash)
 
 	// Gas Limit is important to be high for tx pool
-	parentHeader := &types.Header{StateRoot: hash, GasLimit: 1_000_000_000_000_000}
+	parentHeader := &types.Header{StateRoot: hash, GasLimit: 1e15}
 
 	txPool := &txPoolMock{}
 	txPool.On("Prepare").Once()
 
 	for i, acc := range accounts {
-		receiver := types.Address(acc.Ecdsa.Address())
-		privateKey, err := acc.GetEcdsaPrivateKey()
-
-		require.NoError(t, err)
-
 		gas := uint64(gasLimit)
 		// fifth tx will cause filling to stop
 		if i == 4 {
@@ -94,10 +98,10 @@ func TestBlockBuilder_BuildBlockTxOneFailedTxAndOneTakesTooMuchGas(t *testing.T)
 			GasPrice: big.NewInt(gasPrice),
 			Gas:      gas,
 			Nonce:    0,
-			To:       &receiver,
+			To:       &acc.address,
 		})
 
-		tx, err = signer.SignTx(tx, privateKey)
+		tx, err = signer.SignTx(tx, acc.privKey)
 		require.NoError(t, err)
 
 		// all tx until the fifth will be retrieved from the pool
@@ -147,15 +151,17 @@ func TestBlockBuilder_BuildBlockTxOneFailedTxAndOneTakesTooMuchGas(t *testing.T)
 	require.Len(t, bb.txns, 3, "Should have 3 transactions but has %d", len(bb.txns))
 	require.Len(t, bb.Receipts(), 3)
 
+	logsBloom := fb.Block.Header.LogsBloom
+
 	// assert logs bloom
 	for _, r := range bb.Receipts() {
 		for _, l := range r.Logs {
-			assert.True(t, fb.Block.Header.LogsBloom.IsLogInBloom(l))
+			assert.True(t, logsBloom.IsLogInBloom(l))
 		}
 	}
 
-	assert.False(t, fb.Block.Header.LogsBloom.IsLogInBloom(
+	assert.False(t, logsBloom.IsLogInBloom(
 		&types.Log{Address: types.StringToAddress("999911117777")}))
-	assert.False(t, fb.Block.Header.LogsBloom.IsLogInBloom(
+	assert.False(t, logsBloom.IsLogInBloom(
 		&types.Log{Address: types.StringToAddress("111177779999")}))
 }

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -197,7 +197,6 @@ func (c *consensusRuntime) initStakeManager(logger hcf.Logger, dbTx *bolt.Tx) er
 	c.stakeManager, err = newStakeManager(
 		logger.Named("stake-manager"),
 		c.state,
-		wallet.NewEcdsaSigner(c.config.Key),
 		contracts.StakeManagerContract,
 		c.config.blockchain,
 		c.config.polybftBackend,

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -79,7 +79,6 @@ type stakeManager struct {
 func newStakeManager(
 	logger hclog.Logger,
 	state *State,
-	key ethgo.Key,
 	stakeManagerAddr types.Address,
 	blockchain blockchainBackend,
 	polybftBackend polybftBackend,
@@ -88,7 +87,6 @@ func newStakeManager(
 	sm := &stakeManager{
 		logger:                   logger,
 		state:                    state,
-		key:                      key,
 		stakeManagerContractAddr: stakeManagerAddr,
 		polybftBackend:           polybftBackend,
 		blockchain:               blockchain,

--- a/consensus/polybft/stake_manager_fuzz_test.go
+++ b/consensus/polybft/stake_manager_fuzz_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/mock"
@@ -111,7 +110,6 @@ func FuzzTestStakeManagerPostBlock(f *testing.F) {
 		stakeManager, err := newStakeManager(
 			hclog.NewNullLogger(),
 			state,
-			wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 			types.StringToAddress("0x0002"),
 			bcMock,
 			nil,
@@ -154,7 +152,6 @@ func FuzzTestStakeManagerUpdateValidatorSet(f *testing.F) {
 	stakeManager, err := newStakeManager(
 		hclog.NewNullLogger(),
 		state,
-		wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 		types.StringToAddress("0x0001"),
 		bcMock,
 		nil,

--- a/consensus/polybft/stake_manager_test.go
+++ b/consensus/polybft/stake_manager_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -52,7 +51,6 @@ func TestStakeManager_PostBlock(t *testing.T) {
 		stakeManager, err := newStakeManager(
 			hclog.NewNullLogger(),
 			state,
-			wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 			stakeManagerAddr,
 			bcMock,
 			nil,
@@ -108,7 +106,6 @@ func TestStakeManager_PostBlock(t *testing.T) {
 		stakeManager, err := newStakeManager(
 			hclog.NewNullLogger(),
 			state,
-			wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 			types.StringToAddress("0x0001"),
 			bcMock,
 			nil,
@@ -173,7 +170,6 @@ func TestStakeManager_PostBlock(t *testing.T) {
 		stakeManager, err := newStakeManager(
 			hclog.NewNullLogger(),
 			state,
-			wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 			types.StringToAddress("0x0001"),
 			bcMock,
 			nil,
@@ -231,7 +227,6 @@ func TestStakeManager_UpdateValidatorSet(t *testing.T) {
 	stakeManager, err := newStakeManager(
 		hclog.NewNullLogger(),
 		state,
-		wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 		types.StringToAddress("0x0001"),
 		bcMock,
 		nil,
@@ -420,7 +415,6 @@ func TestStakeManager_UpdateOnInit(t *testing.T) {
 	_, err := newStakeManager(
 		hclog.NewNullLogger(),
 		state,
-		wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 		stakeManagerAddr,
 		nil,
 		polyBackendMock,

--- a/consensus/polybft/wallet/account.go
+++ b/consensus/polybft/wallet/account.go
@@ -5,10 +5,11 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/umbracle/ethgo/wallet"
+
 	"github.com/0xPolygon/polygon-edge/bls"
 	"github.com/0xPolygon/polygon-edge/secrets"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/umbracle/ethgo/wallet"
 )
 
 // Account is an account for key signatures

--- a/consensus/polybft/wallet/key.go
+++ b/consensus/polybft/wallet/key.go
@@ -65,7 +65,7 @@ func (k *Key) SignIBFTMessage(msg *proto.Message) (*proto.Message, error) {
 // RecoverAddressFromSignature calculates keccak256 hash of provided rawContent
 // and recovers signer address from given signature and hash
 func RecoverAddressFromSignature(sig, rawContent []byte) (types.Address, error) {
-	pub, err := crypto.RecoverPubkey(sig, crypto.Keccak256(rawContent))
+	pub, err := crypto.RecoverPubKey(sig, crypto.Keccak256(rawContent))
 	if err != nil {
 		return types.Address{}, fmt.Errorf("cannot recover address from signature: %w", err)
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -10,17 +10,16 @@ import (
 	"hash"
 	"math/big"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	btc_ecdsa "github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/umbracle/fastrlp"
+	"golang.org/x/crypto/sha3"
+
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/helper/keystore"
 	"github.com/0xPolygon/polygon-edge/secrets"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/umbracle/fastrlp"
-	"golang.org/x/crypto/sha3"
 )
-
-// S256 is the secp256k1 elliptic curve
-var S256 = btcec.S256()
 
 var (
 	secp256k1N, _  = new(big.Int).SetString("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141", 16)
@@ -38,6 +37,18 @@ type KeyType string
 const (
 	KeyECDSA KeyType = "ecdsa"
 	KeyBLS   KeyType = "bls"
+)
+
+const (
+	// ECDSASignatureLength indicates the byte length required to carry a signature with recovery id.
+	// (64 bytes ECDSA signature + 1 byte recovery id)
+	ECDSASignatureLength = 64 + 1
+
+	// recoveryID is ECDSA signature recovery id
+	recoveryID = byte(27)
+
+	// recoveryIDOffset points to the byte offset within the signature that contains the recovery id.
+	recoveryIDOffset = 64
 )
 
 // KeccakState wraps sha3.state. In addition to the usual hash methods, it also supports
@@ -99,38 +110,45 @@ func CreateAddress2(addr types.Address, salt [32]byte, inithash []byte) types.Ad
 }
 
 func ParseECDSAPrivateKey(buf []byte) (*ecdsa.PrivateKey, error) {
-	prv, _ := btcec.PrivKeyFromBytes(S256, buf)
+	prv, _ := btcec.PrivKeyFromBytes(buf)
 
 	return prv.ToECDSA(), nil
 }
 
 // MarshalECDSAPrivateKey serializes the private key's D value to a []byte
 func MarshalECDSAPrivateKey(priv *ecdsa.PrivateKey) ([]byte, error) {
-	return (*btcec.PrivateKey)(priv).Serialize(), nil
+	btcPriv, err := convertToBtcPrivKey(priv)
+	if err != nil {
+		return nil, err
+	}
+
+	defer btcPriv.Zero()
+
+	return btcPriv.Serialize(), nil
 }
 
 // GenerateECDSAKey generates a new key based on the secp256k1 elliptic curve.
 func GenerateECDSAKey() (*ecdsa.PrivateKey, error) {
-	return ecdsa.GenerateKey(S256, rand.Reader)
+	return ecdsa.GenerateKey(btcec.S256(), rand.Reader)
 }
 
 // ParsePublicKey parses bytes into a public key on the secp256k1 elliptic curve.
 func ParsePublicKey(buf []byte) (*ecdsa.PublicKey, error) {
-	x, y := elliptic.Unmarshal(S256, buf)
+	x, y := elliptic.Unmarshal(btcec.S256(), buf)
 	if x == nil || y == nil {
 		return nil, fmt.Errorf("cannot unmarshal")
 	}
 
-	return &ecdsa.PublicKey{Curve: S256, X: x, Y: y}, nil
+	return &ecdsa.PublicKey{Curve: btcec.S256(), X: x, Y: y}, nil
 }
 
 // MarshalPublicKey marshals a public key on the secp256k1 elliptic curve.
 func MarshalPublicKey(pub *ecdsa.PublicKey) []byte {
-	return elliptic.Marshal(S256, pub.X, pub.Y)
+	return elliptic.Marshal(btcec.S256(), pub.X, pub.Y)
 }
 
 func Ecrecover(hash, sig []byte) ([]byte, error) {
-	pub, err := RecoverPubkey(sig, hash)
+	pub, err := RecoverPubKey(sig, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -138,28 +156,23 @@ func Ecrecover(hash, sig []byte) ([]byte, error) {
 	return MarshalPublicKey(pub), nil
 }
 
-// RecoverPubkey verifies the compact signature "signature" of "hash" for the
-// secp256k1 curve.
-func RecoverPubkey(signature, hash []byte) (*ecdsa.PublicKey, error) {
+// RecoverPubKey verifies the compact signature "signature" of "hash" for the secp256k1 curve.
+func RecoverPubKey(signature, hash []byte) (*ecdsa.PublicKey, error) {
 	if len(hash) != types.HashLength {
 		return nil, errHashOfInvalidLength
 	}
 
-	size := len(signature)
-	term := byte(27)
-
-	// Make sure the signature is present
-	if signature == nil || size < 1 {
+	signatureSize := len(signature)
+	if signatureSize != ECDSASignatureLength {
 		return nil, errInvalidSignature
 	}
 
-	if signature[size-1] == 1 {
-		term = 28
-	}
+	// Convert to btcec input format with 'recovery id' v at the beginning.
+	btcsig := make([]byte, signatureSize)
+	btcsig[0] = signature[signatureSize-1] + recoveryID
+	copy(btcsig[1:], signature)
 
-	sig := append([]byte{term}, signature[:size-1]...)
-	pub, _, err := btcec.RecoverCompact(S256, sig, hash)
-
+	pub, _, err := btc_ecdsa.RecoverCompact(btcsig, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -167,20 +180,38 @@ func RecoverPubkey(signature, hash []byte) (*ecdsa.PublicKey, error) {
 	return pub.ToECDSA(), nil
 }
 
-// Sign produces a compact signature of the data in hash with the given
+// Sign produces an ECDSA signature of the data in hash with the given
 // private key on the secp256k1 curve.
+
+// The produced signature is in the [R || S || V] format where V is 0 or 1.
 func Sign(priv *ecdsa.PrivateKey, hash []byte) ([]byte, error) {
-	sig, err := btcec.SignCompact(S256, (*btcec.PrivateKey)(priv), hash, false)
+	if len(hash) != types.HashLength {
+		return nil, fmt.Errorf("hash is required to be exactly %d bytes (%d)", types.HashLength, len(hash))
+	}
+
+	if priv.Curve != btcec.S256() {
+		return nil, errors.New("private key curve is not secp256k1")
+	}
+
+	// convert from ecdsa.PrivateKey to btcec.PrivateKey
+	btcPrivKey, err := convertToBtcPrivKey(priv)
 	if err != nil {
 		return nil, err
 	}
 
-	term := byte(0)
-	if sig[0] == 28 {
-		term = 1
+	defer btcPrivKey.Zero()
+
+	sig, err := btc_ecdsa.SignCompact(btcPrivKey, hash, false)
+	if err != nil {
+		return nil, err
 	}
 
-	return append(sig, term)[1:], nil
+	// Convert to Ethereum signature format with 'recovery id' v at the end.
+	v := sig[0] - recoveryID
+	copy(sig, sig[1:])
+	sig[recoveryIDOffset] = v
+
+	return sig, nil
 }
 
 // Keccak256 calculates the Keccak256
@@ -307,4 +338,17 @@ func ReadConsensusKey(manager secrets.SecretsManager) (*ecdsa.PrivateKey, error)
 	}
 
 	return BytesToECDSAPrivateKey(validatorKey)
+}
+
+// convertToBtcPrivKey converts provided ECDSA private key to btc private key format
+// used by btcec library
+func convertToBtcPrivKey(priv *ecdsa.PrivateKey) (*btcec.PrivateKey, error) {
+	var btcPriv btcec.PrivateKey
+
+	overflow := btcPriv.Key.SetByteSlice(priv.D.Bytes())
+	if overflow || btcPriv.Key.IsZero() {
+		return nil, errors.New("invalid private key")
+	}
+
+	return &btcPriv, nil
 }

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -445,14 +445,14 @@ func TestRecoverPublicKey(t *testing.T) {
 	t.Run("Empty hash", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := RecoverPubkey(testSignature, []byte{})
+		_, err := RecoverPubKey(testSignature, []byte{})
 		require.ErrorIs(t, err, errHashOfInvalidLength)
 	})
 
 	t.Run("Hash of non appropriate length", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := RecoverPubkey(testSignature, []byte{0, 1})
+		_, err := RecoverPubKey(testSignature, []byte{0, 1})
 		require.ErrorIs(t, err, errHashOfInvalidLength)
 	})
 
@@ -467,7 +467,7 @@ func TestRecoverPublicKey(t *testing.T) {
 		signature, err := Sign(privateKey, hash.Bytes())
 		require.NoError(t, err)
 
-		publicKey, err := RecoverPubkey(signature, hash.Bytes())
+		publicKey, err := RecoverPubKey(signature, hash.Bytes())
 		require.NoError(t, err)
 
 		require.True(t, privateKey.PublicKey.Equal(publicKey))

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Ethernal-Tech/merkle-tree v0.0.0-20231213143318-4db9da419e04
 	github.com/armon/go-metrics v0.4.1
 	github.com/aws/aws-sdk-go v1.50.8
-	github.com/btcsuite/btcd v0.22.1
+	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/docker/docker v25.0.2+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/envoyproxy/protoc-gen-validate v1.0.4
@@ -82,6 +82,7 @@ require (
 	github.com/andybalholm/brotli v1.0.6 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/btcsuite/btcd v0.22.1 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 // indirect
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBT
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.1 h1:CnwP9LM/M9xuRrGSCGeMVs9iv09uMqwsVX7EeIpgV2c=
 github.com/btcsuite/btcd v0.22.1/go.mod h1:wqgTSL29+50LRkmOVknEdmt8ZojIzhuWvgu/iptuN7Y=
+github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf7DClJ3U=
+github.com/btcsuite/btcd/btcec/v2 v2.3.2/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=

--- a/helper/enode/enode.go
+++ b/helper/enode/enode.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"strconv"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 )
@@ -113,7 +115,7 @@ func NodeIDToPubKey(buf []byte) (*ecdsa.PublicKey, error) {
 		return nil, fmt.Errorf("not enough length: expected %d but found %d", nodeIDBytes, len(buf))
 	}
 
-	p := &ecdsa.PublicKey{Curve: crypto.S256, X: new(big.Int), Y: new(big.Int)}
+	p := &ecdsa.PublicKey{Curve: btcec.S256(), X: new(big.Int), Y: new(big.Int)}
 	half := len(buf) / 2
 	p.X.SetBytes(buf[:half])
 	p.Y.SetBytes(buf[half:])

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -2382,7 +2382,7 @@ func Test_opCall(t *testing.T) {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			state, closeFn := getState(&tt.config)
+			state, closeFn := getState(&test.config)
 			defer closeFn()
 
 			state.gas = test.initState.gas


### PR DESCRIPTION
# Description

This PR removes direct dependency on BTC full node (https://github.com/btcsuite/btcd) implementation and instead uses the `btcec` go module directly (https://github.com/btcsuite/btcd/tree/master/btcec).

TODO:
- [ ] Introduce `crypto.ECDSAKey` to the Blade and use it instead of `*wallet.Key`.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
