### PR TITLE
London test fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ generate-bsd-licenses: check-git
 
 .PHONY: unit-test
 unit-test: check-go
-	go test -race -shuffle=on -coverprofile coverage.out -timeout 20m `go list ./... | grep -v e2e`
+	go test -race -shuffle=on -coverprofile coverage.out -timeout 1h `go list ./... | grep -v e2e`
 
 .PHONY: fuzz-test
 fuzz-test: check-go

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ generate-bsd-licenses: check-git
 
 .PHONY: unit-test
 unit-test: check-go
-	go test -race -shuffle=on -coverprofile coverage.out -timeout 1h `go list ./... | grep -v e2e`
+	go test -race -shuffle=on -coverprofile coverage.out -timeout 20m `go list ./... | grep -v e2e`
 
 .PHONY: fuzz-test
 fuzz-test: check-go

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -12,7 +12,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/state"
-	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/contract"
@@ -219,7 +218,6 @@ func (s *stateProvider) Call(addr ethgo.Address, input []byte, opts *contract.Ca
 		input,
 		big.NewInt(0),
 		10000000,
-		runtime.NewAccessList(),
 	)
 	if result.Failed() {
 		return nil, result.Err

--- a/consensus/polybft/contracts_initializer.go
+++ b/consensus/polybft/contracts_initializer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/state"
-	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/umbracle/ethgo/abi"
 )
@@ -413,7 +412,7 @@ func approveEpochManagerAsSpender(polyBFTConfig PolyBFTConfig, transition *state
 
 // callContract calls given smart contract function, encoded in input parameter
 func callContract(from, to types.Address, input []byte, contractName string, transition *state.Transition) error {
-	result := transition.Call2(from, to, input, big.NewInt(0), contractCallGasLimit, runtime.NewAccessList())
+	result := transition.Call2(from, to, input, big.NewInt(0), contractCallGasLimit)
 	if result.Failed() {
 		if result.Reverted() {
 			if revertReason, err := abi.UnpackRevertError(result.ReturnValue); err == nil {

--- a/consensus/polybft/sc_integration_test.go
+++ b/consensus/polybft/sc_integration_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/state"
-	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -58,7 +57,7 @@ func TestIntegration_PerformExit(t *testing.T) {
 		input, err := abi.GetMethod(function).Encode(args)
 		require.NoError(t, err)
 
-		result := transition.Call2(deployerAddress, addr, input, big.NewInt(0), gasLimit, runtime.NewAccessList())
+		result := transition.Call2(deployerAddress, addr, input, big.NewInt(0), gasLimit)
 		require.True(t, result.Succeeded())
 
 		return result.ReturnValue
@@ -119,7 +118,7 @@ func TestIntegration_PerformExit(t *testing.T) {
 	}).EncodeAbi()
 	require.NoError(t, err)
 
-	result := transition.Call2(deployerAddress, rootERC20Addr, mintInput, nil, gasLimit, runtime.NewAccessList())
+	result := transition.Call2(deployerAddress, rootERC20Addr, mintInput, nil, gasLimit)
 	require.NoError(t, result.Err)
 
 	// approve
@@ -129,7 +128,7 @@ func TestIntegration_PerformExit(t *testing.T) {
 	}).EncodeAbi()
 	require.NoError(t, err)
 
-	result = transition.Call2(senderAddress, rootERC20Addr, approveInput, big.NewInt(0), gasLimit, runtime.NewAccessList())
+	result = transition.Call2(senderAddress, rootERC20Addr, approveInput, big.NewInt(0), gasLimit)
 	require.NoError(t, result.Err)
 
 	// deposit
@@ -141,7 +140,7 @@ func TestIntegration_PerformExit(t *testing.T) {
 	require.NoError(t, err)
 
 	// send sync events to childchain so that receiver can obtain tokens
-	result = transition.Call2(senderAddress, rootERC20PredicateAddr, depositInput, big.NewInt(0), gasLimit, runtime.NewAccessList())
+	result = transition.Call2(senderAddress, rootERC20PredicateAddr, depositInput, big.NewInt(0), gasLimit)
 	require.NoError(t, result.Err)
 
 	// simulate withdrawal from childchain to rootchain
@@ -231,7 +230,7 @@ func TestIntegration_PerformExit(t *testing.T) {
 	submitCheckpointEncoded, err := cm.abiEncodeCheckpointBlock(blockNumber, blockHash, extra, accSet)
 	require.NoError(t, err)
 
-	result = transition.Call2(senderAddress, checkpointManagerAddr, submitCheckpointEncoded, big.NewInt(0), gasLimit, runtime.NewAccessList())
+	result = transition.Call2(senderAddress, checkpointManagerAddr, submitCheckpointEncoded, big.NewInt(0), gasLimit)
 	require.NoError(t, result.Err)
 	require.Equal(t, getField(checkpointManagerAddr, contractsapi.CheckpointManager.Abi, "currentCheckpointBlockNumber")[31], uint8(1))
 
@@ -256,7 +255,7 @@ func TestIntegration_PerformExit(t *testing.T) {
 	}).EncodeAbi()
 	require.NoError(t, err)
 
-	result = transition.Call2(senderAddress, exitHelperContractAddress, exitFnInput, big.NewInt(0), gasLimit, runtime.NewAccessList())
+	result = transition.Call2(senderAddress, exitHelperContractAddress, exitFnInput, big.NewInt(0), gasLimit)
 	require.NoError(t, result.Err)
 
 	// check that first exit event is processed
@@ -383,7 +382,7 @@ func TestIntegration_CommitEpoch(t *testing.T) {
 		require.NoError(t, err)
 
 		// call commit epoch
-		result := transition.Call2(contracts.SystemCaller, contracts.EpochManagerContract, input, big.NewInt(0), 10000000000, runtime.NewAccessList())
+		result := transition.Call2(contracts.SystemCaller, contracts.EpochManagerContract, input, big.NewInt(0), 10000000000)
 		require.NoError(t, result.Err)
 		t.Logf("Number of validators %d on commit epoch, Gas used %+v\n", accSet.Len(), result.GasUsed)
 
@@ -392,7 +391,7 @@ func TestIntegration_CommitEpoch(t *testing.T) {
 		require.NoError(t, err)
 
 		// call commit epoch
-		result = transition.Call2(contracts.SystemCaller, contracts.EpochManagerContract, input, big.NewInt(0), 10000000000, runtime.NewAccessList())
+		result = transition.Call2(contracts.SystemCaller, contracts.EpochManagerContract, input, big.NewInt(0), 10000000000)
 		require.NoError(t, result.Err)
 		t.Logf("Number of validators %d on commit epoch, Gas used %+v\n", accSet.Len(), result.GasUsed)
 	}
@@ -402,14 +401,14 @@ func deployAndInitContract(t *testing.T, transition *state.Transition, bytecode 
 	initCallback func() ([]byte, error)) types.Address {
 	t.Helper()
 
-	deployResult := transition.Create2(sender, bytecode, big.NewInt(0), 1e9, runtime.NewAccessList())
+	deployResult := transition.Create2(sender, bytecode, big.NewInt(0), 1e9)
 	assert.NoError(t, deployResult.Err)
 
 	if initCallback != nil {
 		initInput, err := initCallback()
 		require.NoError(t, err)
 
-		result := transition.Call2(sender, deployResult.Address, initInput, big.NewInt(0), 1e9, runtime.NewAccessList())
+		result := transition.Call2(sender, deployResult.Address, initInput, big.NewInt(0), 1e9)
 		require.NoError(t, result.Err)
 	}
 

--- a/consensus/polybft/system_state_test.go
+++ b/consensus/polybft/system_state_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/state"
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
-	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +45,7 @@ func TestSystemState_GetNextCommittedIndex(t *testing.T) {
 	transition := newTestTransition(t, nil)
 
 	// deploy a contract
-	result := transition.Create2(types.Address{}, bin, big.NewInt(0), 1000000000, runtime.NewAccessList())
+	result := transition.Create2(types.Address{}, bin, big.NewInt(0), 1000000000)
 	assert.NoError(t, result.Err)
 
 	provider := &stateProvider{
@@ -93,7 +92,7 @@ func TestSystemState_GetEpoch(t *testing.T) {
 	transition := newTestTransition(t, nil)
 
 	// deploy a contract
-	result := transition.Create2(types.Address{}, bin, big.NewInt(0), 1000000000, runtime.NewAccessList())
+	result := transition.Create2(types.Address{}, bin, big.NewInt(0), 1000000000)
 	assert.NoError(t, result.Err)
 
 	provider := &stateProvider{

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -513,6 +513,8 @@ func TestE2E_Consensus_CustomRewardToken(t *testing.T) {
 // and check if balance of sender, receiver, burn contract and miner is updates correctly
 // in accordance with EIP-1559 specifications
 func TestE2E_Consensus_EIP1559Check(t *testing.T) {
+	t.Skip("TODO - since we removed burn from evm, this should be fixed after the burn solution")
+
 	sender, err := wallet.GenerateKey()
 	require.NoError(t, err)
 

--- a/helper/predeployment/predeployment.go
+++ b/helper/predeployment/predeployment.go
@@ -61,7 +61,6 @@ func getPredeployAccount(address types.Address, input []byte,
 		big.NewInt(0),
 		math.MaxInt64,
 		input,
-		runtime.NewAccessList(),
 	)
 
 	// Enable all forks

--- a/helper/predeployment/predeployment.go
+++ b/helper/predeployment/predeployment.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/big"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/umbracle/ethgo/abi"
 
 	"github.com/0xPolygon/polygon-edge/chain"
@@ -67,7 +68,7 @@ func getPredeployAccount(address types.Address, input []byte,
 	config := chain.AllForksEnabled.At(0)
 
 	// Create a transition
-	transition := state.NewTransition(config, snapshot, radix)
+	transition := state.NewTransition(hclog.NewNullLogger(), config, snapshot, radix)
 	transition.ContextPtr().ChainID = chainID
 
 	// Run the transition through the EVM

--- a/state/executor.go
+++ b/state/executor.go
@@ -485,10 +485,17 @@ func (t *Transition) subGasLimitPrice(msg *types.Transaction) error {
 }
 
 func (t *Transition) nonceCheck(msg *types.Transaction) error {
-	nonce := t.state.GetNonce(msg.From())
+	currentNonce := t.state.GetNonce(msg.From())
 
-	if nonce != msg.Nonce() {
-		return ErrNonceIncorrect
+	if msgNonce := msg.Nonce(); currentNonce < msgNonce {
+		return fmt.Errorf("%w: address %v, tx: %d state: %d", ErrNonceTooHigh,
+			msg.From(), msgNonce, currentNonce)
+	} else if currentNonce > msgNonce {
+		return fmt.Errorf("%w: address %v, tx: %d state: %d", ErrNonceTooLow,
+			msg.From(), msgNonce, currentNonce)
+	} else if currentNonce+1 < currentNonce {
+		return fmt.Errorf("%w: address %v, nonce: %d", ErrNonceMax,
+			msg.From(), currentNonce)
 	}
 
 	return nil
@@ -536,7 +543,9 @@ func (t *Transition) checkDynamicFees(msg *types.Transaction) error {
 // surfacing of these errors reject the transaction thus not including it in the block
 
 var (
-	ErrNonceIncorrect        = errors.New("incorrect nonce")
+	ErrNonceTooLow           = errors.New("nonce too low")
+	ErrNonceTooHigh          = errors.New("nonce too high")
+	ErrNonceMax              = errors.New("nonce has max value")
 	ErrSenderNoEOA           = errors.New("sender not an eoa")
 	ErrNotEnoughFundsForGas  = errors.New("not enough funds to cover gas costs")
 	ErrBlockLimitReached     = errors.New("gas limit reached in the pool")
@@ -652,8 +661,13 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 		result = t.Call2(msg.From(), *(msg.To()), msg.Input(), value, gasLeft, initialAccessList)
 	}
 
+	refundQuotient := LegacyRefundQuotient
+	if t.config.London {
+		refundQuotient = LondonRefundQuotient
+	}
+
 	refund := t.state.GetRefund()
-	result.UpdateGasUsed(msg.Gas(), refund)
+	result.UpdateGasUsed(msg.Gas(), refund, refundQuotient)
 
 	if t.ctx.Tracer != nil {
 		t.ctx.Tracer.TxEnd(result.GasLeft)
@@ -681,10 +695,10 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 
 	// Burn some amount if the london hardfork is applied.
 	// Basically, burn amount is just transferred to the current burn contract.
-	if t.config.London && msg.Type() != types.StateTx {
-		burnAmount := new(big.Int).Mul(new(big.Int).SetUint64(result.GasUsed), t.ctx.BaseFee)
-		t.state.AddBalance(t.ctx.BurnContract, burnAmount)
-	}
+	// if t.config.London && msg.Type() != types.StateTx {
+	// 	burnAmount := new(big.Int).Mul(new(big.Int).SetUint64(result.GasUsed), t.ctx.BaseFee)
+	// 	t.state.AddBalance(t.ctx.BurnContract, burnAmount)
+	// }
 
 	// return gas to the pool
 	t.addGasPool(result.GasLeft)
@@ -966,6 +980,20 @@ func (t *Transition) applyCreate(c *runtime.Contract, host runtime.Host) *runtim
 		return &runtime.ExecutionResult{
 			GasLeft: 0,
 			Err:     runtime.ErrMaxCodeSizeExceeded,
+		}
+	}
+
+	// Reject code starting with 0xEF if EIP-3541 is enabled.
+	if result.Err == nil && len(result.ReturnValue) >= 1 && result.ReturnValue[0] == 0xEF && t.config.London {
+		if err := t.state.RevertToSnapshot(snapshot); err != nil {
+			return &runtime.ExecutionResult{
+				Err: err,
+			}
+		}
+
+		return &runtime.ExecutionResult{
+			GasLeft: 0,
+			Err:     runtime.ErrInvalidCode,
 		}
 	}
 

--- a/state/executor.go
+++ b/state/executor.go
@@ -1342,7 +1342,7 @@ func (t *Transition) RevertToSnapshot(snapshot int) error {
 	})
 
 	if idx == len(t.journalRevisions) || t.journalRevisions[idx].ID != snapshot {
-		return fmt.Errorf("journal revision id %v cannot be reverted", snapshot)
+		return fmt.Errorf("journal revision id %d cannot be reverted", snapshot)
 	}
 
 	journalIndex := t.journalRevisions[idx].Index

--- a/state/executor.go
+++ b/state/executor.go
@@ -1117,7 +1117,7 @@ func (t *Transition) GetNonce(addr types.Address) uint64 {
 }
 
 func (t *Transition) Selfdestruct(addr types.Address, beneficiary types.Address) {
-	if !t.state.HasSuicided(addr) {
+	if !t.config.London && !t.state.HasSuicided(addr) {
 		t.state.AddRefund(24000)
 	}
 

--- a/state/executor.go
+++ b/state/executor.go
@@ -698,7 +698,7 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 	coinbaseFee := new(big.Int).Mul(new(big.Int).SetUint64(result.GasUsed), effectiveTip)
 	t.state.AddBalance(t.ctx.Coinbase, coinbaseFee)
 
-	// nolint:godox
+	//nolint:godox
 	// TODO - burning of base fee should not be done in the EVM
 	// Burn some amount if the london hardfork is applied.
 	// Basically, burn amount is just transferred to the current burn contract.
@@ -1342,6 +1342,7 @@ func (t *Transition) RevertToSnapshot(snapshot int) error {
 	})
 
 	if idx == len(t.journalRevisions) || t.journalRevisions[idx].ID != snapshot {
+		//nolint:gocritic
 		panic(fmt.Errorf("journal revision id %v cannot be reverted", snapshot))
 	}
 

--- a/state/executor.go
+++ b/state/executor.go
@@ -90,6 +90,7 @@ func (e *Executor) WriteGenesis(
 		config:      config,
 		precompiles: precompiled.NewPrecompiled(),
 		journal:     &runtime.Journal{},
+		accessList:  runtime.NewAccessList(),
 	}
 
 	for addr, account := range alloc {
@@ -303,6 +304,7 @@ func NewTransition(config chain.ForksInTime, snap Snapshot, radix *Txn) *Transit
 		evm:         evm.NewEVM(),
 		precompiles: precompiled.NewPrecompiled(),
 		journal:     &runtime.Journal{},
+		accessList:  runtime.NewAccessList(),
 	}
 }
 

--- a/state/executor.go
+++ b/state/executor.go
@@ -488,6 +488,9 @@ func (t *Transition) subGasLimitPrice(msg *types.Transaction) error {
 	balanceCheck := new(big.Int).Set(upfrontGasCost)
 	if msg.Type() == types.DynamicFeeTx {
 		balanceCheck.Add(balanceCheck, msg.Value())
+		balanceCheck.SetUint64(msg.Gas())
+		balanceCheck = balanceCheck.Mul(balanceCheck, msg.GasFeeCap())
+		balanceCheck.Add(balanceCheck, msg.Value())
 	}
 
 	if have, want := t.state.GetBalance(msg.From()), balanceCheck; have.Cmp(want) < 0 {

--- a/state/executor.go
+++ b/state/executor.go
@@ -224,6 +224,7 @@ func (e *Executor) BeginTxn(
 		precompiles: precompiled.NewPrecompiled(),
 		PostHook:    e.PostHook,
 		journal:     &runtime.Journal{},
+		accessList:  runtime.NewAccessList(),
 	}
 
 	// enable contract deployment allow list (if any)

--- a/state/executor.go
+++ b/state/executor.go
@@ -1342,8 +1342,7 @@ func (t *Transition) RevertToSnapshot(snapshot int) error {
 	})
 
 	if idx == len(t.journalRevisions) || t.journalRevisions[idx].ID != snapshot {
-		//nolint:gocritic
-		panic(fmt.Errorf("journal revision id %v cannot be reverted", snapshot))
+		return fmt.Errorf("journal revision id %v cannot be reverted", snapshot)
 	}
 
 	journalIndex := t.journalRevisions[idx].Index

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -36,7 +37,7 @@ func TestOverride(t *testing.T) {
 	balance := big.NewInt(2)
 	code := []byte{0x1}
 
-	tt := NewTransition(chain.ForksInTime{}, state, newTxn(state))
+	tt := NewTransition(hclog.NewNullLogger(), chain.ForksInTime{}, state, newTxn(state))
 
 	require.Empty(t, tt.state.GetCode(types.ZeroAddress))
 
@@ -259,7 +260,7 @@ func Test_Transition_EIP2929(t *testing.T) {
 			txn.SetCode(addr, tt.code)
 
 			enabledForks := chain.AllForksEnabled.At(0)
-			transition := NewTransition(enabledForks, state, txn)
+			transition := NewTransition(hclog.NewNullLogger(), enabledForks, state, txn)
 			initialAccessList := runtime.NewAccessList()
 			initialAccessList.PrepareAccessList(transition.ctx.Origin, &addr, transition.precompiles.Addrs, nil)
 			transition.accessList = initialAccessList

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -262,8 +262,9 @@ func Test_Transition_EIP2929(t *testing.T) {
 			transition := NewTransition(enabledForks, state, txn)
 			initialAccessList := runtime.NewAccessList()
 			initialAccessList.PrepareAccessList(transition.ctx.Origin, &addr, transition.precompiles.Addrs, nil)
+			transition.accessList = initialAccessList
 
-			result := transition.Call2(transition.ctx.Origin, addr, nil, big.NewInt(0), uint64(1000000), initialAccessList)
+			result := transition.Call2(transition.ctx.Origin, addr, nil, big.NewInt(0), uint64(1000000))
 			assert.Equal(t, tt.gasConsumed, result.GasUsed, "Gas consumption for %s is inaccurate according to EIP 2929", tt.name)
 		})
 	}

--- a/state/runtime/evm/dispatch_table.go
+++ b/state/runtime/evm/dispatch_table.go
@@ -61,7 +61,7 @@ func init() {
 	register(SLT, handler{inst: opSlt, stack: 2, gas: 3})
 	register(SGT, handler{inst: opSgt, stack: 2, gas: 3})
 
-	register(SIGNEXTEND, handler{inst: opSignExtension, stack: 1, gas: 5})
+	register(SIGNEXTEND, handler{inst: opSignExtension, stack: 2, gas: 5})
 
 	register(SHL, handler{inst: opShl, stack: 2, gas: 3})
 	register(SHR, handler{inst: opShr, stack: 2, gas: 3})

--- a/state/runtime/evm/evm_fuzz_test.go
+++ b/state/runtime/evm/evm_fuzz_test.go
@@ -138,6 +138,15 @@ func (m *mockHostF) GetRefund() uint64 {
 	return m.refund
 }
 
+func (m *mockHostF) AddSlotToAccessList(addr types.Address, slot types.Hash) {}
+func (m *mockHostF) AddAddressToAccessList(addr types.Address)               {}
+func (m *mockHostF) ContainsAccessListAddress(addr types.Address) bool       { return false }
+func (m *mockHostF) ContainsAccessListSlot(addr types.Address, slot types.Hash) (bool, bool) {
+	return false, false
+}
+func (m *mockHostF) DeleteAccessListAddress(addr types.Address)               {}
+func (m *mockHostF) DeleteAccessListSlot(addr types.Address, slot types.Hash) {}
+
 func FuzzTestEVM(f *testing.F) {
 	seed := []byte{
 		PUSH1, 0x01, PUSH1, 0x02, ADD,

--- a/state/runtime/evm/evm_test.go
+++ b/state/runtime/evm/evm_test.go
@@ -21,7 +21,6 @@ func newMockContract(value *big.Int, gas uint64, code []byte) *runtime.Contract 
 		value,
 		gas,
 		code,
-		runtime.NewAccessList(),
 	)
 }
 
@@ -30,7 +29,8 @@ func newMockContract(value *big.Int, gas uint64, code []byte) *runtime.Contract 
 type mockHost struct {
 	mock.Mock
 
-	tracer runtime.VMTracer
+	tracer     runtime.VMTracer
+	accessList *runtime.AccessList
 }
 
 func (m *mockHost) AccountExists(addr types.Address) bool {
@@ -134,6 +134,30 @@ func (m *mockHost) GetTracer() runtime.VMTracer {
 
 func (m *mockHost) GetRefund() uint64 {
 	panic("Not implemented in tests") //nolint:gocritic
+}
+
+func (m *mockHost) AddSlotToAccessList(addr types.Address, slot types.Hash) {
+	m.accessList.AddSlot(addr, slot)
+}
+
+func (m *mockHost) AddAddressToAccessList(addr types.Address) {
+	m.accessList.AddAddress(addr)
+}
+
+func (m *mockHost) ContainsAccessListAddress(addr types.Address) bool {
+	return m.accessList.ContainsAddress(addr)
+}
+
+func (m *mockHost) ContainsAccessListSlot(addr types.Address, slot types.Hash) (bool, bool) {
+	return m.accessList.Contains(addr, slot)
+}
+
+func (m *mockHost) DeleteAccessListAddress(addr types.Address) {
+	m.accessList.DeleteAddress(addr)
+}
+
+func (m *mockHost) DeleteAccessListSlot(addr types.Address, slot types.Hash) {
+	m.accessList.DeleteSlot(addr, slot)
 }
 
 func TestRun(t *testing.T) {

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -1418,9 +1418,6 @@ func (c *state) buildCreateContract(op OpCode) (*runtime.Contract, error) {
 
 	// Calculate and consume gas cost
 
-	// var overflow bool
-	var gasCost uint64
-
 	// Both CREATE and CREATE2 use memory
 	var input []byte
 
@@ -1431,22 +1428,17 @@ func (c *state) buildCreateContract(op OpCode) (*runtime.Contract, error) {
 		return nil, nil
 	}
 
-	// Consume memory resize gas (TODO, change with get2) (to be fixed in EVM-528) //nolint:godox
-	if !c.consumeGas(gasCost) {
-		return nil, nil
-	}
-
-	if hasTransfer {
-		if c.host.GetBalance(c.msg.Address).Cmp(value) < 0 {
-			return nil, types.ErrInsufficientFunds
-		}
-	}
-
 	if op == CREATE2 {
 		// Consume sha3 gas cost
 		size := length.Uint64()
 		if !c.consumeGas(((size + 31) / 32) * sha3WordGas) {
 			return nil, nil
+		}
+	}
+
+	if hasTransfer {
+		if c.host.GetBalance(c.msg.Address).Cmp(value) < 0 {
+			return nil, types.ErrInsufficientFunds
 		}
 	}
 

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -1487,7 +1487,6 @@ func Test_opSload(t *testing.T) {
 			op:   SLOAD,
 			contract: &runtime.Contract{
 				Address: address1,
-				Journal: &runtime.Journal{},
 			},
 			config: &chain.ForksInTime{
 				Berlin: true,
@@ -1525,6 +1524,9 @@ func Test_opSload(t *testing.T) {
 						key1: val1,
 					},
 				},
+				mockHost: mockHost{
+					accessList: runtime.NewAccessList(),
+				},
 			},
 		},
 		{
@@ -1532,7 +1534,6 @@ func Test_opSload(t *testing.T) {
 			op:   SLOAD,
 			contract: &runtime.Contract{
 				Address: address1,
-				Journal: &runtime.Journal{},
 			},
 			config: &chain.ForksInTime{
 				Berlin: true,
@@ -1574,6 +1575,9 @@ func Test_opSload(t *testing.T) {
 						key1: val1,
 					},
 				},
+				mockHost: mockHost{
+					accessList: runtime.NewAccessList(),
+				},
 			},
 		},
 		{
@@ -1581,7 +1585,6 @@ func Test_opSload(t *testing.T) {
 			op:   SLOAD,
 			contract: &runtime.Contract{
 				Address: address1,
-				Journal: &runtime.Journal{},
 			},
 			config: &chain.ForksInTime{
 				Berlin:   false,
@@ -1616,6 +1619,9 @@ func Test_opSload(t *testing.T) {
 						key1: val1,
 					},
 				},
+				mockHost: mockHost{
+					accessList: runtime.NewAccessList(),
+				},
 			},
 		},
 	}
@@ -1634,8 +1640,8 @@ func Test_opSload(t *testing.T) {
 			s.stack = tt.initState.stack
 			s.memory = tt.initState.memory
 			s.config = tt.config
+			tt.mockHost.accessList = tt.initState.accessList
 			s.host = tt.mockHost
-			tt.contract.AccessList = tt.initState.accessList
 
 			opSload(s)
 
@@ -1643,7 +1649,7 @@ func Test_opSload(t *testing.T) {
 			assert.Equal(t, tt.resultState.sp, s.sp, "sp in state after execution is not correct")
 			assert.Equal(t, tt.resultState.stack, s.stack, "stack in state after execution is not correct")
 			assert.Equal(t, tt.resultState.memory, s.memory, "memory in state after execution is not correct")
-			assert.Equal(t, tt.resultState.accessList, tt.contract.AccessList, "accesslist in state after execution is not correct")
+			assert.Equal(t, tt.resultState.accessList, tt.mockHost.accessList, "accesslist in state after execution is not correct")
 			assert.Equal(t, tt.resultState.stop, s.stop, "stop in state after execution is not correct")
 			assert.Equal(t, tt.resultState.err, s.err, "err in state after execution is not correct")
 		})
@@ -1711,6 +1717,9 @@ func TestCreate(t *testing.T) {
 					GasLeft: 500,
 					GasUsed: 500,
 				},
+				mockHost: mockHost{
+					accessList: runtime.NewAccessList(),
+				},
 			},
 		},
 		{
@@ -1749,7 +1758,11 @@ func TestCreate(t *testing.T) {
 				stop: true,
 				err:  errWriteProtection,
 			},
-			mockHost: &mockHostForInstructions{},
+			mockHost: &mockHostForInstructions{
+				mockHost: mockHost{
+					accessList: runtime.NewAccessList(),
+				},
+			},
 		},
 		{
 			name:     "should throw errOpCodeNotFound when op is CREATE2 and config.Constantinople is disabled",
@@ -1787,7 +1800,11 @@ func TestCreate(t *testing.T) {
 				stop: true,
 				err:  errOpCodeNotFound,
 			},
-			mockHost: &mockHostForInstructions{},
+			mockHost: &mockHostForInstructions{
+				mockHost: mockHost{
+					accessList: runtime.NewAccessList(),
+				},
+			},
 		},
 		{
 			name: "should set zero address if op is CREATE and contract call throws ErrCodeStoreOutOfGas",
@@ -1834,6 +1851,9 @@ func TestCreate(t *testing.T) {
 				callxResult: &runtime.ExecutionResult{
 					GasLeft: 1000,
 					Err:     runtime.ErrCodeStoreOutOfGas,
+				},
+				mockHost: mockHost{
+					accessList: runtime.NewAccessList(),
 				},
 			},
 		},
@@ -1882,6 +1902,9 @@ func TestCreate(t *testing.T) {
 				callxResult: &runtime.ExecutionResult{
 					GasLeft: 1000,
 					Err:     errRevert,
+				},
+				mockHost: mockHost{
+					accessList: runtime.NewAccessList(),
 				},
 			},
 		},
@@ -1933,6 +1956,9 @@ func TestCreate(t *testing.T) {
 					// if it is ErrCodeStoreOutOfGas then we set GasLeft to 0
 					GasLeft: 0,
 					Err:     runtime.ErrCodeStoreOutOfGas,
+				},
+				mockHost: mockHost{
+					accessList: runtime.NewAccessList(),
 				},
 			},
 		},
@@ -2284,9 +2310,7 @@ func Test_opCall(t *testing.T) {
 			name: "should not copy result into memory if outSize is 0",
 			op:   STATICCALL,
 			contract: &runtime.Contract{
-				Static:     true,
-				Journal:    &runtime.Journal{},
-				AccessList: runtime.NewAccessList(),
+				Static: true,
 			},
 			config: allEnabledForks,
 			initState: &state{
@@ -2310,6 +2334,9 @@ func Test_opCall(t *testing.T) {
 			mockHost: &mockHostForInstructions{
 				callxResult: &runtime.ExecutionResult{
 					ReturnValue: []byte{0x03},
+				},
+				mockHost: mockHost{
+					accessList: runtime.NewAccessList(),
 				},
 			},
 		},

--- a/state/runtime/journal.go
+++ b/state/runtime/journal.go
@@ -4,8 +4,13 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
+type JournalRevision struct {
+	ID    int
+	Index int
+}
+
 type JournalEntry interface {
-	Revert(c *Contract)
+	Revert(host Host)
 }
 
 type Journal struct {
@@ -16,12 +21,17 @@ func (j *Journal) Append(entry JournalEntry) {
 	j.entries = append(j.entries, entry)
 }
 
-func (j *Journal) Revert(c *Contract) {
-	for i := len(j.entries) - 1; i >= 0; i-- {
-		j.entries[i].Revert(c)
+func (j *Journal) Revert(host Host, snapshot int) {
+	for i := len(j.entries) - 1; i >= snapshot; i-- {
+		// Undo the changes made by the operation
+		j.entries[i].Revert(host)
 	}
 
-	j.entries = j.entries[:0]
+	j.entries = j.entries[:snapshot]
+}
+
+func (j *Journal) Len() int {
+	return len(j.entries)
 }
 
 type (
@@ -36,12 +46,12 @@ type (
 
 var _ JournalEntry = (*AccessListAddAccountChange)(nil)
 
-func (ch AccessListAddAccountChange) Revert(c *Contract) {
-	c.AccessList.DeleteAddress(ch.Address)
+func (ch AccessListAddAccountChange) Revert(host Host) {
+	host.DeleteAccessListAddress(ch.Address)
 }
 
 var _ JournalEntry = (*AccessListAddSlotChange)(nil)
 
-func (ch AccessListAddSlotChange) Revert(c *Contract) {
-	c.AccessList.DeleteSlot(ch.Address, ch.Slot)
+func (ch AccessListAddSlotChange) Revert(host Host) {
+	host.DeleteAccessListSlot(ch.Address, ch.Slot)
 }

--- a/state/runtime/precompiled/base.go
+++ b/state/runtime/precompiled/base.go
@@ -39,7 +39,11 @@ func (e *ecrecover) run(input []byte, caller types.Address, _ runtime.Host) ([]b
 		return nil, nil
 	}
 
-	pubKey, err := crypto.Ecrecover(input[:32], append(input[64:128], v))
+	sig := make([]byte, 65)
+	copy(sig, input[64:128])
+	sig[64] = v
+
+	pubKey, err := crypto.Ecrecover(input[:32], sig)
 	if err != nil {
 		return nil, nil
 	}

--- a/state/runtime/precompiled/native_transfer_test.go
+++ b/state/runtime/precompiled/native_transfer_test.go
@@ -171,6 +171,34 @@ func (d dummyHost) GetNonce(addr types.Address) uint64 {
 	return 0
 }
 
+func (d *dummyHost) AddSlotToAccessList(addr types.Address, slot types.Hash) {
+	d.t.Fatalf("AddSlotToAccessList is not implemented")
+}
+
+func (d *dummyHost) AddAddressToAccessList(addr types.Address) {
+	d.t.Fatalf("AddAddressToAccessList is not implemented")
+}
+
+func (d *dummyHost) ContainsAccessListAddress(addr types.Address) bool {
+	d.t.Fatalf("ContainsAccessListAddress is not implemented")
+
+	return false
+}
+
+func (d *dummyHost) ContainsAccessListSlot(addr types.Address, slot types.Hash) (bool, bool) {
+	d.t.Fatalf("ContainsAccessListSlot is not implemented")
+
+	return false, false
+}
+
+func (d *dummyHost) DeleteAccessListAddress(addr types.Address) {
+	d.t.Fatalf("DeleteAccessListAddress is not implemented")
+}
+
+func (d *dummyHost) DeleteAccessListSlot(addr types.Address, slot types.Hash) {
+	d.t.Fatalf("DeleteAccessListSlot is not implemented")
+}
+
 func (d dummyHost) Transfer(from types.Address, to types.Address, amount *big.Int) error {
 	if d.balances == nil {
 		d.balances = map[types.Address]*big.Int{}

--- a/state/runtime/runtime.go
+++ b/state/runtime/runtime.go
@@ -119,11 +119,11 @@ func (r *ExecutionResult) Succeeded() bool { return r.Err == nil }
 func (r *ExecutionResult) Failed() bool    { return r.Err != nil }
 func (r *ExecutionResult) Reverted() bool  { return errors.Is(r.Err, ErrExecutionReverted) }
 
-func (r *ExecutionResult) UpdateGasUsed(gasLimit uint64, refund uint64) {
+func (r *ExecutionResult) UpdateGasUsed(gasLimit uint64, refund, refundQuotient uint64) {
 	r.GasUsed = gasLimit - r.GasLeft
 
 	// Refund can go up to half the gas used
-	if maxRefund := r.GasUsed / 2; refund > maxRefund {
+	if maxRefund := r.GasUsed / refundQuotient; refund > maxRefund {
 		refund = maxRefund
 	}
 
@@ -143,6 +143,7 @@ var (
 	ErrUnauthorizedCaller       = errors.New("unauthorized caller")
 	ErrInvalidInputData         = errors.New("invalid input data")
 	ErrNotAuth                  = errors.New("not in allow list")
+	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
 )
 
 // StackUnderflowError wraps an evm error when the items on the stack less

--- a/state/transition_test.go
+++ b/state/transition_test.go
@@ -16,9 +16,10 @@ func newTestTransition(preState map[types.Address]*PreState) *Transition {
 	}
 
 	return &Transition{
-		logger: hclog.NewNullLogger(),
-		state:  newTestTxn(preState),
-		ctx:    runtime.TxContext{BaseFee: big.NewInt(0)},
+		logger:  hclog.NewNullLogger(),
+		state:   newTestTxn(preState),
+		ctx:     runtime.TxContext{BaseFee: big.NewInt(0)},
+		journal: &runtime.Journal{},
 	}
 }
 

--- a/state/transition_test.go
+++ b/state/transition_test.go
@@ -60,7 +60,7 @@ func TestSubGasLimitPrice(t *testing.T) {
 			gas:      10,
 			gasPrice: 10,
 			// should return ErrNotEnoughFundsForGas when state.SubBalance returns ErrNotEnoughFunds
-			expectedErr: ErrNotEnoughFundsForGas,
+			expectedErr: ErrInsufficientFunds,
 		},
 	}
 
@@ -78,7 +78,12 @@ func TestSubGasLimitPrice(t *testing.T) {
 
 			err := transition.subGasLimitPrice(msg)
 
-			assert.Equal(t, tt.expectedErr, err)
+			if tt.expectedErr != nil {
+				assert.ErrorContains(t, err, tt.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
 			if err == nil {
 				// should reduce cost for gas from balance
 				reducedAmount := new(big.Int).Mul(msg.GasPrice(), big.NewInt(int64(msg.Gas())))

--- a/state/transition_test.go
+++ b/state/transition_test.go
@@ -48,7 +48,7 @@ func TestSubGasLimitPrice(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name: "should fail by ErrNotEnoughFunds",
+			name: "should fail by ErrInsufficientFunds",
 			preState: map[types.Address]*PreState{
 				addr1: {
 					Nonce:   0,
@@ -59,7 +59,7 @@ func TestSubGasLimitPrice(t *testing.T) {
 			from:     addr1,
 			gas:      10,
 			gasPrice: 10,
-			// should return ErrNotEnoughFundsForGas when state.SubBalance returns ErrNotEnoughFunds
+			// should return ErrInsufficientFunds when state.SubBalance returns ErrNotEnoughFunds
 			expectedErr: ErrInsufficientFunds,
 		},
 	}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -348,7 +348,13 @@ func (t *stTransaction) At(i indexes, baseFee *big.Int) (*types.Transaction, err
 		}), nil
 	}
 
+	txType := types.LegacyTx
+	if isDynamicTransaction {
+		txType = types.DynamicFeeTx
+	}
+
 	return types.NewTx(&types.MixedTxn{
+		Type:       txType,
 		From:       t.From,
 		To:         t.To,
 		Nonce:      t.Nonce,
@@ -576,18 +582,19 @@ var Forks = map[string]*chain.Forks{
 		chain.Berlin:         chain.NewFork(0),
 		chain.London:         chain.NewFork(5),
 	},
-	// "London": {
-	// 	chain.EIP3607:        chain.NewFork(0),
-	// 	chain.Homestead:      chain.NewFork(0),
-	// 	chain.EIP150:         chain.NewFork(0),
-	// 	chain.EIP155:         chain.NewFork(0),
-	// 	chain.EIP158:         chain.NewFork(0),
-	// 	chain.Byzantium:      chain.NewFork(0),
-	// 	chain.Constantinople: chain.NewFork(0),
-	// 	chain.Petersburg:     chain.NewFork(0),
-	// 	chain.Istanbul:       chain.NewFork(0),
-	// 	chain.London:         chain.NewFork(0),
-	// },
+	"London": {
+		chain.EIP3607:        chain.NewFork(0),
+		chain.Homestead:      chain.NewFork(0),
+		chain.EIP150:         chain.NewFork(0),
+		chain.EIP155:         chain.NewFork(0),
+		chain.EIP158:         chain.NewFork(0),
+		chain.Byzantium:      chain.NewFork(0),
+		chain.Constantinople: chain.NewFork(0),
+		chain.Petersburg:     chain.NewFork(0),
+		chain.Istanbul:       chain.NewFork(0),
+		chain.Berlin:         chain.NewFork(0),
+		chain.London:         chain.NewFork(0),
+	},
 }
 
 func contains(l []string, name string) bool {

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -349,7 +349,7 @@ func (t *stTransaction) At(i indexes, baseFee *big.Int) (*types.Transaction, err
 	}
 
 	txType := types.LegacyTx
-	if isDynamicTransaction {
+	if isDynamiFeeTx {
 		txType = types.DynamicFeeTx
 	}
 


### PR DESCRIPTION
# Description

This PR fixes issues in regards to the London (`EIP-1559`) fork tests.

### Bug Fixes
1. Move `access list` from `runtime.Contract` to `Transition`. This way, `access list` is only held by one object.
2. Moving `journal` from `runtime.Contract` to `Transition`. This way, `journal` is only held by one object. This was necessary, because journals should be aware of the snapshot number as well (`journalRevisions`). For example, a contract can call another contract, and that other contract can call a third contract, each call creates a new snapshot. If let's say a call to the third contract fails, any slot or address added to the access list in calls of the first two contracts should not be removed from the access list. That is way `journal` must be aware of the snapshot id, so that it knows to remove only items from the snapshot that failed.
3.  When applying a transaction in the `Transition` object, and doing a pre-check of the transaction to see if some basic conditions are met, nonce check was not totally complete. Before this fix, it only checked if the passed nonce is equal from the one in state. Now the check is more granular (checks if nonce is lower, higher, or maxed out, and returns a proper error).
4.   When applying a transaction in the `Transition` object, and doing a pre-check of the transaction to see if account has enough funds to pay for the transaction, the check was not quite complete in case of `Dynamic` (`London`) transactions. This is now synced with `geth`.
5. Fixed amounts to be refunded after transaction is applied in the `Transition` object. Refund quotient was the same for `Berlin` and `London` forks, which was not correct.
6. Commented out burning of base fee in the evm. This should not be done in that place. Left a TODO, since this should be revisited in next PRs.
7. A check if the return code of the transaction starts with `0xEF` when `London` fork is enabled was missing in the case when deploying a new contract.
8. When `opSelfDestruct` is executed, a check if London fork is enabled was missing when doing the refund. Only if `London` is not enabled, self destruct should do refund to the address that is being suicide.
9. `SIGNEXTEND` instruction did not have the correct stack size value.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually