### PR TITLE
Introduce `ECDSAKey` and decouple from `ethgo` lib transactions signing logic

### DIFF
--- a/command/bridge/deploy/deploy_test.go
+++ b/command/bridge/deploy/deploy_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/jsonrpc"
 	"github.com/umbracle/ethgo/testutil"
 
@@ -32,7 +33,7 @@ func TestDeployContracts_NoPanics(t *testing.T) {
 	testKey, err := helper.DecodePrivateKey("")
 	require.NoError(t, err)
 
-	receipt, err := server.Fund(testKey.Address())
+	receipt, err := server.Fund(ethgo.Address(testKey.Address()))
 	require.NoError(t, err)
 	require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
 

--- a/command/bridge/deposit/erc1155/deposit_erc1155.go
+++ b/command/bridge/deposit/erc1155/deposit_erc1155.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/umbracle/ethgo"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
@@ -245,8 +244,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 }
 
 // createDepositTxn encodes parameters for deposit function on rootchain predicate contract
-func createDepositTxn(sender ethgo.Address, receivers []types.Address,
-	amounts, tokenIDs []*big.Int) (*ethgo.Transaction, error) {
+func createDepositTxn(sender types.Address, receivers []types.Address,
+	amounts, tokenIDs []*big.Int) (*types.Transaction, error) {
 	depositBatchFn := &contractsapi.DepositBatchRootERC1155PredicateFn{
 		RootToken: types.StringToAddress(dp.TokenAddr),
 		Receivers: receivers,
@@ -259,14 +258,14 @@ func createDepositTxn(sender ethgo.Address, receivers []types.Address,
 		return nil, fmt.Errorf("failed to encode provided parameters: %w", err)
 	}
 
-	addr := ethgo.Address(types.StringToAddress(dp.PredicateAddr))
+	addr := types.StringToAddress(dp.PredicateAddr)
 
 	return helper.CreateTransaction(sender, &addr, input,
 		nil, !dp.ChildChainMintable), nil
 }
 
 // createMintTxn encodes parameters for mint function on rootchain token contract
-func createMintTxn(sender, receiver types.Address, amounts, tokenIDs []*big.Int) (*ethgo.Transaction, error) {
+func createMintTxn(sender, receiver types.Address, amounts, tokenIDs []*big.Int) (*types.Transaction, error) {
 	mintFn := &contractsapi.MintBatchRootERC1155Fn{
 		To:      receiver,
 		Amounts: amounts,
@@ -278,16 +277,16 @@ func createMintTxn(sender, receiver types.Address, amounts, tokenIDs []*big.Int)
 		return nil, fmt.Errorf("failed to encode provided parameters: %w", err)
 	}
 
-	addr := ethgo.Address(types.StringToAddress(dp.TokenAddr))
+	addr := types.StringToAddress(dp.TokenAddr)
 
-	return helper.CreateTransaction(ethgo.Address(sender), &addr,
+	return helper.CreateTransaction(sender, &addr,
 		input, nil, !dp.ChildChainMintable), nil
 }
 
 // createApproveERC1155PredicateTxn sends approve transaction
 // to ERC1155 token for ERC1155 predicate so that it is able to spend given tokens
 func createApproveERC1155PredicateTxn(rootERC1155Predicate,
-	rootERC1155Token types.Address) (*ethgo.Transaction, error) {
+	rootERC1155Token types.Address) (*types.Transaction, error) {
 	approveFnParams := &contractsapi.SetApprovalForAllRootERC1155Fn{
 		Operator: rootERC1155Predicate,
 		Approved: true,
@@ -298,8 +297,6 @@ func createApproveERC1155PredicateTxn(rootERC1155Predicate,
 		return nil, fmt.Errorf("failed to encode parameters for RootERC1155.setApprovalForAll. error: %w", err)
 	}
 
-	addr := ethgo.Address(rootERC1155Token)
-
-	return helper.CreateTransaction(ethgo.ZeroAddress, &addr,
+	return helper.CreateTransaction(types.ZeroAddress, &rootERC1155Token,
 		input, nil, !dp.ChildChainMintable), nil
 }

--- a/command/bridge/deposit/erc20/deposit_erc20.go
+++ b/command/bridge/deposit/erc20/deposit_erc20.go
@@ -267,7 +267,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 }
 
 // createDepositTxn encodes parameters for deposit function on rootchain predicate contract
-func createDepositTxn(sender, receiver types.Address, amount *big.Int) (*ethgo.Transaction, error) {
+func createDepositTxn(sender, receiver types.Address, amount *big.Int) (*types.Transaction, error) {
 	depositToFn := &contractsapi.DepositToRootERC20PredicateFn{
 		RootToken: types.StringToAddress(dp.TokenAddr),
 		Receiver:  receiver,
@@ -279,8 +279,8 @@ func createDepositTxn(sender, receiver types.Address, amount *big.Int) (*ethgo.T
 		return nil, fmt.Errorf("failed to encode provided parameters: %w", err)
 	}
 
-	addr := ethgo.Address(types.StringToAddress(dp.PredicateAddr))
+	addr := types.StringToAddress(dp.PredicateAddr)
 
-	return helper.CreateTransaction(ethgo.Address(sender), &addr,
+	return helper.CreateTransaction(sender, &addr,
 		input, nil, !dp.ChildChainMintable), nil
 }

--- a/command/bridge/deposit/erc721/deposit_erc721.go
+++ b/command/bridge/deposit/erc721/deposit_erc721.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	"github.com/0xPolygon/polygon-edge/command/bridge/helper"
@@ -12,8 +14,6 @@ import (
 	helperCommon "github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/spf13/cobra"
-	"github.com/umbracle/ethgo"
 )
 
 type depositERC721Params struct {
@@ -219,8 +219,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 }
 
 // createDepositTxn encodes parameters for deposit function on rootchain predicate contract
-func createDepositTxn(sender ethgo.Address,
-	receivers []types.Address, tokenIDs []*big.Int) (*ethgo.Transaction, error) {
+func createDepositTxn(sender types.Address,
+	receivers []types.Address, tokenIDs []*big.Int) (*types.Transaction, error) {
 	depositToRoot := &contractsapi.DepositBatchRootERC721PredicateFn{
 		RootToken: types.StringToAddress(dp.TokenAddr),
 		Receivers: receivers,
@@ -232,13 +232,13 @@ func createDepositTxn(sender ethgo.Address,
 		return nil, fmt.Errorf("failed to encode provided parameters: %w", err)
 	}
 
-	addr := ethgo.Address(types.StringToAddress(dp.PredicateAddr))
+	addr := types.StringToAddress(dp.PredicateAddr)
 
 	return helper.CreateTransaction(sender, &addr, input, nil, !dp.ChildChainMintable), nil
 }
 
 // createMintTxn encodes parameters for mint function on rootchain token contract
-func createMintTxn(sender, receiver types.Address) (*ethgo.Transaction, error) {
+func createMintTxn(sender, receiver types.Address) (*types.Transaction, error) {
 	mintFn := &contractsapi.MintRootERC721Fn{
 		To: receiver,
 	}
@@ -248,14 +248,14 @@ func createMintTxn(sender, receiver types.Address) (*ethgo.Transaction, error) {
 		return nil, fmt.Errorf("failed to encode provided parameters: %w", err)
 	}
 
-	addr := ethgo.Address(types.StringToAddress(dp.TokenAddr))
+	addr := types.StringToAddress(dp.TokenAddr)
 
-	return helper.CreateTransaction(ethgo.Address(sender), &addr,
+	return helper.CreateTransaction(sender, &addr,
 		input, nil, !dp.ChildChainMintable), nil
 }
 
 // createApproveERC721PredicateTxn sends approve transaction
-func createApproveERC721PredicateTxn(rootERC721Predicate, rootERC721Token types.Address) (*ethgo.Transaction, error) {
+func createApproveERC721PredicateTxn(rootERC721Predicate, rootERC721Token types.Address) (*types.Transaction, error) {
 	approveFnParams := &contractsapi.SetApprovalForAllRootERC721Fn{
 		Operator: rootERC721Predicate,
 		Approved: true,
@@ -266,8 +266,6 @@ func createApproveERC721PredicateTxn(rootERC721Predicate, rootERC721Token types.
 		return nil, fmt.Errorf("failed to encode parameters for RootERC721.approve. error: %w", err)
 	}
 
-	addr := ethgo.Address(rootERC721Token)
-
-	return helper.CreateTransaction(ethgo.ZeroAddress, &addr, input,
+	return helper.CreateTransaction(types.ZeroAddress, &rootERC721Token, input,
 		nil, !dp.ChildChainMintable), nil
 }

--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/jsonrpc"
 
 	"github.com/0xPolygon/polygon-edge/command"
@@ -156,7 +155,7 @@ func run(cmd *cobra.Command, _ []string) {
 }
 
 // createExitTxn encodes parameters for exit function on root chain ExitHelper contract
-func createExitTxn(sender ethgo.Address, proof types.Proof) (*ethgo.Transaction,
+func createExitTxn(sender types.Address, proof types.Proof) (*types.Transaction,
 	*contractsapi.L2StateSyncedEvent, error) {
 	exitInput, err := polybft.GetExitInputFromProof(proof)
 	if err != nil {
@@ -180,9 +179,9 @@ func createExitTxn(sender ethgo.Address, proof types.Proof) (*ethgo.Transaction,
 		return nil, nil, fmt.Errorf("failed to encode provided parameters: %w", err)
 	}
 
-	exitHelperAddr := ethgo.Address(types.StringToAddress(ep.exitHelperAddrRaw))
+	exitHelperAddr := types.StringToAddress(ep.exitHelperAddrRaw)
 	txn := helper.CreateTransaction(sender, &exitHelperAddr, input, nil, true)
-	txn.Gas = txrelayer.DefaultGasLimit
+	txn.SetGas(txrelayer.DefaultGasLimit)
 
 	return txn, exitEvent, err
 }

--- a/command/bridge/finalize/finalize.go
+++ b/command/bridge/finalize/finalize.go
@@ -15,6 +15,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -105,7 +106,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("enlist validator failed: %w", err)
 	}
 
-	bladeManagerAddr := ethgo.Address(params.bladeManagerAddr)
+	bladeManagerAddr := params.bladeManagerAddr
 
 	// finalize genesis accounts on BladeManager so that no one can stake and premine no more
 	encoded, err := finalizeGenesisABIFn.Encode([]interface{}{})
@@ -145,7 +146,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to encode genesis set input: %w", err)
 	}
 
-	genesisSetHexOut, err := txRelayer.Call(ethgo.ZeroAddress, bladeManagerAddr, genesisSetInput)
+	genesisSetHexOut, err := txRelayer.Call(types.ZeroAddress, bladeManagerAddr, genesisSetInput)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve genesis set: %w", err)
 	}
@@ -315,7 +316,7 @@ func validatorSetToABISlice(o command.OutputFormatter,
 func initializeCheckpointManager(outputter command.OutputFormatter,
 	txRelayer txrelayer.TxRelayer,
 	consensusConfig polybft.PolyBFTConfig, chainID int64,
-	deployerKey ethgo.Key) error {
+	deployerKey crypto.Key) error {
 	validatorSet, err := validatorSetToABISlice(outputter, consensusConfig.InitialValidatorSet)
 	if err != nil {
 		return fmt.Errorf("failed to convert validators to map: %w", err)
@@ -333,7 +334,7 @@ func initializeCheckpointManager(outputter command.OutputFormatter,
 		return fmt.Errorf("failed to encode initialization params for CheckpointManager.initialize. error: %w", err)
 	}
 
-	if _, err := bridgeHelper.SendTransaction(txRelayer, ethgo.Address(consensusConfig.Bridge.CheckpointManagerAddr),
+	if _, err := bridgeHelper.SendTransaction(txRelayer, consensusConfig.Bridge.CheckpointManagerAddr,
 		input, "CheckpointManager", deployerKey); err != nil {
 		return err
 	}

--- a/command/bridge/fund/fund.go
+++ b/command/bridge/fund/fund.go
@@ -96,8 +96,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 				return ctx.Err()
 
 			default:
-				fundAddr := ethgo.Address(params.addresses[i])
-				txn := helper.CreateTransaction(ethgo.ZeroAddress, &fundAddr, nil, params.amountValues[i], true)
+				fundAddr := params.addresses[i]
+				txn := helper.CreateTransaction(types.ZeroAddress, &fundAddr, nil, params.amountValues[i], true)
 
 				var (
 					receipt *ethgo.Receipt

--- a/command/bridge/helper/utils.go
+++ b/command/bridge/helper/utils.go
@@ -277,17 +277,21 @@ func CreateTransaction(sender types.Address, receiver *types.Address,
 	var txData types.TxData
 	if isDynamicFeeTx {
 		txData = &types.DynamicFeeTx{
-			From:  sender,
-			To:    receiver,
-			Value: value,
-			Input: input,
+			BaseTx: &types.BaseTx{
+				From:  sender,
+				To:    receiver,
+				Value: value,
+				Input: input,
+			},
 		}
 	} else {
 		txData = &types.LegacyTx{
-			From:  sender,
-			To:    receiver,
-			Value: value,
-			Input: input,
+			BaseTx: &types.BaseTx{
+				From:  sender,
+				To:    receiver,
+				Value: value,
+				Input: input,
+			},
 		}
 	}
 

--- a/command/bridge/helper/utils.go
+++ b/command/bridge/helper/utils.go
@@ -274,18 +274,24 @@ func SendTransaction(txRelayer txrelayer.TxRelayer, addr types.Address, input []
 // CreateTransaction is a helper function that creates either dynamic fee or legacy transaction based on provided flag
 func CreateTransaction(sender types.Address, receiver *types.Address,
 	input []byte, value *big.Int, isDynamicFeeTx bool) *types.Transaction {
-	txType := types.LegacyTx
+	var txData types.TxData
 	if isDynamicFeeTx {
-		txType = types.DynamicFeeTx
+		txData = &types.DynamicFeeTx{
+			From:  sender,
+			To:    receiver,
+			Value: value,
+			Input: input,
+		}
+	} else {
+		txData = &types.LegacyTx{
+			From:  sender,
+			To:    receiver,
+			Value: value,
+			Input: input,
+		}
 	}
 
-	return types.NewTx(&types.MixedTxn{
-		From:  sender,
-		To:    receiver,
-		Value: value,
-		Input: input,
-		Type:  txType,
-	})
+	return types.NewTx(txData)
 }
 
 func DeployProxyContract(txRelayer txrelayer.TxRelayer, deployerKey crypto.Key, proxyContractName string,

--- a/command/bridge/helper/utils.go
+++ b/command/bridge/helper/utils.go
@@ -276,23 +276,9 @@ func CreateTransaction(sender types.Address, receiver *types.Address,
 	input []byte, value *big.Int, isDynamicFeeTx bool) *types.Transaction {
 	var txData types.TxData
 	if isDynamicFeeTx {
-		txData = &types.DynamicFeeTx{
-			BaseTx: &types.BaseTx{
-				From:  sender,
-				To:    receiver,
-				Value: value,
-				Input: input,
-			},
-		}
+		txData = types.NewDynamicFeeTx(types.WithFrom(sender), types.WithTo(receiver), types.WithValue(value), types.WithInput(input))
 	} else {
-		txData = &types.LegacyTx{
-			BaseTx: &types.BaseTx{
-				From:  sender,
-				To:    receiver,
-				Value: value,
-				Input: input,
-			},
-		}
+		txData = types.NewLegacyTx(types.WithFrom(sender), types.WithTo(receiver), types.WithValue(value), types.WithInput(input))
 	}
 
 	return types.NewTx(txData)

--- a/command/bridge/helper/utils.go
+++ b/command/bridge/helper/utils.go
@@ -276,9 +276,11 @@ func CreateTransaction(sender types.Address, receiver *types.Address,
 	input []byte, value *big.Int, isDynamicFeeTx bool) *types.Transaction {
 	var txData types.TxData
 	if isDynamicFeeTx {
-		txData = types.NewDynamicFeeTx(types.WithFrom(sender), types.WithTo(receiver), types.WithValue(value), types.WithInput(input))
+		txData = types.NewDynamicFeeTx(types.WithFrom(sender),
+			types.WithTo(receiver), types.WithValue(value), types.WithInput(input))
 	} else {
-		txData = types.NewLegacyTx(types.WithFrom(sender), types.WithTo(receiver), types.WithValue(value), types.WithInput(input))
+		txData = types.NewLegacyTx(types.WithFrom(sender),
+			types.WithTo(receiver), types.WithValue(value), types.WithInput(input))
 	}
 
 	return types.NewTx(txData)

--- a/command/bridge/helper/utils.go
+++ b/command/bridge/helper/utils.go
@@ -10,13 +10,13 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/umbracle/ethgo"
-	"github.com/umbracle/ethgo/wallet"
 
 	polybftsecrets "github.com/0xPolygon/polygon-edge/command/secrets/init"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	polybftWallet "github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
@@ -49,7 +49,7 @@ var (
 	ErrNoAddressesProvided = errors.New("no addresses provided")
 	ErrInconsistentLength  = errors.New("addresses and amounts must be equal length")
 
-	rootchainAccountKey *wallet.Key
+	rootchainAccountKey *crypto.ECDSAKey
 )
 
 type MessageResult struct {
@@ -66,7 +66,7 @@ func (r MessageResult) GetOutput() string {
 }
 
 // DecodePrivateKey decodes a private key from provided raw private key
-func DecodePrivateKey(rawKey string) (ethgo.Key, error) {
+func DecodePrivateKey(rawKey string) (crypto.Key, error) {
 	privateKeyRaw := TestAccountPrivKey
 	if rawKey != "" {
 		privateKeyRaw = rawKey
@@ -77,7 +77,7 @@ func DecodePrivateKey(rawKey string) (ethgo.Key, error) {
 		return nil, fmt.Errorf("failed to decode private key string '%s': %w", privateKeyRaw, err)
 	}
 
-	rootchainAccountKey, err = wallet.NewWalletFromPrivKey(dec)
+	rootchainAccountKey, err = crypto.NewECDSAKeyFromRawPrivECDSA(dec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize key from provided private key '%s': %w", privateKeyRaw, err)
 	}
@@ -132,7 +132,7 @@ func ReadRootchainIP() (string, error) {
 // GetECDSAKey returns the key based on provided parameters
 // If private key is provided, it will return that key
 // if not, it will return the key from the secrets manager
-func GetECDSAKey(privateKey, accountDir, accountConfig string) (ethgo.Key, error) {
+func GetECDSAKey(privateKey, accountDir, accountConfig string) (crypto.Key, error) {
 	if privateKey != "" {
 		key, err := DecodePrivateKey(privateKey)
 		if err != nil {
@@ -152,9 +152,9 @@ func GetECDSAKey(privateKey, accountDir, accountConfig string) (ethgo.Key, error
 
 // GetValidatorInfo queries SupernetManager smart contract on root
 // and retrieves validator info for given address
-func GetValidatorInfo(validatorAddr ethgo.Address, supernetManagerAddr, stakeManagerAddr types.Address,
+func GetValidatorInfo(validatorAddr types.Address, supernetManagerAddr, stakeManagerAddr types.Address,
 	txRelayer txrelayer.TxRelayer) (*polybft.ValidatorInfo, error) {
-	caller := ethgo.Address(contracts.SystemCaller)
+	caller := contracts.SystemCaller
 	getValidatorMethod := contractsapi.StakeManager.Abi.GetMethod("stakeOf")
 
 	encode, err := getValidatorMethod.Encode([]interface{}{validatorAddr})
@@ -162,7 +162,7 @@ func GetValidatorInfo(validatorAddr ethgo.Address, supernetManagerAddr, stakeMan
 		return nil, err
 	}
 
-	response, err := txRelayer.Call(caller, ethgo.Address(supernetManagerAddr), encode)
+	response, err := txRelayer.Call(caller, supernetManagerAddr, encode)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func GetValidatorInfo(validatorAddr ethgo.Address, supernetManagerAddr, stakeMan
 		return nil, err
 	}
 
-	response, err = txRelayer.Call(caller, ethgo.Address(stakeManagerAddr), encode)
+	response, err = txRelayer.Call(caller, stakeManagerAddr, encode)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func GetValidatorInfo(validatorAddr ethgo.Address, supernetManagerAddr, stakeMan
 
 // CreateMintTxn encodes parameters for mint function on rootchain token contract
 func CreateMintTxn(receiver, erc20TokenAddr types.Address,
-	amount *big.Int, rootchainTx bool) (*ethgo.Transaction, error) {
+	amount *big.Int, rootchainTx bool) (*types.Transaction, error) {
 	mintFn := &contractsapi.MintRootERC20Fn{
 		To:     receiver,
 		Amount: amount,
@@ -231,8 +231,7 @@ func CreateMintTxn(receiver, erc20TokenAddr types.Address,
 		return nil, fmt.Errorf("failed to encode provided parameters: %w", err)
 	}
 
-	addr := ethgo.Address(erc20TokenAddr)
-	txn := CreateTransaction(ethgo.ZeroAddress, &addr, input, nil, rootchainTx)
+	txn := CreateTransaction(types.ZeroAddress, &erc20TokenAddr, input, nil, rootchainTx)
 
 	return txn, nil
 }
@@ -240,7 +239,7 @@ func CreateMintTxn(receiver, erc20TokenAddr types.Address,
 // CreateApproveERC20Txn sends approve transaction
 // to ERC20 token for spender so that it is able to spend given tokens
 func CreateApproveERC20Txn(amount *big.Int,
-	spender, erc20TokenAddr types.Address, rootchainTx bool) (*ethgo.Transaction, error) {
+	spender, erc20TokenAddr types.Address, rootchainTx bool) (*types.Transaction, error) {
 	approveFnParams := &contractsapi.ApproveRootERC20Fn{
 		Spender: spender,
 		Amount:  amount,
@@ -251,20 +250,18 @@ func CreateApproveERC20Txn(amount *big.Int,
 		return nil, fmt.Errorf("failed to encode parameters for RootERC20.approve. error: %w", err)
 	}
 
-	addr := ethgo.Address(erc20TokenAddr)
-
-	return CreateTransaction(ethgo.ZeroAddress, &addr, input, nil, rootchainTx), nil
+	return CreateTransaction(types.ZeroAddress, &erc20TokenAddr, input, nil, rootchainTx), nil
 }
 
 // SendTransaction sends provided transaction
-func SendTransaction(txRelayer txrelayer.TxRelayer, addr ethgo.Address, input []byte, contractName string,
-	deployerKey ethgo.Key) (*ethgo.Receipt, error) {
-	txn := CreateTransaction(ethgo.ZeroAddress, &addr, input, nil, true)
+func SendTransaction(txRelayer txrelayer.TxRelayer, addr types.Address, input []byte, contractName string,
+	deployerKey crypto.Key) (*ethgo.Receipt, error) {
+	txn := CreateTransaction(types.ZeroAddress, &addr, input, nil, true)
 
 	receipt, err := txRelayer.SendTransaction(txn, deployerKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send transaction to %s contract (%s). error: %w",
-			contractName, txn.To.Address(), err)
+			contractName, txn.To(), err)
 	}
 
 	if receipt == nil || receipt.Status != uint64(types.ReceiptSuccess) {
@@ -275,25 +272,23 @@ func SendTransaction(txRelayer txrelayer.TxRelayer, addr ethgo.Address, input []
 }
 
 // CreateTransaction is a helper function that creates either dynamic fee or legacy transaction based on provided flag
-func CreateTransaction(sender ethgo.Address, receiver *ethgo.Address,
-	input []byte, value *big.Int, isDynamicFeeTx bool) *ethgo.Transaction {
-	txn := &ethgo.Transaction{
+func CreateTransaction(sender types.Address, receiver *types.Address,
+	input []byte, value *big.Int, isDynamicFeeTx bool) *types.Transaction {
+	txType := types.LegacyTx
+	if isDynamicFeeTx {
+		txType = types.DynamicFeeTx
+	}
+
+	return types.NewTx(&types.MixedTxn{
 		From:  sender,
 		To:    receiver,
-		Input: input,
 		Value: value,
-	}
-
-	if isDynamicFeeTx {
-		txn.Type = ethgo.TransactionDynamicFee
-	} else {
-		txn.Type = ethgo.TransactionLegacy
-	}
-
-	return txn
+		Input: input,
+		Type:  txType,
+	})
 }
 
-func DeployProxyContract(txRelayer txrelayer.TxRelayer, deployerKey ethgo.Key, proxyContractName string,
+func DeployProxyContract(txRelayer txrelayer.TxRelayer, deployerKey crypto.Key, proxyContractName string,
 	proxyAdmin, logicAddress types.Address) (*ethgo.Receipt, error) {
 	proxyConstructorFn := contractsapi.TransparentUpgradeableProxyConstructorFn{
 		Logic:  logicAddress,
@@ -312,7 +307,7 @@ func DeployProxyContract(txRelayer txrelayer.TxRelayer, deployerKey ethgo.Key, p
 	proxyDeployInput = append(proxyDeployInput, contractsapi.TransparentUpgradeableProxy.Bytecode...)
 	proxyDeployInput = append(proxyDeployInput, constructorInput...)
 
-	txn := CreateTransaction(ethgo.ZeroAddress, nil, proxyDeployInput, nil, true)
+	txn := CreateTransaction(types.ZeroAddress, nil, proxyDeployInput, nil, true)
 
 	receipt, err := txRelayer.SendTransaction(txn, deployerKey)
 	if err != nil {

--- a/command/bridge/premine/premine.go
+++ b/command/bridge/premine/premine.go
@@ -13,7 +13,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/spf13/cobra"
-	"github.com/umbracle/ethgo"
 )
 
 var (
@@ -140,7 +139,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	bladeManagerAddr := ethgo.Address(types.StringToAddress(params.bladeManager))
+	bladeManagerAddr := types.StringToAddress(params.bladeManager)
 	txn := bridgeHelper.CreateTransaction(ownerKey.Address(), &bladeManagerAddr, premineInput, nil, false)
 
 	receipt, err = txRelayer.SendTransaction(txn, ownerKey)

--- a/command/bridge/withdraw/erc1155/withdraw_erc1155.go
+++ b/command/bridge/withdraw/erc1155/withdraw_erc1155.go
@@ -7,14 +7,13 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/umbracle/ethgo"
-	"github.com/umbracle/ethgo/wallet"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	"github.com/0xPolygon/polygon-edge/command/bridge/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	helperCommon "github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -85,7 +84,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	senderAccount, err := wallet.NewWalletFromPrivKey(senderKeyRaw)
+	senderAccount, err := crypto.NewECDSAKeyFromRawPrivECDSA(senderKeyRaw)
 	if err != nil {
 		outputter.SetError(err)
 
@@ -173,7 +172,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 }
 
 // createWithdrawTxn encodes parameters for withdraw function on child chain predicate contract
-func createWithdrawTxn(receivers []types.Address, amounts, TokenIDs []*big.Int) (*ethgo.Transaction, error) {
+func createWithdrawTxn(receivers []types.Address, amounts, TokenIDs []*big.Int) (*types.Transaction, error) {
 	withdrawFn := &contractsapi.WithdrawBatchChildERC1155PredicateFn{
 		ChildToken: types.StringToAddress(wp.TokenAddr),
 		Receivers:  receivers,
@@ -186,8 +185,8 @@ func createWithdrawTxn(receivers []types.Address, amounts, TokenIDs []*big.Int) 
 		return nil, fmt.Errorf("failed to encode provided parameters: %w", err)
 	}
 
-	addr := ethgo.Address(types.StringToAddress(wp.PredicateAddr))
+	addr := types.StringToAddress(wp.PredicateAddr)
 
-	return helper.CreateTransaction(ethgo.ZeroAddress, &addr, input,
+	return helper.CreateTransaction(types.ZeroAddress, &addr, input,
 		nil, wp.ChildChainMintable), nil
 }

--- a/command/bridge/withdraw/erc1155/withdraw_erc1155.go
+++ b/command/bridge/withdraw/erc1155/withdraw_erc1155.go
@@ -100,7 +100,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 	receivers := make([]types.Address, len(wp.Receivers))
 	amounts := make([]*big.Int, len(wp.Receivers))
-	TokenIDs := make([]*big.Int, len(wp.Receivers))
+	tokenIDs := make([]*big.Int, len(wp.Receivers))
 
 	for i, receiverRaw := range wp.Receivers {
 		receivers[i] = types.StringToAddress(receiverRaw)
@@ -122,11 +122,11 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		}
 
 		amounts[i] = amount
-		TokenIDs[i] = tokenID
+		tokenIDs[i] = tokenID
 	}
 
 	// withdraw tokens transaction
-	txn, err := createWithdrawTxn(receivers, amounts, TokenIDs)
+	txn, err := createWithdrawTxn(receivers, amounts, tokenIDs)
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to create tx input: %w", err))
 
@@ -172,12 +172,12 @@ func runCommand(cmd *cobra.Command, _ []string) {
 }
 
 // createWithdrawTxn encodes parameters for withdraw function on child chain predicate contract
-func createWithdrawTxn(receivers []types.Address, amounts, TokenIDs []*big.Int) (*types.Transaction, error) {
+func createWithdrawTxn(receivers []types.Address, amounts, tokenIDs []*big.Int) (*types.Transaction, error) {
 	withdrawFn := &contractsapi.WithdrawBatchChildERC1155PredicateFn{
 		ChildToken: types.StringToAddress(wp.TokenAddr),
 		Receivers:  receivers,
 		Amounts:    amounts,
-		TokenIDs:   TokenIDs,
+		TokenIDs:   tokenIDs,
 	}
 
 	input, err := withdrawFn.EncodeAbi()

--- a/command/bridge/withdraw/erc20/withdraw_erc20.go
+++ b/command/bridge/withdraw/erc20/withdraw_erc20.go
@@ -6,14 +6,13 @@ import (
 	"math/big"
 
 	"github.com/spf13/cobra"
-	"github.com/umbracle/ethgo"
-	"github.com/umbracle/ethgo/wallet"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	"github.com/0xPolygon/polygon-edge/command/bridge/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	helperCommon "github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -76,7 +75,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	senderAccount, err := wallet.NewWalletFromPrivKey(senderKeyRaw)
+	senderAccount, err := crypto.NewECDSAKeyFromRawPrivECDSA(senderKeyRaw)
 	if err != nil {
 		outputter.SetError(err)
 
@@ -152,7 +151,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 }
 
 // createWithdrawTxn encodes parameters for withdraw function on destination predicate contract
-func createWithdrawTxn(receiver types.Address, amount *big.Int) (*ethgo.Transaction, error) {
+func createWithdrawTxn(receiver types.Address, amount *big.Int) (*types.Transaction, error) {
 	withdrawToFn := &contractsapi.WithdrawToChildERC20PredicateFn{
 		ChildToken: types.StringToAddress(wp.TokenAddr),
 		Receiver:   receiver,
@@ -164,8 +163,8 @@ func createWithdrawTxn(receiver types.Address, amount *big.Int) (*ethgo.Transact
 		return nil, fmt.Errorf("failed to encode provided parameters: %w", err)
 	}
 
-	addr := ethgo.Address(types.StringToAddress(wp.PredicateAddr))
+	addr := types.StringToAddress(wp.PredicateAddr)
 
-	return helper.CreateTransaction(ethgo.ZeroAddress, &addr, input,
+	return helper.CreateTransaction(types.ZeroAddress, &addr, input,
 		nil, wp.ChildChainMintable), nil
 }

--- a/command/bridge/withdraw/erc721/withdraw_erc721.go
+++ b/command/bridge/withdraw/erc721/withdraw_erc721.go
@@ -11,12 +11,11 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/bridge/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	helperCommon "github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/spf13/cobra"
-	"github.com/umbracle/ethgo"
-	"github.com/umbracle/ethgo/wallet"
 )
 
 var (
@@ -76,7 +75,7 @@ func run(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	senderAccount, err := wallet.NewWalletFromPrivKey(senderKeyRaw)
+	senderAccount, err := crypto.NewECDSAKeyFromRawPrivECDSA(senderKeyRaw)
 	if err != nil {
 		outputter.SetError(err)
 
@@ -152,7 +151,7 @@ func run(cmd *cobra.Command, _ []string) {
 }
 
 // createWithdrawTxn encodes parameters for withdraw function on child chain predicate contract
-func createWithdrawTxn(receivers []types.Address, tokenIDs []*big.Int) (*ethgo.Transaction, error) {
+func createWithdrawTxn(receivers []types.Address, tokenIDs []*big.Int) (*types.Transaction, error) {
 	withdrawToFn := &contractsapi.WithdrawBatchChildERC721PredicateFn{
 		ChildToken: types.StringToAddress(wp.TokenAddr),
 		Receivers:  receivers,
@@ -164,8 +163,8 @@ func createWithdrawTxn(receivers []types.Address, tokenIDs []*big.Int) (*ethgo.T
 		return nil, fmt.Errorf("failed to encode provided parameters: %w", err)
 	}
 
-	addr := ethgo.Address(types.StringToAddress(wp.PredicateAddr))
+	addr := types.StringToAddress(wp.PredicateAddr)
 
-	return helper.CreateTransaction(ethgo.ZeroAddress, &addr, input,
+	return helper.CreateTransaction(types.ZeroAddress, &addr, input,
 		nil, wp.ChildChainMintable), nil
 }

--- a/command/secrets/init/params_test.go
+++ b/command/secrets/init/params_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/umbracle/ethgo/wallet"
 
 	"github.com/0xPolygon/polygon-edge/bls"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/secrets/helper"
 )
 
@@ -94,7 +94,8 @@ func Test_getResult(t *testing.T) {
 	// Test public key serialization
 	privKey, err := hex.DecodeString(sir.PrivateKey)
 	require.NoError(t, err)
-	k, err := wallet.NewWalletFromPrivKey(privKey)
+
+	k, err := crypto.NewECDSAKeyFromRawPrivECDSA(privKey)
 	require.NoError(t, err)
 
 	pubKey := k.Address().String()

--- a/command/validator/helper/helper.go
+++ b/command/validator/helper/helper.go
@@ -14,7 +14,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/umbracle/ethgo"
 )
 
 const (
@@ -59,7 +58,7 @@ func GetAccountFromDir(accountDir string) (*wallet.Account, error) {
 
 // GetValidatorInfo queries CustomSupernetManager, StakeManager and RewardPool smart contracts
 // to retrieve validator info for given address
-func GetValidatorInfo(validatorAddr ethgo.Address, childRelayer txrelayer.TxRelayer) (*polybft.ValidatorInfo, error) {
+func GetValidatorInfo(validatorAddr types.Address, childRelayer txrelayer.TxRelayer) (*polybft.ValidatorInfo, error) {
 	getValidatorMethod := contractsapi.StakeManager.Abi.GetMethod("getValidator")
 
 	encode, err := getValidatorMethod.Encode([]interface{}{validatorAddr})
@@ -67,8 +66,7 @@ func GetValidatorInfo(validatorAddr ethgo.Address, childRelayer txrelayer.TxRela
 		return nil, err
 	}
 
-	response, err := childRelayer.Call(ethgo.Address(contracts.SystemCaller),
-		ethgo.Address(contracts.StakeManagerContract), encode)
+	response, err := childRelayer.Call(contracts.SystemCaller, contracts.StakeManagerContract, encode)
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +107,7 @@ func GetValidatorInfo(validatorAddr ethgo.Address, childRelayer txrelayer.TxRela
 		return nil, err
 	}
 
-	response, err = childRelayer.Call(ethgo.Address(contracts.SystemCaller),
-		ethgo.Address(contracts.StakeManagerContract), encode)
+	response, err = childRelayer.Call(contracts.SystemCaller, contracts.StakeManagerContract, encode)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +126,7 @@ func GetValidatorInfo(validatorAddr ethgo.Address, childRelayer txrelayer.TxRela
 		return nil, err
 	}
 
-	response, err = childRelayer.Call(ethgo.ZeroAddress, ethgo.Address(contracts.EpochManagerContract), encode)
+	response, err = childRelayer.Call(types.ZeroAddress, contracts.EpochManagerContract, encode)
 	if err != nil {
 		return nil, err
 	}

--- a/command/validator/registration/register_validator.go
+++ b/command/validator/registration/register_validator.go
@@ -183,8 +183,7 @@ func registerValidator(sender txrelayer.TxRelayer, account *wallet.Account,
 		return nil, fmt.Errorf("register validator failed: %w", err)
 	}
 
-	stakeManagerAddr := ethgo.Address(contracts.StakeManagerContract)
-	txn := bridgeHelper.CreateTransaction(ethgo.ZeroAddress, &stakeManagerAddr, input, nil, true)
+	txn := bridgeHelper.CreateTransaction(types.ZeroAddress, &contracts.StakeManagerContract, input, nil, true)
 
 	return sender.SendTransaction(txn, account.Ecdsa)
 }

--- a/command/validator/stake/stake.go
+++ b/command/validator/stake/stake.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/0xPolygon/polygon-edge/command"
 	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
 	"github.com/0xPolygon/polygon-edge/command/helper"
@@ -13,8 +15,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/spf13/cobra"
-	"github.com/umbracle/ethgo"
 )
 
 var (
@@ -112,9 +112,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	stakeManagerAddr := ethgo.Address(contracts.StakeManagerContract)
-
-	txn := bridgeHelper.CreateTransaction(validatorAccount.Ecdsa.Address(), &stakeManagerAddr, encoded, nil, true)
+	txn := bridgeHelper.CreateTransaction(validatorAccount.Ecdsa.Address(),
+		&contracts.StakeManagerContract, encoded, nil, true)
 
 	receipt, err = txRelayer.SendTransaction(txn, validatorAccount.Ecdsa)
 	if err != nil {

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -13,7 +13,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/spf13/cobra"
-	"github.com/umbracle/ethgo"
 )
 
 var params unstakeParams
@@ -87,11 +86,11 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	txn := &ethgo.Transaction{
+	txn := types.NewTx(&types.MixedTxn{
 		From:  validatorAccount.Ecdsa.Address(),
 		Input: encoded,
-		To:    (*ethgo.Address)(&contracts.StakeManagerContract),
-	}
+		To:    &contracts.StakeManagerContract,
+	})
 
 	receipt, err := txRelayer.SendTransaction(txn, validatorAccount.Ecdsa)
 	if err != nil {

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -87,9 +87,11 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txn := types.NewTx(&types.LegacyTx{
-		From:  validatorAccount.Ecdsa.Address(),
-		Input: encoded,
-		To:    &contracts.StakeManagerContract,
+		BaseTx: &types.BaseTx{
+			From:  validatorAccount.Ecdsa.Address(),
+			Input: encoded,
+			To:    &contracts.StakeManagerContract,
+		},
 	})
 
 	receipt, err := txRelayer.SendTransaction(txn, validatorAccount.Ecdsa)

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -86,13 +86,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	txn := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			From:  validatorAccount.Ecdsa.Address(),
-			Input: encoded,
-			To:    &contracts.StakeManagerContract,
-		},
-	})
+	txn := types.NewTx(types.NewLegacyTx(types.WithFrom(validatorAccount.Ecdsa.Address()), types.WithInput(encoded), types.WithTo(&contracts.StakeManagerContract)))
 
 	receipt, err := txRelayer.SendTransaction(txn, validatorAccount.Ecdsa)
 	if err != nil {

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -86,7 +86,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	txn := types.NewTx(&types.MixedTxn{
+	txn := types.NewTx(&types.LegacyTx{
 		From:  validatorAccount.Ecdsa.Address(),
 		Input: encoded,
 		To:    &contracts.StakeManagerContract,

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -86,7 +86,10 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	txn := types.NewTx(types.NewLegacyTx(types.WithFrom(validatorAccount.Ecdsa.Address()), types.WithInput(encoded), types.WithTo(&contracts.StakeManagerContract)))
+	txn := types.NewTx(types.NewLegacyTx(
+		types.WithFrom(validatorAccount.Ecdsa.Address()),
+		types.WithInput(encoded),
+		types.WithTo(&contracts.StakeManagerContract)))
 
 	receipt, err := txRelayer.SendTransaction(txn, validatorAccount.Ecdsa)
 	if err != nil {

--- a/command/validator/whitelist/whitelist_validators.go
+++ b/command/validator/whitelist/whitelist_validators.go
@@ -13,7 +13,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/spf13/cobra"
-	"github.com/umbracle/ethgo"
 )
 
 var params whitelistParams
@@ -97,8 +96,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("whitelist validator failed. Could not abi encode whitelist function: %w", err)
 	}
 
-	stakeManagerAddr := ethgo.Address(contracts.StakeManagerContract)
-	txn := bridgeHelper.CreateTransaction(ecdsaKey.Address(), &stakeManagerAddr, encoded, nil, true)
+	txn := bridgeHelper.CreateTransaction(ecdsaKey.Address(), &contracts.StakeManagerContract, encoded, nil, true)
 
 	receipt, err := txRelayer.SendTransaction(txn, ecdsaKey)
 	if err != nil {

--- a/command/validator/withdraw-rewards/rewards.go
+++ b/command/validator/withdraw-rewards/rewards.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/umbracle/ethgo"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
@@ -69,7 +68,6 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	validatorAddr := validatorAccount.Ecdsa.Address()
-	epochManagerContract := ethgo.Address(contracts.EpochManagerContract)
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
 		txrelayer.WithReceiptTimeout(150*time.Millisecond))
@@ -82,7 +80,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	response, err := txRelayer.Call(validatorAddr, epochManagerContract, encoded)
+	response, err := txRelayer.Call(validatorAddr, contracts.EpochManagerContract, encoded)
 	if err != nil {
 		return err
 	}
@@ -97,7 +95,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	txn := bridgeHelper.CreateTransaction(validatorAddr, &epochManagerContract, encoded, nil, false)
+	txn := bridgeHelper.CreateTransaction(validatorAddr, &contracts.EpochManagerContract, encoded, nil, false)
 
 	receipt, err := txRelayer.SendTransaction(txn, validatorAccount.Ecdsa)
 	if err != nil {

--- a/command/validator/withdraw/withdraw.go
+++ b/command/validator/withdraw/withdraw.go
@@ -14,7 +14,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/spf13/cobra"
-	"github.com/umbracle/ethgo"
 )
 
 var params withdrawParams
@@ -77,8 +76,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	receiver := (*ethgo.Address)(&contracts.StakeManagerContract)
-	txn := bridgeHelper.CreateTransaction(validatorAccount.Ecdsa.Address(), receiver, encoded, nil, false)
+	txn := bridgeHelper.CreateTransaction(validatorAccount.Ecdsa.Address(),
+		&contracts.StakeManagerContract, encoded, nil, false)
 
 	receipt, err := txRelayer.SendTransaction(txn, validatorAccount.Ecdsa)
 	if err != nil {

--- a/consensus/polybft/block_builder_test.go
+++ b/consensus/polybft/block_builder_test.go
@@ -37,7 +37,7 @@ func TestBlockBuilder_BuildBlockTxOneFailedTxAndOneTakesTooMuchGas(t *testing.T)
 	accounts := [6]*account{}
 
 	for i := range accounts {
-		ecdsaKey, err := crypto.GenerateECDSAKey()
+		ecdsaKey, err := crypto.GenerateECDSAPrivateKey()
 		require.NoError(t, err)
 
 		accounts[i] = &account{

--- a/consensus/polybft/block_builder_test.go
+++ b/consensus/polybft/block_builder_test.go
@@ -1,12 +1,12 @@
 package polybft
 
 import (
-	"crypto/ecdsa"
 	"math/big"
 	"testing"
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/chain"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/state"
@@ -29,21 +29,13 @@ func TestBlockBuilder_BuildBlockTxOneFailedTxAndOneTakesTooMuchGas(t *testing.T)
 		chainID       = 100
 	)
 
-	type account struct {
-		privKey *ecdsa.PrivateKey
-		address types.Address
-	}
+	accounts := make([]*wallet.Account, 0, 6)
 
-	accounts := [6]*account{}
-
-	for i := range accounts {
-		ecdsaKey, err := crypto.GenerateECDSAPrivateKey()
+	for i := 0; i < cap(accounts); i++ {
+		acc, err := wallet.GenerateAccount()
 		require.NoError(t, err)
 
-		accounts[i] = &account{
-			privKey: ecdsaKey,
-			address: crypto.PubKeyToAddress(&ecdsaKey.PublicKey),
-		}
+		accounts = append(accounts, acc)
 	}
 
 	forks := &chain.Forks{}
@@ -71,7 +63,7 @@ func TestBlockBuilder_BuildBlockTxOneFailedTxAndOneTakesTooMuchGas(t *testing.T)
 	for i, acc := range accounts {
 		// the third tx will fail because of insufficient balance
 		if i != 2 {
-			balanceMap[acc.address] = &chain.GenesisAccount{Balance: ethgo.Ether(1)}
+			balanceMap[acc.Address()] = &chain.GenesisAccount{Balance: ethgo.Ether(1)}
 		}
 	}
 
@@ -93,15 +85,19 @@ func TestBlockBuilder_BuildBlockTxOneFailedTxAndOneTakesTooMuchGas(t *testing.T)
 			gas = blockGasLimit - 1
 		}
 
+		recipient := acc.Address()
+
 		tx := types.NewTx(types.NewLegacyTx(
 			types.WithGasPrice(big.NewInt(gasPrice)),
 			types.WithValue(big.NewInt(amount)),
 			types.WithGas(gas),
 			types.WithNonce(0),
-			types.WithTo(&acc.address),
+			types.WithTo(&recipient),
 		))
 
-		tx, err = signer.SignTx(tx, acc.privKey)
+		tx, err = signer.SignTxWithCallback(tx, func(hash types.Hash) (sig []byte, err error) {
+			return acc.Ecdsa.Sign(hash.Bytes())
+		})
 		require.NoError(t, err)
 
 		// all tx until the fifth will be retrieved from the pool

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -228,6 +228,6 @@ func (s *stateProvider) Call(addr ethgo.Address, input []byte, opts *contract.Ca
 
 // Txn is part of the contract.Provider interface to make Ethereum transactions. We disable this function
 // since the system state does not make any transaction
-func (s *stateProvider) Txn(ethgo.Address, ethgo.Key, []byte) (contract.Txn, error) {
+func (s *stateProvider) Txn(_ ethgo.Address, _ ethgo.Key, _ []byte) (contract.Txn, error) {
 	return nil, errSendTxnUnsupported
 }

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -58,7 +59,7 @@ var _ CheckpointManager = (*checkpointManager)(nil)
 // checkpointManager encapsulates logic for checkpoint data submission
 type checkpointManager struct {
 	// key is the identity of the node submitting a checkpoint
-	key ethgo.Key
+	key crypto.Key
 	// blockchain is abstraction for blockchain
 	blockchain blockchainBackend
 	// consensusBackend is abstraction for polybft consensus specific functions
@@ -76,7 +77,7 @@ type checkpointManager struct {
 }
 
 // newCheckpointManager creates a new instance of checkpointManager
-func newCheckpointManager(key ethgo.Key,
+func newCheckpointManager(key crypto.Key,
 	checkpointManagerSC types.Address, txRelayer txrelayer.TxRelayer,
 	blockchain blockchainBackend, backend polybftBackend, logger hclog.Logger,
 	state *State) *checkpointManager {
@@ -98,7 +99,7 @@ func getCurrentCheckpointBlock(relayer txrelayer.TxRelayer, checkpointManagerAdd
 		return 0, fmt.Errorf("failed to encode currentCheckpointBlockNumber function parameters: %w", err)
 	}
 
-	currentCheckpointBlockRaw, err := relayer.Call(ethgo.ZeroAddress, ethgo.Address(checkpointManagerAddr),
+	currentCheckpointBlockRaw, err := relayer.Call(types.ZeroAddress, checkpointManagerAddr,
 		checkpointBlockNumInput)
 	if err != nil {
 		return 0, fmt.Errorf("failed to invoke currentCheckpointBlockNumber function on the rootchain: %w", err)
@@ -198,8 +199,6 @@ func (c *checkpointManager) submitCheckpoint(latestHeader *types.Header, isEndOf
 func (c *checkpointManager) encodeAndSendCheckpoint(header *types.Header, extra *Extra, isEndOfEpoch bool) error {
 	c.logger.Debug("send checkpoint txn...", "block number", header.Number)
 
-	checkpointManager := ethgo.Address(c.checkpointManagerAddr)
-
 	nextEpochValidators := validator.AccountSet{}
 
 	if isEndOfEpoch {
@@ -216,11 +215,11 @@ func (c *checkpointManager) encodeAndSendCheckpoint(header *types.Header, extra 
 		return fmt.Errorf("failed to encode checkpoint data to ABI for block %d: %w", header.Number, err)
 	}
 
-	txn := &ethgo.Transaction{
-		To:    &checkpointManager,
+	txn := types.NewTx(&types.MixedTxn{
+		To:    &c.checkpointManagerAddr,
 		Input: input,
-		Type:  ethgo.TransactionDynamicFee,
-	}
+		Type:  types.DynamicFeeTx,
+	})
 
 	receipt, err := c.rootChainRelayer.SendTransaction(txn, c.key)
 	if err != nil {
@@ -331,9 +330,7 @@ func (c *checkpointManager) GenerateExitProof(exitID uint64) (types.Proof, error
 		return types.Proof{}, fmt.Errorf("failed to encode get checkpoint block input: %w", err)
 	}
 
-	getCheckpointBlockResp, err := c.rootChainRelayer.Call(
-		ethgo.ZeroAddress,
-		ethgo.Address(c.checkpointManagerAddr),
+	getCheckpointBlockResp, err := c.rootChainRelayer.Call(types.ZeroAddress, c.checkpointManagerAddr,
 		input)
 	if err != nil {
 		return types.Proof{}, fmt.Errorf("failed to retrieve checkpoint block for exit ID %d: %w", exitID, err)

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -215,10 +215,9 @@ func (c *checkpointManager) encodeAndSendCheckpoint(header *types.Header, extra 
 		return fmt.Errorf("failed to encode checkpoint data to ABI for block %d: %w", header.Number, err)
 	}
 
-	txn := types.NewTx(&types.MixedTxn{
+	txn := types.NewTx(&types.DynamicFeeTx{
 		To:    &c.checkpointManagerAddr,
 		Input: input,
-		Type:  types.DynamicFeeTx,
 	})
 
 	receipt, err := c.rootChainRelayer.SendTransaction(txn, c.key)

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -215,12 +215,10 @@ func (c *checkpointManager) encodeAndSendCheckpoint(header *types.Header, extra 
 		return fmt.Errorf("failed to encode checkpoint data to ABI for block %d: %w", header.Number, err)
 	}
 
-	txn := types.NewTx(&types.DynamicFeeTx{
-		BaseTx: &types.BaseTx{
-			To:    &c.checkpointManagerAddr,
-			Input: input,
-		},
-	})
+	txn := types.NewTx(types.NewDynamicFeeTx(
+		types.WithTo(&c.checkpointManagerAddr),
+		types.WithInput(input),
+	))
 
 	receipt, err := c.rootChainRelayer.SendTransaction(txn, c.key)
 	if err != nil {

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -216,8 +216,10 @@ func (c *checkpointManager) encodeAndSendCheckpoint(header *types.Header, extra 
 	}
 
 	txn := types.NewTx(&types.DynamicFeeTx{
-		To:    &c.checkpointManagerAddr,
-		Input: input,
+		BaseTx: &types.BaseTx{
+			To:    &c.checkpointManagerAddr,
+			Input: input,
+		},
 	})
 
 	receipt, err := c.rootChainRelayer.SendTransaction(txn, c.key)

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	merkle "github.com/Ethernal-Tech/merkle-tree"
 	hclog "github.com/hashicorp/go-hclog"
@@ -476,14 +477,14 @@ func newDummyTxRelayer(t *testing.T) *dummyTxRelayer {
 	return &dummyTxRelayer{test: t}
 }
 
-func (d *dummyTxRelayer) Call(from ethgo.Address, to ethgo.Address, input []byte) (string, error) {
+func (d *dummyTxRelayer) Call(from types.Address, to types.Address, input []byte) (string, error) {
 	args := d.Called(from, to, input)
 
 	return args.String(0), args.Error(1)
 }
 
-func (d *dummyTxRelayer) SendTransaction(transaction *ethgo.Transaction, key ethgo.Key) (*ethgo.Receipt, error) {
-	blockNumber := getBlockNumberCheckpointSubmitInput(d.test, transaction.Input)
+func (d *dummyTxRelayer) SendTransaction(transaction *types.Transaction, key crypto.Key) (*ethgo.Receipt, error) {
+	blockNumber := getBlockNumberCheckpointSubmitInput(d.test, transaction.Input())
 	d.checkpointBlocks = append(d.checkpointBlocks, blockNumber)
 	args := d.Called(transaction, key)
 
@@ -491,7 +492,7 @@ func (d *dummyTxRelayer) SendTransaction(transaction *ethgo.Transaction, key eth
 }
 
 // SendTransactionLocal sends non-signed transaction (this is only for testing purposes)
-func (d *dummyTxRelayer) SendTransactionLocal(txn *ethgo.Transaction) (*ethgo.Receipt, error) {
+func (d *dummyTxRelayer) SendTransactionLocal(txn *types.Transaction) (*ethgo.Receipt, error) {
 	args := d.Called(txn)
 
 	return args.Get(0).(*ethgo.Receipt), args.Error(1)

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -40,7 +40,7 @@ func TestCheckpointManager_SubmitCheckpoint(t *testing.T) {
 	t.Run("submit checkpoint happy path", func(t *testing.T) {
 		t.Parallel()
 
-		var aliases = []string{"A", "B", "C", "D", "E"}
+		aliases := []string{"A", "B", "C", "D", "E"}
 
 		validators := validator.NewTestValidatorsWithAliases(t, aliases)
 		validatorsMetadata := validators.GetPublicIdentities()
@@ -387,7 +387,7 @@ func TestCheckpointManager_GenerateExitProof(t *testing.T) {
 	require.NoError(t, err)
 
 	dummyTxRelayer := newDummyTxRelayer(t)
-	dummyTxRelayer.On("Call", ethgo.ZeroAddress, ethgo.ZeroAddress, input).
+	dummyTxRelayer.On("Call", types.ZeroAddress, types.ZeroAddress, input).
 		Return(hex.EncodeToString(foundCheckpointReturn), error(nil))
 
 	// create checkpoint manager and insert exit events
@@ -454,7 +454,7 @@ func TestCheckpointManager_GenerateExitProof(t *testing.T) {
 		inputTwo, err := getCheckpointBlockFn.EncodeAbi()
 		require.NoError(t, err)
 
-		dummyTxRelayer.On("Call", ethgo.ZeroAddress, ethgo.ZeroAddress, inputTwo).
+		dummyTxRelayer.On("Call", types.ZeroAddress, types.ZeroAddress, inputTwo).
 			Return(hex.EncodeToString(notFoundCheckpointReturn), error(nil))
 
 		_, err = checkpointMgr.GenerateExitProof(futureBlockToGetExit)

--- a/consensus/polybft/exit_relayer.go
+++ b/consensus/polybft/exit_relayer.go
@@ -227,7 +227,7 @@ func (e *exitRelayer) sendTx(events []*RelayerEventMetaData) error {
 		return err
 	}
 
-	exitTxn := types.NewTx(&types.MixedTxn{
+	exitTxn := types.NewTx(&types.LegacyTx{
 		From:  e.key.Address(),
 		To:    &e.config.eventExecutionAddr,
 		Input: input,

--- a/consensus/polybft/exit_relayer.go
+++ b/consensus/polybft/exit_relayer.go
@@ -227,13 +227,11 @@ func (e *exitRelayer) sendTx(events []*RelayerEventMetaData) error {
 		return err
 	}
 
-	exitTxn := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			From:  e.key.Address(),
-			To:    &e.config.eventExecutionAddr,
-			Input: input,
-		},
-	})
+	exitTxn := types.NewTx(types.NewLegacyTx(
+		types.WithFrom(e.key.Address()),
+		types.WithTo(&e.config.eventExecutionAddr),
+		types.WithInput(input),
+	))
 
 	// send batchExecute exit events
 	_, err = e.txRelayer.SendTransaction(exitTxn, e.key)

--- a/consensus/polybft/exit_relayer.go
+++ b/consensus/polybft/exit_relayer.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
@@ -43,7 +44,7 @@ var _ ExitRelayer = (*exitRelayer)(nil)
 type exitRelayer struct {
 	*relayerEventsProcessor
 
-	key            ethgo.Key
+	key            crypto.Key
 	proofRetriever ExitEventProofRetriever
 	txRelayer      txrelayer.TxRelayer
 	logger         hclog.Logger
@@ -56,7 +57,7 @@ type exitRelayer struct {
 // newExitRelayer creates a new instance of exitRelayer
 func newExitRelayer(
 	txRelayer txrelayer.TxRelayer,
-	key ethgo.Key,
+	key crypto.Key,
 	proofRetriever ExitEventProofRetriever,
 	blockchain blockchainBackend,
 	exitStore *ExitStore,
@@ -226,12 +227,14 @@ func (e *exitRelayer) sendTx(events []*RelayerEventMetaData) error {
 		return err
 	}
 
-	// send batchExecute exit events
-	_, err = e.txRelayer.SendTransaction(&ethgo.Transaction{
+	exitTxn := types.NewTx(&types.MixedTxn{
 		From:  e.key.Address(),
-		To:    (*ethgo.Address)(&e.config.eventExecutionAddr),
+		To:    &e.config.eventExecutionAddr,
 		Input: input,
-	}, e.key)
+	})
+
+	// send batchExecute exit events
+	_, err = e.txRelayer.SendTransaction(exitTxn, e.key)
 
 	return err
 }

--- a/consensus/polybft/exit_relayer.go
+++ b/consensus/polybft/exit_relayer.go
@@ -228,9 +228,11 @@ func (e *exitRelayer) sendTx(events []*RelayerEventMetaData) error {
 	}
 
 	exitTxn := types.NewTx(&types.LegacyTx{
-		From:  e.key.Address(),
-		To:    &e.config.eventExecutionAddr,
-		Input: input,
+		BaseTx: &types.BaseTx{
+			From:  e.key.Address(),
+			To:    &e.config.eventExecutionAddr,
+			Input: input,
+		},
 	})
 
 	// send batchExecute exit events

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
@@ -67,7 +68,7 @@ var _ StakeManager = (*stakeManager)(nil)
 type stakeManager struct {
 	logger                   hclog.Logger
 	state                    *State
-	key                      ethgo.Key
+	key                      crypto.Key
 	stakeManagerContractAddr types.Address
 	validatorSetContract     types.Address
 	polybftBackend           polybftBackend

--- a/consensus/polybft/stake_manager_test.go
+++ b/consensus/polybft/stake_manager_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -500,7 +501,7 @@ func newDummyStakeTxRelayer(t *testing.T, callback func() *validator.ValidatorMe
 	}
 }
 
-func (d *dummyStakeTxRelayer) Call(from ethgo.Address, to ethgo.Address, input []byte) (string, error) {
+func (d *dummyStakeTxRelayer) Call(from types.Address, to types.Address, input []byte) (string, error) {
 	args := d.Called(from, to, input)
 
 	if d.callback != nil {
@@ -520,14 +521,14 @@ func (d *dummyStakeTxRelayer) Call(from ethgo.Address, to ethgo.Address, input [
 	return args.String(0), args.Error(1)
 }
 
-func (d *dummyStakeTxRelayer) SendTransaction(transaction *ethgo.Transaction, key ethgo.Key) (*ethgo.Receipt, error) {
+func (d *dummyStakeTxRelayer) SendTransaction(transaction *types.Transaction, key crypto.Key) (*ethgo.Receipt, error) {
 	args := d.Called(transaction, key)
 
 	return args.Get(0).(*ethgo.Receipt), args.Error(1)
 }
 
 // SendTransactionLocal sends non-signed transaction (this is only for testing purposes)
-func (d *dummyStakeTxRelayer) SendTransactionLocal(txn *ethgo.Transaction) (*ethgo.Receipt, error) {
+func (d *dummyStakeTxRelayer) SendTransactionLocal(txn *types.Transaction) (*ethgo.Receipt, error) {
 	args := d.Called(txn)
 
 	return args.Get(0).(*ethgo.Receipt), args.Error(1)

--- a/consensus/polybft/state_sync_relayer.go
+++ b/consensus/polybft/state_sync_relayer.go
@@ -162,10 +162,12 @@ func (ssr stateSyncRelayerImpl) sendTx(events []*RelayerEventMetaData) error {
 	}
 
 	txn := types.NewTx(&types.LegacyTx{
-		From:  ssr.key.Address(),
-		To:    &ssr.config.eventExecutionAddr,
-		Gas:   types.StateTransactionGasLimit,
-		Input: input,
+		BaseTx: &types.BaseTx{
+			From:  ssr.key.Address(),
+			To:    &ssr.config.eventExecutionAddr,
+			Gas:   types.StateTransactionGasLimit,
+			Input: input,
+		},
 	})
 
 	// send batchExecute state sync

--- a/consensus/polybft/state_sync_relayer.go
+++ b/consensus/polybft/state_sync_relayer.go
@@ -160,14 +160,12 @@ func (ssr stateSyncRelayerImpl) sendTx(events []*RelayerEventMetaData) error {
 		return err
 	}
 
-	txn := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			From:  ssr.key.Address(),
-			To:    &ssr.config.eventExecutionAddr,
-			Gas:   types.StateTransactionGasLimit,
-			Input: input,
-		},
-	})
+	txn := types.NewTx(types.NewLegacyTx(
+		types.WithFrom(ssr.key.Address()),
+		types.WithTo(&ssr.config.eventExecutionAddr),
+		types.WithGas(types.StateTransactionGasLimit),
+		types.WithInput(input),
+	))
 
 	// send batchExecute state sync
 	_, err = ssr.txRelayer.SendTransaction(txn, ssr.key)

--- a/consensus/polybft/state_sync_relayer.go
+++ b/consensus/polybft/state_sync_relayer.go
@@ -161,7 +161,7 @@ func (ssr stateSyncRelayerImpl) sendTx(events []*RelayerEventMetaData) error {
 		return err
 	}
 
-	txn := types.NewTx(&types.MixedTxn{
+	txn := types.NewTx(&types.LegacyTx{
 		From:  ssr.key.Address(),
 		To:    &ssr.config.eventExecutionAddr,
 		Gas:   types.StateTransactionGasLimit,

--- a/consensus/polybft/stats.go
+++ b/consensus/polybft/stats.go
@@ -162,7 +162,7 @@ func (s *State) startStatsReleasing() {
 // publishRootchainMetrics publishes rootchain related metrics
 func (p *Polybft) publishRootchainMetrics(logger hclog.Logger) {
 	interval := p.config.MetricsInterval
-	validatorAddr := p.key.Address()
+	validatorAddr := ethgo.Address(p.key.Address())
 	bridgeCfg := p.genesisClientConfig.Bridge
 
 	// zero means metrics are disabled
@@ -188,7 +188,7 @@ func (p *Polybft) publishRootchainMetrics(logger hclog.Logger) {
 			return
 		case <-ticker.C:
 			// rootchain validator balance
-			balance, err := relayer.Client().Eth().GetBalance(p.key.Address(), ethgo.Latest)
+			balance, err := relayer.Client().Eth().GetBalance(validatorAddr, ethgo.Latest)
 			if err != nil {
 				logger.Error("failed to query eth_getBalance", "err", err)
 			} else {

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -13,7 +13,7 @@ import (
 // ValidatorInfo is data transfer object which holds validator information,
 // provided by smart contract
 type ValidatorInfo struct {
-	Address             ethgo.Address `json:"address"`
+	Address             types.Address `json:"address"`
 	Stake               *big.Int      `json:"stake"`
 	WithdrawableRewards *big.Int      `json:"withdrawableRewards"`
 	IsActive            bool          `json:"isActive"`

--- a/consensus/polybft/system_state_test.go
+++ b/consensus/polybft/system_state_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/umbracle/ethgo/abi"
 	"github.com/umbracle/ethgo/contract"
 	"github.com/umbracle/ethgo/testutil"
+	"github.com/umbracle/ethgo/wallet"
 )
 
 func TestSystemState_GetNextCommittedIndex(t *testing.T) {
@@ -116,13 +117,14 @@ func TestSystemState_GetEpoch(t *testing.T) {
 func TestStateProvider_Txn_NotSupported(t *testing.T) {
 	t.Parallel()
 
-	transition := newTestTransition(t, nil)
-
 	provider := &stateProvider{
-		transition: transition,
+		transition: newTestTransition(t, nil),
 	}
 
-	_, err := provider.Txn(ethgo.ZeroAddress, createTestKey(t), []byte{0x1})
+	key, err := wallet.GenerateKey()
+	require.NoError(t, err)
+
+	_, err = provider.Txn(ethgo.ZeroAddress, key, []byte{0x1})
 	require.ErrorIs(t, err, errSendTxnUnsupported)
 }
 

--- a/consensus/polybft/wallet/account.go
+++ b/consensus/polybft/wallet/account.go
@@ -8,19 +8,20 @@ import (
 	"github.com/umbracle/ethgo/wallet"
 
 	"github.com/0xPolygon/polygon-edge/bls"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/secrets"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
 // Account is an account for key signatures
 type Account struct {
-	Ecdsa *wallet.Key
+	Ecdsa *crypto.ECDSAKey
 	Bls   *bls.PrivateKey
 }
 
 // GenerateAccount generates a new random account
 func GenerateAccount() (*Account, error) {
-	key, err := wallet.GenerateKey()
+	key, err := crypto.GenerateECDSAKey()
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate key. error: %w", err)
 	}
@@ -52,7 +53,7 @@ func NewAccountFromSecret(secretsManager secrets.SecretsManager) (*Account, erro
 }
 
 // GetEcdsaFromSecret retrieves validator(ECDSA) key by using provided secretsManager
-func GetEcdsaFromSecret(secretsManager secrets.SecretsManager) (*wallet.Key, error) {
+func GetEcdsaFromSecret(secretsManager secrets.SecretsManager) (*crypto.ECDSAKey, error) {
 	encodedKey, err := secretsManager.GetSecret(secrets.ValidatorKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve ecdsa key: %w", err)
@@ -63,7 +64,7 @@ func GetEcdsaFromSecret(secretsManager secrets.SecretsManager) (*wallet.Key, err
 		return nil, fmt.Errorf("failed to retrieve ecdsa key: %w", err)
 	}
 
-	key, err := wallet.NewWalletFromPrivKey(ecdsaRaw)
+	key, err := crypto.NewECDSAKeyFromRawPrivECDSA(ecdsaRaw)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve ecdsa key: %w", err)
 	}

--- a/consensus/polybft/wallet/account.go
+++ b/consensus/polybft/wallet/account.go
@@ -5,8 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/umbracle/ethgo/wallet"
-
 	"github.com/0xPolygon/polygon-edge/bls"
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/secrets"
@@ -117,7 +115,7 @@ func (a *Account) GetEcdsaPrivateKey() (*ecdsa.PrivateKey, error) {
 		return nil, err
 	}
 
-	return wallet.ParsePrivateKey(ecdsaRaw)
+	return crypto.ParseECDSAPrivateKey(ecdsaRaw)
 }
 
 func (a Account) Address() types.Address {

--- a/consensus/polybft/wallet/key.go
+++ b/consensus/polybft/wallet/key.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/0xPolygon/go-ibft/messages/proto"
-	"github.com/umbracle/ethgo"
 	protobuf "google.golang.org/protobuf/proto"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
@@ -28,7 +27,7 @@ func (k *Key) String() string {
 }
 
 // Address returns ECDSA address
-func (k *Key) Address() ethgo.Address {
+func (k *Key) Address() types.Address {
 	return k.raw.Ecdsa.Address()
 }
 
@@ -73,13 +72,13 @@ func RecoverAddressFromSignature(sig, rawContent []byte) (types.Address, error) 
 	return crypto.PubKeyToAddress(pub), nil
 }
 
-// ECDSASigner implements ethgo.Key interface and it is used for signing using provided ECDSA key
+// ECDSASigner implements crypto.Key interface and it is used for signing using provided ECDSA key
 type ECDSASigner struct {
 	*Key
 }
 
-func NewEcdsaSigner(ecdsaKey *Key) *ECDSASigner {
-	return &ECDSASigner{Key: ecdsaKey}
+func NewEcdsaSigner(key *Key) *ECDSASigner {
+	return &ECDSASigner{Key: key}
 }
 
 func (k *ECDSASigner) Sign(b []byte) ([]byte, error) {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -128,8 +128,8 @@ func MarshalECDSAPrivateKey(priv *ecdsa.PrivateKey) ([]byte, error) {
 	return btcPriv.Serialize(), nil
 }
 
-// GenerateECDSAKey generates a new key based on the secp256k1 elliptic curve.
-func GenerateECDSAKey() (*ecdsa.PrivateKey, error) {
+// GenerateECDSAPrivateKey generates a new key based on the secp256k1 elliptic curve.
+func GenerateECDSAPrivateKey() (*ecdsa.PrivateKey, error) {
 	return ecdsa.GenerateKey(btcec.S256(), rand.Reader)
 }
 
@@ -264,7 +264,7 @@ func GetAddressFromKey(key goCrypto.PrivateKey) (types.Address, error) {
 
 // generateECDSAKeyAndMarshal generates a new ECDSA private key and serializes it to a byte array
 func generateECDSAKeyAndMarshal() ([]byte, error) {
-	key, err := GenerateECDSAKey()
+	key, err := GenerateECDSAPrivateKey()
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestKeyEncoding(t *testing.T) {
 	for i := 0; i < 10; i++ {
-		priv, _ := GenerateECDSAKey()
+		priv, _ := GenerateECDSAPrivateKey()
 
 		// marshall private key
 		buf, err := MarshalECDSAPrivateKey(priv)
@@ -461,7 +461,7 @@ func TestRecoverPublicKey(t *testing.T) {
 
 		hash := types.BytesToHash([]byte{0, 1, 2})
 
-		privateKey, err := GenerateECDSAKey()
+		privateKey, err := GenerateECDSAPrivateKey()
 		require.NoError(t, err)
 
 		signature, err := Sign(privateKey, hash.Bytes())

--- a/crypto/ecdsa_key.go
+++ b/crypto/ecdsa_key.go
@@ -1,0 +1,76 @@
+package crypto
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/0xPolygon/polygon-edge/types"
+)
+
+type Key interface {
+	Address() types.Address
+	Sign(hash []byte) ([]byte, error)
+}
+
+var _ Key = (*ECDSAKey)(nil)
+
+type ECDSAKey struct {
+	priv *ecdsa.PrivateKey
+	pub  *ecdsa.PublicKey
+	addr types.Address
+}
+
+// NewECDSAKey returns new instance of ECDSAKey
+func NewECDSAKey(priv *ecdsa.PrivateKey) *ECDSAKey {
+	return &ECDSAKey{
+		priv: priv,
+		pub:  &priv.PublicKey,
+		addr: PubKeyToAddress(&priv.PublicKey),
+	}
+}
+
+// GenerateECDSAKey generates an ECDSA private key and wraps it into ECDSA key
+// (that is a wrapper for ECDSA private key and holds private key, public key and address)
+func GenerateECDSAKey() (*ECDSAKey, error) {
+	privKey, err := GenerateECDSAPrivateKey()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewECDSAKey(privKey), nil
+}
+
+// NewECDSAKeyFromRawPrivECDSA parses provided
+func NewECDSAKeyFromRawPrivECDSA(rawPrivKey []byte) (*ECDSAKey, error) {
+	priv, err := ParseECDSAPrivateKey(rawPrivKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewECDSAKey(priv), nil
+}
+
+// Sign uses the private key and signs the provided hash which produces a signature as a result
+func (k *ECDSAKey) Sign(hash []byte) ([]byte, error) {
+	return Sign(k.priv, hash)
+}
+
+// Address is a getter function for Ethereum address derived from the public key
+func (k *ECDSAKey) Address() types.Address {
+	return k.addr
+}
+
+// MarshallPrivateKey returns 256-bit big-endian binary-encoded representation of the private key
+// padded to a length of 32 bytes.
+func (k *ECDSAKey) MarshallPrivateKey() ([]byte, error) {
+	btcPrivKey, err := convertToBtcPrivKey(k.priv)
+	if err != nil {
+		return nil, err
+	}
+
+	return btcPrivKey.Serialize(), nil
+}
+
+// String returns hex encoded ECDSA address
+func (k *ECDSAKey) String() string {
+	return k.addr.String()
+}

--- a/crypto/txsigner.go
+++ b/crypto/txsigner.go
@@ -33,7 +33,7 @@ type TxSigner interface {
 	SignTx(tx *types.Transaction, priv *ecdsa.PrivateKey) (*types.Transaction, error)
 
 	// SignTxWithCallback signs a transaction by using a custom callback
-	SignTxWithCallback(tx *types.Transaction, signFn func(hash []byte) (sig []byte, err error)) (*types.Transaction, error)
+	SignTxWithCallback(tx *types.Transaction, signFn func(hash types.Hash) (sig []byte, err error)) (*types.Transaction, error)
 }
 
 // NewSigner creates a new signer based on currently supported forks

--- a/crypto/txsigner.go
+++ b/crypto/txsigner.go
@@ -29,8 +29,8 @@ type TxSigner interface {
 	// Sender returns the sender of the transaction
 	Sender(*types.Transaction) (types.Address, error)
 
-	// SignTx signs a transaction
-	SignTx(tx *types.Transaction, priv *ecdsa.PrivateKey) (*types.Transaction, error)
+	// SignTx takes the original transaction as input and returns its signed version
+	SignTx(*types.Transaction, *ecdsa.PrivateKey) (*types.Transaction, error)
 
 	// SignTxWithCallback signs a transaction by using a custom callback
 	SignTxWithCallback(tx *types.Transaction,

--- a/crypto/txsigner.go
+++ b/crypto/txsigner.go
@@ -33,7 +33,8 @@ type TxSigner interface {
 	SignTx(tx *types.Transaction, priv *ecdsa.PrivateKey) (*types.Transaction, error)
 
 	// SignTxWithCallback signs a transaction by using a custom callback
-	SignTxWithCallback(tx *types.Transaction, signFn func(hash types.Hash) (sig []byte, err error)) (*types.Transaction, error)
+	SignTxWithCallback(tx *types.Transaction,
+		signFn func(hash types.Hash) (sig []byte, err error)) (*types.Transaction, error)
 }
 
 // NewSigner creates a new signer based on currently supported forks

--- a/crypto/txsigner.go
+++ b/crypto/txsigner.go
@@ -29,8 +29,11 @@ type TxSigner interface {
 	// Sender returns the sender of the transaction
 	Sender(*types.Transaction) (types.Address, error)
 
-	// SingTx takes the original transaction as input and returns its signed version
-	SignTx(*types.Transaction, *ecdsa.PrivateKey) (*types.Transaction, error)
+	// SignTx signs a transaction
+	SignTx(tx *types.Transaction, priv *ecdsa.PrivateKey) (*types.Transaction, error)
+
+	// SignTxWithCallback signs a transaction by using a custom callback
+	SignTxWithCallback(tx *types.Transaction, signFn func(hash []byte) (sig []byte, err error)) (*types.Transaction, error)
 }
 
 // NewSigner creates a new signer based on currently supported forks

--- a/crypto/txsigner_berlin.go
+++ b/crypto/txsigner_berlin.go
@@ -113,7 +113,7 @@ func (signer *BerlinSigner) Sender(tx *types.Transaction) (types.Address, error)
 	return recoverAddress(signer.Hash(tx), r, s, v, true)
 }
 
-// SingTx takes the original transaction as input and returns its signed version
+// SignTx takes the original transaction as input and returns its signed version
 func (signer *BerlinSigner) SignTx(tx *types.Transaction, privateKey *ecdsa.PrivateKey) (*types.Transaction, error) {
 	if tx.Type() == types.DynamicFeeTxType {
 		return nil, types.ErrTxTypeNotSupported
@@ -124,7 +124,6 @@ func (signer *BerlinSigner) SignTx(tx *types.Transaction, privateKey *ecdsa.Priv
 	}
 
 	tx = tx.Copy()
-
 	h := signer.Hash(tx)
 
 	sig, err := Sign(privateKey, h[:])

--- a/crypto/txsigner_eip155.go
+++ b/crypto/txsigner_eip155.go
@@ -118,14 +118,13 @@ func (signer *EIP155Signer) Sender(tx *types.Transaction) (types.Address, error)
 	return recoverAddress(signer.Hash(tx), r, s, bigV, true)
 }
 
-// SingTx takes the original transaction as input and returns its signed version
+// SignTx takes the original transaction as input and returns its signed version
 func (signer *EIP155Signer) SignTx(tx *types.Transaction, privateKey *ecdsa.PrivateKey) (*types.Transaction, error) {
 	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType {
 		return nil, types.ErrTxTypeNotSupported
 	}
 
 	tx = tx.Copy()
-
 	hash := signer.Hash(tx)
 
 	signature, err := Sign(privateKey, hash[:])

--- a/crypto/txsigner_eip155.go
+++ b/crypto/txsigner_eip155.go
@@ -139,11 +139,11 @@ func (signer *EIP155Signer) SignTx(tx *types.Transaction, privateKey *ecdsa.Priv
 }
 
 func (e *EIP155Signer) SignTxWithCallback(tx *types.Transaction,
-	signFn func(hash []byte) (sig []byte, err error)) (*types.Transaction, error) {
+	signFn func(hash types.Hash) (sig []byte, err error)) (*types.Transaction, error) {
 	tx = tx.Copy()
 	h := e.Hash(tx)
 
-	signature, err := signFn(h.Bytes())
+	signature, err := signFn(h)
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/txsigner_eip155.go
+++ b/crypto/txsigner_eip155.go
@@ -132,7 +132,12 @@ func (signer *EIP155Signer) SignTx(tx *types.Transaction, privateKey *ecdsa.Priv
 		return nil, err
 	}
 
-	tx.SplitToRawSignatureValues(sig, e.calculateV(sig[64]))
+	tx.SplitToRawSignatureValues(signature, signer.calculateV(signature[64]))
+
+	_, _, s := tx.RawSignatureValues()
+	if s.Cmp(secp256k1NHalf) > 0 {
+		return nil, errors.New("SignTx method: S must be inclusively lower than secp256k1n/2")
+	}
 
 	return tx, nil
 }

--- a/crypto/txsigner_eip155.go
+++ b/crypto/txsigner_eip155.go
@@ -144,6 +144,10 @@ func (signer *EIP155Signer) SignTx(tx *types.Transaction, privateKey *ecdsa.Priv
 
 func (e *EIP155Signer) SignTxWithCallback(tx *types.Transaction,
 	signFn func(hash types.Hash) (sig []byte, err error)) (*types.Transaction, error) {
+	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType {
+		return nil, types.ErrTxTypeNotSupported
+	}
+
 	tx = tx.Copy()
 	h := e.Hash(tx)
 

--- a/crypto/txsigner_eip155_test.go
+++ b/crypto/txsigner_eip155_test.go
@@ -65,7 +65,7 @@ func TestEIP155Signer_Sender(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			key, keyGenError := GenerateECDSAKey()
+			key, keyGenError := GenerateECDSAPrivateKey()
 			if keyGenError != nil {
 				t.Fatalf("Unable to generate key")
 			}
@@ -100,7 +100,7 @@ func TestEIP155Signer_ChainIDMismatch(t *testing.T) {
 	toAddress := types.StringToAddress("1")
 
 	for _, chainIDTop := range chainIDS {
-		key, keyGenError := GenerateECDSAKey()
+		key, keyGenError := GenerateECDSAPrivateKey()
 		if keyGenError != nil {
 			t.Fatalf("Unable to generate key")
 		}

--- a/crypto/txsigner_frontier.go
+++ b/crypto/txsigner_frontier.go
@@ -95,7 +95,8 @@ func (signer *FrontierSigner) SignTx(tx *types.Transaction, privateKey *ecdsa.Pr
 }
 
 // signTxInternal takes the original transaction as input and returns its signed version
-func (signer *FrontierSigner) signTxInternal(tx *types.Transaction, privateKey *ecdsa.PrivateKey) (*types.Transaction, error) {
+func (signer *FrontierSigner) signTxInternal(tx *types.Transaction,
+	privateKey *ecdsa.PrivateKey) (*types.Transaction, error) {
 	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType {
 		return nil, types.ErrTxTypeNotSupported
 	}

--- a/crypto/txsigner_frontier.go
+++ b/crypto/txsigner_frontier.go
@@ -89,14 +89,13 @@ func (signer *FrontierSigner) sender(tx *types.Transaction, isHomestead bool) (t
 	return recoverAddress(signer.Hash(tx), r, s, parity, isHomestead)
 }
 
-// SingTx takes the original transaction as input and returns its signed version
+// SignTx takes the original transaction as input and returns its signed version
 func (signer *FrontierSigner) SignTx(tx *types.Transaction, privateKey *ecdsa.PrivateKey) (*types.Transaction, error) {
-	return signer.signTx(tx, privateKey, nil)
+	return signer.signTxInternal(tx, privateKey)
 }
 
-// SingTx takes the original transaction as input and returns its signed version
-func (signer *FrontierSigner) signTx(tx *types.Transaction, privateKey *ecdsa.PrivateKey,
-	validateFn func(v, r, s *big.Int) error) (*types.Transaction, error) {
+// signTxInternal takes the original transaction as input and returns its signed version
+func (signer *FrontierSigner) signTxInternal(tx *types.Transaction, privateKey *ecdsa.PrivateKey) (*types.Transaction, error) {
 	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType {
 		return nil, types.ErrTxTypeNotSupported
 	}
@@ -109,7 +108,7 @@ func (signer *FrontierSigner) signTx(tx *types.Transaction, privateKey *ecdsa.Pr
 		return nil, err
 	}
 
-	tx.SplitToRawSignatureValues(sig, f.calculateV(sig[64]))
+	tx.SplitToRawSignatureValues(signature, signer.calculateV(signature[64]))
 
 	return tx, nil
 }

--- a/crypto/txsigner_frontier.go
+++ b/crypto/txsigner_frontier.go
@@ -102,7 +102,7 @@ func (signer *FrontierSigner) signTxInternal(tx *types.Transaction,
 	}
 
 	tx = tx.Copy()
-	h := f.Hash(tx)
+	hash := signer.Hash(tx)
 
 	signature, err := Sign(privateKey, hash[:])
 	if err != nil {

--- a/crypto/txsigner_frontier.go
+++ b/crypto/txsigner_frontier.go
@@ -117,6 +117,10 @@ func (signer *FrontierSigner) signTxInternal(tx *types.Transaction,
 func (f *FrontierSigner) SignTxWithCallback(
 	tx *types.Transaction,
 	signFn func(hash types.Hash) (sig []byte, err error)) (*types.Transaction, error) {
+	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType {
+		return nil, types.ErrTxTypeNotSupported
+	}
+
 	tx = tx.Copy()
 	h := f.Hash(tx)
 

--- a/crypto/txsigner_frontier.go
+++ b/crypto/txsigner_frontier.go
@@ -116,11 +116,11 @@ func (signer *FrontierSigner) signTx(tx *types.Transaction, privateKey *ecdsa.Pr
 
 func (f *FrontierSigner) SignTxWithCallback(
 	tx *types.Transaction,
-	signFn func(hash []byte) (sig []byte, err error)) (*types.Transaction, error) {
+	signFn func(hash types.Hash) (sig []byte, err error)) (*types.Transaction, error) {
 	tx = tx.Copy()
 	h := f.Hash(tx)
 
-	signature, err := signFn(h.Bytes())
+	signature, err := signFn(h)
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/txsigner_frontier_test.go
+++ b/crypto/txsigner_frontier_test.go
@@ -12,7 +12,7 @@ func TestFrontierSigner(t *testing.T) {
 	signer := &FrontierSigner{}
 
 	toAddress := types.StringToAddress("1")
-	key, err := GenerateECDSAKey()
+	key, err := GenerateECDSAPrivateKey()
 	assert.NoError(t, err)
 
 	txn := types.NewTx(types.NewLegacyTx(

--- a/crypto/txsigner_london.go
+++ b/crypto/txsigner_london.go
@@ -115,14 +115,13 @@ func (signer *LondonSigner) Sender(tx *types.Transaction) (types.Address, error)
 	return recoverAddress(signer.Hash(tx), r, s, v, true)
 }
 
-// SingTx takes the original transaction as input and returns its signed version
+// SignTx takes the original transaction as input and returns its signed version
 func (signer *LondonSigner) SignTx(tx *types.Transaction, privateKey *ecdsa.PrivateKey) (*types.Transaction, error) {
 	if tx.Type() != types.DynamicFeeTxType {
 		return signer.BerlinSigner.SignTx(tx, privateKey)
 	}
 
 	tx = tx.Copy()
-
 	h := signer.Hash(tx)
 
 	sig, err := Sign(privateKey, h[:])

--- a/crypto/txsigner_london_test.go
+++ b/crypto/txsigner_london_test.go
@@ -67,7 +67,7 @@ func TestLondonSignerSender(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			key, err := GenerateECDSAKey()
+			key, err := GenerateECDSAPrivateKey()
 			require.NoError(t, err, "unable to generate private key")
 
 			var txn *types.Transaction

--- a/e2e-polybft/e2e/acls_test.go
+++ b/e2e-polybft/e2e/acls_test.go
@@ -37,8 +37,8 @@ func TestE2E_AllowList_ContractDeployment(t *testing.T) {
 	admin, _ := crypto.GenerateECDSAKey()
 	target, _ := crypto.GenerateECDSAKey()
 
-	adminAddr := types.Address(admin.Address())
-	targetAddr := types.Address(target.Address())
+	adminAddr := admin.Address()
+	targetAddr := target.Address()
 
 	otherAddr := types.Address{0x1}
 

--- a/e2e-polybft/e2e/acls_test.go
+++ b/e2e-polybft/e2e/acls_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/state/runtime/addresslist"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/require"
-	"github.com/umbracle/ethgo/wallet"
 )
 
 // Contract used as bytecode
@@ -368,9 +367,9 @@ func TestE2E_AddressLists_Bridge(t *testing.T) {
 	// create two accounts, one for an admin sender and a second
 	// one for a non-enabled account that will switch on-off between
 	// both enabled and non-enabled roles.
-	admin, _ := wallet.GenerateKey()
-	target, _ := wallet.GenerateKey()
-	other, _ := wallet.GenerateKey()
+	admin, _ := crypto.GenerateECDSAKey()
+	target, _ := crypto.GenerateECDSAKey()
+	other, _ := crypto.GenerateECDSAKey()
 
 	adminAddr := types.Address(admin.Address())
 	targetAddr := types.Address(target.Address())

--- a/e2e-polybft/e2e/acls_test.go
+++ b/e2e-polybft/e2e/acls_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/state/runtime/addresslist"
@@ -34,8 +35,8 @@ func TestE2E_AllowList_ContractDeployment(t *testing.T) {
 	// create two accounts, one for an admin sender and a second
 	// one for a non-enabled account that will switch on-off between
 	// both enabled and non-enabled roles.
-	admin, _ := wallet.GenerateKey()
-	target, _ := wallet.GenerateKey()
+	admin, _ := crypto.GenerateECDSAKey()
+	target, _ := crypto.GenerateECDSAKey()
 
 	adminAddr := types.Address(admin.Address())
 	targetAddr := types.Address(target.Address())
@@ -132,17 +133,14 @@ func TestE2E_BlockList_ContractDeployment(t *testing.T) {
 	// create two accounts, one for an admin sender and a second
 	// one for a non-enabled account that will switch on-off between
 	// both enabled and non-enabled roles.
-	admin, _ := wallet.GenerateKey()
-	target, _ := wallet.GenerateKey()
-
-	adminAddr := types.Address(admin.Address())
-	targetAddr := types.Address(target.Address())
+	admin, _ := crypto.GenerateECDSAKey()
+	target, _ := crypto.GenerateECDSAKey()
 
 	otherAddr := types.Address{0x1}
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithPremine(adminAddr, targetAddr),
-		framework.WithContractDeployerBlockListAdmin(adminAddr),
+		framework.WithPremine(admin.Address(), target.Address()),
+		framework.WithContractDeployerBlockListAdmin(admin.Address()),
 		framework.WithContractDeployerBlockListEnabled(otherAddr),
 	)
 	defer cluster.Stop()
@@ -155,8 +153,8 @@ func TestE2E_BlockList_ContractDeployment(t *testing.T) {
 
 	{
 		// Step 0. Check the role of accounts
-		expectRole(t, cluster, contracts.BlockListContractsAddr, adminAddr, addresslist.AdminRole)
-		expectRole(t, cluster, contracts.BlockListContractsAddr, targetAddr, addresslist.NoRole)
+		expectRole(t, cluster, contracts.BlockListContractsAddr, admin.Address(), addresslist.AdminRole)
+		expectRole(t, cluster, contracts.BlockListContractsAddr, target.Address(), addresslist.NoRole)
 		expectRole(t, cluster, contracts.BlockListContractsAddr, otherAddr, addresslist.EnabledRole)
 	}
 
@@ -184,11 +182,11 @@ func TestE2E_BlockList_ContractDeployment(t *testing.T) {
 
 	{
 		// Step 4. 'adminAddr' sends a transaction to enable 'targetAddr'.
-		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{targetAddr})
+		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{target.Address()})
 
 		adminSetTxn := cluster.MethodTxn(t, admin, contracts.BlockListContractsAddr, input)
 		require.NoError(t, adminSetTxn.Wait())
-		expectRole(t, cluster, contracts.BlockListContractsAddr, targetAddr, addresslist.EnabledRole)
+		expectRole(t, cluster, contracts.BlockListContractsAddr, target.Address(), addresslist.EnabledRole)
 	}
 
 	{
@@ -215,18 +213,14 @@ func TestE2E_AllowList_Transactions(t *testing.T) {
 	// create two accounts, one for an admin sender and a second
 	// one for a non-enabled account that will switch on-off between
 	// both enabled and non-enabled roles.
-	admin, _ := wallet.GenerateKey()
-	target, _ := wallet.GenerateKey()
-	other, _ := wallet.GenerateKey()
-
-	adminAddr := types.Address(admin.Address())
-	targetAddr := types.Address(target.Address())
-	otherAddr := types.Address(other.Address())
+	admin, _ := crypto.GenerateECDSAKey()
+	target, _ := crypto.GenerateECDSAKey()
+	other, _ := crypto.GenerateECDSAKey()
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithPremine(adminAddr, targetAddr, otherAddr),
-		framework.WithTransactionsAllowListAdmin(adminAddr),
-		framework.WithTransactionsAllowListEnabled(otherAddr),
+		framework.WithPremine(admin.Address(), target.Address(), other.Address()),
+		framework.WithTransactionsAllowListAdmin(admin.Address()),
+		framework.WithTransactionsAllowListEnabled(other.Address()),
 	)
 	defer cluster.Stop()
 
@@ -237,9 +231,9 @@ func TestE2E_AllowList_Transactions(t *testing.T) {
 
 	{
 		// Step 0. Check the role of both accounts
-		expectRole(t, cluster, contracts.AllowListTransactionsAddr, adminAddr, addresslist.AdminRole)
-		expectRole(t, cluster, contracts.AllowListTransactionsAddr, targetAddr, addresslist.NoRole)
-		expectRole(t, cluster, contracts.AllowListTransactionsAddr, otherAddr, addresslist.EnabledRole)
+		expectRole(t, cluster, contracts.AllowListTransactionsAddr, admin.Address(), addresslist.AdminRole)
+		expectRole(t, cluster, contracts.AllowListTransactionsAddr, target.Address(), addresslist.NoRole)
+		expectRole(t, cluster, contracts.AllowListTransactionsAddr, other.Address(), addresslist.EnabledRole)
 	}
 
 	{
@@ -268,11 +262,11 @@ func TestE2E_AllowList_Transactions(t *testing.T) {
 
 	{
 		// Step 3. 'adminAddr' sends a transaction to enable 'targetAddr'.
-		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{targetAddr})
+		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{target.Address()})
 
 		adminSetTxn := cluster.MethodTxn(t, admin, contracts.AllowListTransactionsAddr, input)
 		require.NoError(t, adminSetTxn.Wait())
-		expectRole(t, cluster, contracts.AllowListTransactionsAddr, targetAddr, addresslist.EnabledRole)
+		expectRole(t, cluster, contracts.AllowListTransactionsAddr, target.Address(), addresslist.EnabledRole)
 	}
 
 	{
@@ -295,12 +289,12 @@ func TestE2E_AllowList_Transactions(t *testing.T) {
 
 	{
 		// Step 6. 'adminAddr' sends a transaction to disable himself.
-		input, _ := addresslist.SetNoneFunc.Encode([]interface{}{adminAddr})
+		input, _ := addresslist.SetNoneFunc.Encode([]interface{}{admin.Address()})
 
 		noneSetTxn := cluster.MethodTxn(t, admin, contracts.AllowListTransactionsAddr, input)
 		require.NoError(t, noneSetTxn.Wait())
 		require.True(t, noneSetTxn.Failed())
-		expectRole(t, cluster, contracts.AllowListTransactionsAddr, adminAddr, addresslist.AdminRole)
+		expectRole(t, cluster, contracts.AllowListTransactionsAddr, admin.Address(), addresslist.AdminRole)
 	}
 }
 
@@ -308,18 +302,14 @@ func TestE2E_BlockList_Transactions(t *testing.T) {
 	// create two accounts, one for an admin sender and a second
 	// one for a non-enabled account that will switch on-off between
 	// both enabled and non-enabled roles.
-	admin, _ := wallet.GenerateKey()
-	target, _ := wallet.GenerateKey()
-	other, _ := wallet.GenerateKey()
-
-	adminAddr := types.Address(admin.Address())
-	targetAddr := types.Address(target.Address())
-	otherAddr := types.Address(other.Address())
+	admin, _ := crypto.GenerateECDSAKey()
+	target, _ := crypto.GenerateECDSAKey()
+	other, _ := crypto.GenerateECDSAKey()
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithPremine(adminAddr, targetAddr, otherAddr),
-		framework.WithTransactionsBlockListAdmin(adminAddr),
-		framework.WithTransactionsBlockListEnabled(otherAddr),
+		framework.WithPremine(admin.Address(), target.Address(), other.Address()),
+		framework.WithTransactionsBlockListAdmin(admin.Address()),
+		framework.WithTransactionsBlockListEnabled(other.Address()),
 	)
 	defer cluster.Stop()
 
@@ -327,9 +317,9 @@ func TestE2E_BlockList_Transactions(t *testing.T) {
 
 	{
 		// Step 0. Check the role of both accounts
-		expectRole(t, cluster, contracts.BlockListTransactionsAddr, adminAddr, addresslist.AdminRole)
-		expectRole(t, cluster, contracts.BlockListTransactionsAddr, targetAddr, addresslist.NoRole)
-		expectRole(t, cluster, contracts.BlockListTransactionsAddr, otherAddr, addresslist.EnabledRole)
+		expectRole(t, cluster, contracts.BlockListTransactionsAddr, admin.Address(), addresslist.AdminRole)
+		expectRole(t, cluster, contracts.BlockListTransactionsAddr, target.Address(), addresslist.NoRole)
+		expectRole(t, cluster, contracts.BlockListTransactionsAddr, other.Address(), addresslist.EnabledRole)
 	}
 
 	{
@@ -359,11 +349,11 @@ func TestE2E_BlockList_Transactions(t *testing.T) {
 
 	{
 		// Step 4. 'adminAddr' sends a transaction to enable 'targetAddr'.
-		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{targetAddr})
+		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{target.Address()})
 
 		adminSetTxn := cluster.MethodTxn(t, admin, contracts.BlockListTransactionsAddr, input)
 		require.NoError(t, adminSetTxn.Wait())
-		expectRole(t, cluster, contracts.BlockListTransactionsAddr, targetAddr, addresslist.EnabledRole)
+		expectRole(t, cluster, contracts.BlockListTransactionsAddr, target.Address(), addresslist.EnabledRole)
 	}
 
 	{

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -100,7 +100,7 @@ func TestE2E_Bridge_RootchainTokensTransfers(t *testing.T) {
 	deployerKey, err := bridgeHelper.DecodePrivateKey("")
 	require.NoError(t, err)
 
-	deployTx := types.NewTx(&types.MixedTxn{
+	deployTx := types.NewTx(&types.LegacyTx{
 		To:    nil,
 		Input: contractsapi.RootERC20.Bytecode,
 	})
@@ -335,7 +335,7 @@ func TestE2E_Bridge_ERC721Transfer(t *testing.T) {
 	rootchainDeployer, err := bridgeHelper.DecodePrivateKey("")
 	require.NoError(t, err)
 
-	deployTx := types.NewTx(&types.MixedTxn{
+	deployTx := types.NewTx(&types.LegacyTx{
 		To:    nil,
 		Input: contractsapi.RootERC721.Bytecode,
 	})
@@ -507,7 +507,7 @@ func TestE2E_Bridge_ERC1155Transfer(t *testing.T) {
 	rootchainDeployer, err := bridgeHelper.DecodePrivateKey("")
 	require.NoError(t, err)
 
-	deployTx := types.NewTx(&types.MixedTxn{
+	deployTx := types.NewTx(&types.LegacyTx{
 		To:    nil,
 		Input: contractsapi.RootERC1155.Bytecode,
 	})
@@ -1100,7 +1100,7 @@ func TestE2E_Bridge_Transfers_AccessLists(t *testing.T) {
 	deployerKey, err := bridgeHelper.DecodePrivateKey("")
 	require.NoError(t, err)
 
-	deployTx := types.NewTx(&types.MixedTxn{
+	deployTx := types.NewTx(&types.LegacyTx{
 		To:    nil,
 		Input: contractsapi.RootERC20.Bytecode,
 	})
@@ -1518,10 +1518,9 @@ func TestE2E_Bridge_L1OriginatedNativeToken_ERC20StakingToken(t *testing.T) {
 
 	nonNativeErc20 := polybftCfg.StakeTokenAddr
 
-	mintTx := types.NewTx(&types.MixedTxn{
+	mintTx := types.NewTx(&types.DynamicFeeTx{
 		To:    &nonNativeErc20,
 		Input: mintInput,
-		Type:  types.DynamicFeeTx,
 	})
 
 	receipt, err := relayer.SendTransaction(mintTx, minter)

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/umbracle/ethgo"
-	"github.com/umbracle/ethgo/wallet"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
@@ -54,7 +53,7 @@ func TestE2E_Bridge_RootchainTokensTransfers(t *testing.T) {
 	receiverKeys := make([]string, transfersCount)
 
 	for i := 0; i < transfersCount; i++ {
-		key, err := wallet.GenerateKey()
+		key, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
 		rawKey, err := key.MarshallPrivateKey()
@@ -299,7 +298,7 @@ func TestE2E_Bridge_ERC721Transfer(t *testing.T) {
 	tokenIDs := make([]string, transfersCount)
 
 	for i := 0; i < transfersCount; i++ {
-		key, err := wallet.GenerateKey()
+		key, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
 		rawKey, err := key.MarshallPrivateKey()
@@ -469,7 +468,7 @@ func TestE2E_Bridge_ERC1155Transfer(t *testing.T) {
 	tokenIDs := make([]string, transfersCount)
 
 	for i := 0; i < transfersCount; i++ {
-		key, err := wallet.GenerateKey()
+		key, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
 		rawKey, err := key.MarshallPrivateKey()
@@ -679,7 +678,7 @@ func TestE2E_Bridge_ChildchainTokensTransfer(t *testing.T) {
 	adminAddr := types.Address(admin.Address())
 
 	for i := uint64(0); i < transfersCount; i++ {
-		key, err := wallet.GenerateKey()
+		key, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
 		rawKey, err := key.MarshallPrivateKey()
@@ -1257,13 +1256,13 @@ func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 		bigZero               = big.NewInt(0)
 	)
 
-	nonValidatorKey, err := wallet.GenerateKey()
+	nonValidatorKey, err := crypto.GenerateECDSAKey()
 	require.NoError(t, err)
 
 	nonValidatorKeyRaw, err := nonValidatorKey.MarshallPrivateKey()
 	require.NoError(t, err)
 
-	rewardWalletKey, err := wallet.GenerateKey()
+	rewardWalletKey, err := crypto.GenerateECDSAKey()
 	require.NoError(t, err)
 
 	rewardWalletKeyRaw, err := rewardWalletKey.MarshallPrivateKey()
@@ -1388,7 +1387,7 @@ func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 		require.NoError(t, err)
 
 		nonValidatorBalanceAfterWithdraw, err := childEthEndpoint.GetBalance(
-			nonValidatorKey.Address(), ethgo.Latest)
+			ethgo.Address(nonValidatorKey.Address()), ethgo.Latest)
 		require.NoError(t, err)
 
 		currentBlock, err := childEthEndpoint.GetBlockByNumber(ethgo.Latest, false)

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -101,8 +101,10 @@ func TestE2E_Bridge_RootchainTokensTransfers(t *testing.T) {
 	require.NoError(t, err)
 
 	deployTx := types.NewTx(&types.LegacyTx{
-		To:    nil,
-		Input: contractsapi.RootERC20.Bytecode,
+		BaseTx: &types.BaseTx{
+			To:    nil,
+			Input: contractsapi.RootERC20.Bytecode,
+		},
 	})
 
 	receipt, err := rootchainTxRelayer.SendTransaction(deployTx, deployerKey)
@@ -336,8 +338,10 @@ func TestE2E_Bridge_ERC721Transfer(t *testing.T) {
 	require.NoError(t, err)
 
 	deployTx := types.NewTx(&types.LegacyTx{
-		To:    nil,
-		Input: contractsapi.RootERC721.Bytecode,
+		BaseTx: &types.BaseTx{
+			To:    nil,
+			Input: contractsapi.RootERC721.Bytecode,
+		},
 	})
 
 	// deploy root ERC 721 token
@@ -508,8 +512,10 @@ func TestE2E_Bridge_ERC1155Transfer(t *testing.T) {
 	require.NoError(t, err)
 
 	deployTx := types.NewTx(&types.LegacyTx{
-		To:    nil,
-		Input: contractsapi.RootERC1155.Bytecode,
+		BaseTx: &types.BaseTx{
+			To:    nil,
+			Input: contractsapi.RootERC1155.Bytecode,
+		},
 	})
 
 	// deploy root ERC 1155 token
@@ -1101,8 +1107,10 @@ func TestE2E_Bridge_Transfers_AccessLists(t *testing.T) {
 	require.NoError(t, err)
 
 	deployTx := types.NewTx(&types.LegacyTx{
-		To:    nil,
-		Input: contractsapi.RootERC20.Bytecode,
+		BaseTx: &types.BaseTx{
+			To:    nil,
+			Input: contractsapi.RootERC20.Bytecode,
+		},
 	})
 
 	// deploy root erc20 token
@@ -1519,8 +1527,10 @@ func TestE2E_Bridge_L1OriginatedNativeToken_ERC20StakingToken(t *testing.T) {
 	nonNativeErc20 := polybftCfg.StakeTokenAddr
 
 	mintTx := types.NewTx(&types.DynamicFeeTx{
-		To:    &nonNativeErc20,
-		Input: mintInput,
+		BaseTx: &types.BaseTx{
+			To:    &nonNativeErc20,
+			Input: mintInput,
+		},
 	})
 
 	receipt, err := relayer.SendTransaction(mintTx, minter)

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -1106,12 +1106,10 @@ func TestE2E_Bridge_Transfers_AccessLists(t *testing.T) {
 	deployerKey, err := bridgeHelper.DecodePrivateKey("")
 	require.NoError(t, err)
 
-	deployTx := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			To:    nil,
-			Input: contractsapi.RootERC20.Bytecode,
-		},
-	})
+	deployTx := types.NewTx(types.NewLegacyTx(
+		types.WithTo(nil),
+		types.WithInput(contractsapi.RootERC20.Bytecode),
+	))
 
 	// deploy root erc20 token
 	receipt, err := rootchainTxRelayer.SendTransaction(deployTx, deployerKey)
@@ -1526,12 +1524,10 @@ func TestE2E_Bridge_L1OriginatedNativeToken_ERC20StakingToken(t *testing.T) {
 
 	nonNativeErc20 := polybftCfg.StakeTokenAddr
 
-	mintTx := types.NewTx(&types.DynamicFeeTx{
-		BaseTx: &types.BaseTx{
-			To:    &nonNativeErc20,
-			Input: mintInput,
-		},
-	})
+	mintTx := types.NewTx(types.NewDynamicFeeTx(
+		types.WithTo(&nonNativeErc20),
+		types.WithInput(mintInput),
+	))
 
 	receipt, err := relayer.SendTransaction(mintTx, minter)
 	require.NoError(t, err)

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -100,12 +100,10 @@ func TestE2E_Bridge_RootchainTokensTransfers(t *testing.T) {
 	deployerKey, err := bridgeHelper.DecodePrivateKey("")
 	require.NoError(t, err)
 
-	deployTx := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			To:    nil,
-			Input: contractsapi.RootERC20.Bytecode,
-		},
-	})
+	deployTx := types.NewTx(types.NewLegacyTx(
+		types.WithTo(nil),
+		types.WithInput(contractsapi.RootERC20.Bytecode),
+	))
 
 	receipt, err := rootchainTxRelayer.SendTransaction(deployTx, deployerKey)
 	require.NoError(t, err)

--- a/e2e-polybft/e2e/burn_contract_test.go
+++ b/e2e-polybft/e2e/burn_contract_test.go
@@ -4,16 +4,16 @@ import (
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/require"
 	"github.com/umbracle/ethgo"
-	"github.com/umbracle/ethgo/wallet"
 )
 
 func TestE2E_BurnContract_Deployed(t *testing.T) {
-	contractKey, _ := wallet.GenerateKey()
-	destinationKey, _ := wallet.GenerateKey()
+	contractKey, _ := crypto.GenerateECDSAKey()
+	destinationKey, _ := crypto.GenerateECDSAKey()
 
 	contractAddr := types.Address(contractKey.Address())
 	destinationAddr := types.Address(destinationKey.Address())

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -445,8 +445,10 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 	require.NoError(t, err)
 
 	tx := types.NewTx(&types.DynamicFeeTx{
-		To:    &contracts.NativeERC20TokenContract,
-		Input: mintInput,
+		BaseTx: &types.BaseTx{
+			To:    &contracts.NativeERC20TokenContract,
+			Input: mintInput,
+		},
 	})
 
 	receipt, err := relayer.SendTransaction(tx, minter)
@@ -468,8 +470,10 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 	require.NoError(t, err)
 
 	tx = types.NewTx(&types.DynamicFeeTx{
-		To:    &contracts.NativeERC20TokenContract,
-		Input: mintInput,
+		BaseTx: &types.BaseTx{
+			To:    &contracts.NativeERC20TokenContract,
+			Input: mintInput,
+		},
 	})
 
 	receipt, err = relayer.SendTransaction(tx, nonMinterAcc.Ecdsa)
@@ -554,17 +558,21 @@ func TestE2E_Consensus_EIP1559Check(t *testing.T) {
 
 	txns := []*types.Transaction{
 		types.NewTx(&types.LegacyTx{
-			Value:    sendAmount,
-			To:       &recipient,
-			Gas:      21000,
-			Nonce:    uint64(0),
+			BaseTx: &types.BaseTx{
+				Value: sendAmount,
+				To:    &recipient,
+				Gas:   21000,
+				Nonce: uint64(0),
+			},
 			GasPrice: ethgo.Gwei(1),
 		}),
 		types.NewTx(&types.DynamicFeeTx{
-			Value:     sendAmount,
-			To:        &recipient,
-			Gas:       21000,
-			Nonce:     uint64(0),
+			BaseTx: &types.BaseTx{
+				Value: sendAmount,
+				To:    &recipient,
+				Gas:   21000,
+				Nonce: uint64(0),
+			},
 			GasFeeCap: ethgo.Gwei(1),
 			GasTipCap: ethgo.Gwei(1),
 		}),
@@ -763,7 +771,11 @@ func TestE2E_Deploy_Nested_Contract(t *testing.T) {
 
 	// deploy Wrapper contract
 	receipt, err := txRelayer.SendTransaction(
-		types.NewTx(&types.LegacyTx{Input: contractsapi.Wrapper.Bytecode}),
+		types.NewTx(&types.LegacyTx{
+			BaseTx: &types.BaseTx{
+				Input: contractsapi.Wrapper.Bytecode,
+			},
+		}),
 		admin)
 	require.NoError(t, err)
 
@@ -790,9 +802,11 @@ func TestE2E_Deploy_Nested_Contract(t *testing.T) {
 	require.NoError(t, err)
 
 	txn := types.NewTx(&types.LegacyTx{
-		From:  admin.Address(),
-		To:    &wrapperAddr,
-		Input: setValueInput,
+		BaseTx: &types.BaseTx{
+			From:  admin.Address(),
+			To:    &wrapperAddr,
+			Input: setValueInput,
+		},
 	})
 
 	receipt, err = txRelayer.SendTransaction(txn, admin)

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -444,12 +444,12 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 	mintInput, err := mintFn.EncodeAbi()
 	require.NoError(t, err)
 
-	tx := types.NewTx(&types.DynamicFeeTx{
-		BaseTx: &types.BaseTx{
-			To:    &contracts.NativeERC20TokenContract,
-			Input: mintInput,
-		},
-	})
+	tx := types.NewTx(
+		types.NewDynamicFeeTx(
+			types.WithTo(&contracts.NativeERC20TokenContract),
+			types.WithInput(mintInput),
+		),
+	)
 
 	receipt, err := relayer.SendTransaction(tx, minter)
 	require.NoError(t, err)
@@ -469,12 +469,10 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 	mintInput, err = mintFn.EncodeAbi()
 	require.NoError(t, err)
 
-	tx = types.NewTx(&types.DynamicFeeTx{
-		BaseTx: &types.BaseTx{
-			To:    &contracts.NativeERC20TokenContract,
-			Input: mintInput,
-		},
-	})
+	tx = types.NewTx(types.NewDynamicFeeTx(
+		types.WithTo(&contracts.NativeERC20TokenContract),
+		types.WithInput(mintInput),
+	))
 
 	receipt, err = relayer.SendTransaction(tx, nonMinterAcc.Ecdsa)
 	require.Error(t, err)
@@ -557,25 +555,21 @@ func TestE2E_Consensus_EIP1559Check(t *testing.T) {
 	sendAmount := ethgo.Gwei(1)
 
 	txns := []*types.Transaction{
-		types.NewTx(&types.LegacyTx{
-			BaseTx: &types.BaseTx{
-				Value: sendAmount,
-				To:    &recipient,
-				Gas:   21000,
-				Nonce: uint64(0),
-			},
-			GasPrice: ethgo.Gwei(1),
-		}),
-		types.NewTx(&types.DynamicFeeTx{
-			BaseTx: &types.BaseTx{
-				Value: sendAmount,
-				To:    &recipient,
-				Gas:   21000,
-				Nonce: uint64(0),
-			},
-			GasFeeCap: ethgo.Gwei(1),
-			GasTipCap: ethgo.Gwei(1),
-		}),
+		types.NewTx(types.NewLegacyTx(
+			types.WithValue(sendAmount),
+			types.WithTo(&recipient),
+			types.WithGas(21000),
+			types.WithNonce(uint64(0)),
+			types.WithGasPrice(ethgo.Gwei(1)),
+		)),
+		types.NewTx(types.NewDynamicFeeTx(
+			types.WithValue(sendAmount),
+			types.WithTo(&recipient),
+			types.WithGas(21000),
+			types.WithNonce(uint64(0)),
+			types.WithGasFeeCap(ethgo.Gwei(1)),
+			types.WithGasTipCap(ethgo.Gwei(1)),
+		)),
 	}
 
 	initialMinerBalance := big.NewInt(0)
@@ -801,13 +795,11 @@ func TestE2E_Deploy_Nested_Contract(t *testing.T) {
 	setValueInput, err := setNumberFn.Encode([]interface{}{numberToPersist})
 	require.NoError(t, err)
 
-	txn := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			From:  admin.Address(),
-			To:    &wrapperAddr,
-			Input: setValueInput,
-		},
-	})
+	txn := types.NewTx(types.NewLegacyTx(
+		types.WithFrom(admin.Address()),
+		types.WithTo(&wrapperAddr),
+		types.WithInput(setValueInput),
+	))
 
 	receipt, err = txRelayer.SendTransaction(txn, admin)
 	require.NoError(t, err)

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -444,10 +444,9 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 	mintInput, err := mintFn.EncodeAbi()
 	require.NoError(t, err)
 
-	tx := types.NewTx(&types.MixedTxn{
+	tx := types.NewTx(&types.DynamicFeeTx{
 		To:    &contracts.NativeERC20TokenContract,
 		Input: mintInput,
-		Type:  types.DynamicFeeTx,
 	})
 
 	receipt, err := relayer.SendTransaction(tx, minter)
@@ -468,10 +467,9 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 	mintInput, err = mintFn.EncodeAbi()
 	require.NoError(t, err)
 
-	tx = types.NewTx(&types.MixedTxn{
+	tx = types.NewTx(&types.DynamicFeeTx{
 		To:    &contracts.NativeERC20TokenContract,
 		Input: mintInput,
-		Type:  types.DynamicFeeTx,
 	})
 
 	receipt, err = relayer.SendTransaction(tx, nonMinterAcc.Ecdsa)
@@ -555,19 +553,18 @@ func TestE2E_Consensus_EIP1559Check(t *testing.T) {
 	sendAmount := ethgo.Gwei(1)
 
 	txns := []*types.Transaction{
-		types.NewTx(&types.MixedTxn{
+		types.NewTx(&types.LegacyTx{
 			Value:    sendAmount,
 			To:       &recipient,
 			Gas:      21000,
 			Nonce:    uint64(0),
 			GasPrice: ethgo.Gwei(1),
 		}),
-		types.NewTx(&types.MixedTxn{
+		types.NewTx(&types.DynamicFeeTx{
 			Value:     sendAmount,
 			To:        &recipient,
 			Gas:       21000,
 			Nonce:     uint64(0),
-			Type:      types.DynamicFeeTx,
 			GasFeeCap: ethgo.Gwei(1),
 			GasTipCap: ethgo.Gwei(1),
 		}),
@@ -766,7 +763,7 @@ func TestE2E_Deploy_Nested_Contract(t *testing.T) {
 
 	// deploy Wrapper contract
 	receipt, err := txRelayer.SendTransaction(
-		types.NewTx(&types.MixedTxn{Input: contractsapi.Wrapper.Bytecode}),
+		types.NewTx(&types.LegacyTx{Input: contractsapi.Wrapper.Bytecode}),
 		admin)
 	require.NoError(t, err)
 
@@ -792,7 +789,7 @@ func TestE2E_Deploy_Nested_Contract(t *testing.T) {
 	setValueInput, err := setNumberFn.Encode([]interface{}{numberToPersist})
 	require.NoError(t, err)
 
-	txn := types.NewTx(&types.MixedTxn{
+	txn := types.NewTx(&types.LegacyTx{
 		From:  admin.Address(),
 		To:    &wrapperAddr,
 		Input: setValueInput,

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/abi"
-	"github.com/umbracle/ethgo/wallet"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/genesis"
@@ -21,6 +20,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
@@ -179,13 +179,13 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 	addrs, err := cluster.InitSecrets(firstValidatorDataDir, 1)
 	require.NoError(t, err)
 
-	firstValidatorAddr := ethgo.Address(addrs[0])
+	firstValidatorAddr := addrs[0]
 
 	// create the second account and extract the address
 	addrs, err = cluster.InitSecrets(secondValidatorDataDir, 1)
 	require.NoError(t, err)
 
-	secondValidatorAddr := ethgo.Address(addrs[0])
+	secondValidatorAddr := addrs[0]
 
 	// assert that accounts are created
 	validatorSecrets, err := genesis.GetValidatorKeyFiles(cluster.Config.TmpDir, cluster.Config.ValidatorPrefix)
@@ -212,12 +212,12 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 		[]*big.Int{initialBalance, initialBalance}, polybftConfig.StakeTokenAddr))
 
 	// first validator's balance to be received
-	firstBalance, err := relayer.Client().Eth().GetBalance(firstValidatorAddr, ethgo.Latest)
+	firstBalance, err := relayer.Client().Eth().GetBalance(ethgo.Address(firstValidatorAddr), ethgo.Latest)
 	require.NoError(t, err)
 	t.Logf("First validator balance=%d\n", firstBalance)
 
 	// second validator's balance to be received
-	secondBalance, err := relayer.Client().Eth().GetBalance(secondValidatorAddr, ethgo.Latest)
+	secondBalance, err := relayer.Client().Eth().GetBalance(ethgo.Address(secondValidatorAddr), ethgo.Latest)
 	require.NoError(t, err)
 	t.Logf("Second validator balance=%d\n", secondBalance)
 
@@ -309,16 +309,16 @@ func TestE2E_Consensus_Validator_Unstake(t *testing.T) {
 
 	cluster.WaitForReady(t)
 
-	initialValidatorBalance, err := srv.JSONRPC().Eth().GetBalance(validatorAcc.Ecdsa.Address(), ethgo.Latest)
+	validatorAddr := ethgo.Address(validatorAcc.Ecdsa.Address())
+
+	initialValidatorBalance, err := srv.JSONRPC().Eth().GetBalance(validatorAddr, ethgo.Latest)
 	require.NoError(t, err)
 	t.Logf("Balance (before unstake)=%d\n", initialValidatorBalance)
-
-	validatorAddr := validatorAcc.Ecdsa.Address()
 
 	// wait for some rewards to get accumulated
 	require.NoError(t, cluster.WaitForBlock(polybftCfg.EpochSize*3, time.Minute))
 
-	validatorInfo, err := validatorHelper.GetValidatorInfo(validatorAddr, relayer)
+	validatorInfo, err := validatorHelper.GetValidatorInfo(validatorAcc.Address(), relayer)
 	require.NoError(t, err)
 	require.True(t, validatorInfo.IsActive)
 
@@ -340,21 +340,21 @@ func TestE2E_Consensus_Validator_Unstake(t *testing.T) {
 	require.NoError(t, srv.WitdhrawStake())
 
 	// check that validator is no longer active (out of validator set)
-	validatorInfo, err = validatorHelper.GetValidatorInfo(validatorAddr, relayer)
+	validatorInfo, err = validatorHelper.GetValidatorInfo(validatorAcc.Address(), relayer)
 	require.NoError(t, err)
 	require.False(t, validatorInfo.IsActive)
 	require.True(t, validatorInfo.Stake.Cmp(big.NewInt(0)) == 0)
 
 	t.Logf("Stake (after unstake and withdraw)=%d\n", validatorInfo.Stake)
 
-	balanceBeforeRewardsWithdraw, err := srv.JSONRPC().Eth().GetBalance(validatorAcc.Ecdsa.Address(), ethgo.Latest)
+	balanceBeforeRewardsWithdraw, err := srv.JSONRPC().Eth().GetBalance(validatorAddr, ethgo.Latest)
 	require.NoError(t, err)
 	t.Logf("Balance (before withdraw rewards)=%d\n", balanceBeforeRewardsWithdraw)
 
 	// withdraw pending rewards
 	require.NoError(t, srv.WithdrawRewards())
 
-	newValidatorBalance, err := srv.JSONRPC().Eth().GetBalance(validatorAcc.Ecdsa.Address(), ethgo.Latest)
+	newValidatorBalance, err := srv.JSONRPC().Eth().GetBalance(validatorAddr, ethgo.Latest)
 	require.NoError(t, err)
 	t.Logf("Balance (after withdrawal of rewards)=%s\n", newValidatorBalance)
 	require.True(t, newValidatorBalance.Cmp(balanceBeforeRewardsWithdraw) > 0)
@@ -374,10 +374,10 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 	initValidatorsBalance := ethgo.Ether(1)
 	initMinterBalance := ethgo.Ether(100000)
 
-	minter, err := wallet.GenerateKey()
+	minter, err := crypto.GenerateECDSAKey()
 	require.NoError(t, err)
 
-	receiver, err := wallet.GenerateKey()
+	receiver, err := crypto.GenerateECDSAKey()
 	require.NoError(t, err)
 
 	// because we are using native token as reward wallet, and it has default premine balance
@@ -430,35 +430,34 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 
 	// send mint transactions
 	mintAmount := ethgo.Ether(1)
-	nativeTokenAddr := ethgo.Address(contracts.NativeERC20TokenContract)
 
 	// make sure minter account can mint tokens
-	receiverAddr := types.Address(receiver.Address())
-	balanceBefore, err := targetJSONRPC.Eth().GetBalance(ethgo.Address(receiverAddr), ethgo.Latest)
+	balanceBefore, err := targetJSONRPC.Eth().GetBalance(ethgo.Address(receiver.Address()), ethgo.Latest)
 	require.NoError(t, err)
-	t.Logf("Pre-mint balance: %v=%d\n", receiverAddr, balanceBefore)
+	t.Logf("Pre-mint balance: %v=%d\n", receiver.Address(), balanceBefore)
 
 	mintFn := &contractsapi.MintRootERC20Fn{
-		To:     receiverAddr,
+		To:     receiver.Address(),
 		Amount: mintAmount,
 	}
 
 	mintInput, err := mintFn.EncodeAbi()
 	require.NoError(t, err)
 
-	receipt, err := relayer.SendTransaction(
-		&ethgo.Transaction{
-			To:    &nativeTokenAddr,
-			Input: mintInput,
-			Type:  ethgo.TransactionDynamicFee,
-		}, minter)
+	tx := types.NewTx(&types.MixedTxn{
+		To:    &contracts.NativeERC20TokenContract,
+		Input: mintInput,
+		Type:  types.DynamicFeeTx,
+	})
+
+	receipt, err := relayer.SendTransaction(tx, minter)
 	require.NoError(t, err)
 	require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
 
-	balanceAfter, err := targetJSONRPC.Eth().GetBalance(ethgo.Address(receiverAddr), ethgo.Latest)
+	balanceAfter, err := targetJSONRPC.Eth().GetBalance(ethgo.Address(receiver.Address()), ethgo.Latest)
 	require.NoError(t, err)
 
-	t.Logf("Post-mint balance: %v=%d\n", receiverAddr, balanceAfter)
+	t.Logf("Post-mint balance: %v=%d\n", receiver.Address(), balanceAfter)
 	require.True(t, balanceAfter.Cmp(new(big.Int).Add(mintAmount, balanceBefore)) >= 0)
 
 	// try sending mint transaction from non minter account and make sure it would fail
@@ -469,12 +468,13 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 	mintInput, err = mintFn.EncodeAbi()
 	require.NoError(t, err)
 
-	receipt, err = relayer.SendTransaction(
-		&ethgo.Transaction{
-			To:    &nativeTokenAddr,
-			Input: mintInput,
-			Type:  ethgo.TransactionDynamicFee,
-		}, nonMinterAcc.Ecdsa)
+	tx = types.NewTx(&types.MixedTxn{
+		To:    &contracts.NativeERC20TokenContract,
+		Input: mintInput,
+		Type:  types.DynamicFeeTx,
+	})
+
+	receipt, err = relayer.SendTransaction(tx, nonMinterAcc.Ecdsa)
 	require.Error(t, err)
 	require.Nil(t, receipt)
 }
@@ -515,10 +515,10 @@ func TestE2E_Consensus_CustomRewardToken(t *testing.T) {
 func TestE2E_Consensus_EIP1559Check(t *testing.T) {
 	t.Skip("TODO - since we removed burn from evm, this should be fixed after the burn solution")
 
-	sender, err := wallet.GenerateKey()
+	sender, err := crypto.GenerateECDSAKey()
 	require.NoError(t, err)
 
-	recipient := ethgo.Address(types.StringToAddress("1234"))
+	recipient := types.StringToAddress("1234")
 
 	// sender must have premined some native tokens
 	cluster := framework.NewTestCluster(t, 5,
@@ -536,9 +536,9 @@ func TestE2E_Consensus_EIP1559Check(t *testing.T) {
 
 	client := cluster.Servers[0].JSONRPC().Eth()
 
-	waitUntilBalancesChanged := func(_ ethgo.Address, initialBalance *big.Int) error {
+	waitUntilBalancesChanged := func(acct types.Address, initialBalance *big.Int) error {
 		err := cluster.WaitUntil(30*time.Second, 1*time.Second, func() bool {
-			balance, err := client.GetBalance(recipient, ethgo.Latest)
+			balance, err := client.GetBalance(ethgo.Address(acct), ethgo.Latest)
 			if err != nil {
 				return true
 			}
@@ -554,32 +554,32 @@ func TestE2E_Consensus_EIP1559Check(t *testing.T) {
 
 	sendAmount := ethgo.Gwei(1)
 
-	txns := []*ethgo.Transaction{
-		{
+	txns := []*types.Transaction{
+		types.NewTx(&types.MixedTxn{
 			Value:    sendAmount,
 			To:       &recipient,
 			Gas:      21000,
 			Nonce:    uint64(0),
-			GasPrice: ethgo.Gwei(1).Uint64(),
-		},
-		{
-			Value:                sendAmount,
-			To:                   &recipient,
-			Gas:                  21000,
-			Nonce:                uint64(0),
-			Type:                 ethgo.TransactionDynamicFee,
-			MaxFeePerGas:         ethgo.Gwei(1),
-			MaxPriorityFeePerGas: ethgo.Gwei(1),
-		},
+			GasPrice: ethgo.Gwei(1),
+		}),
+		types.NewTx(&types.MixedTxn{
+			Value:     sendAmount,
+			To:        &recipient,
+			Gas:       21000,
+			Nonce:     uint64(0),
+			Type:      types.DynamicFeeTx,
+			GasFeeCap: ethgo.Gwei(1),
+			GasTipCap: ethgo.Gwei(1),
+		}),
 	}
 
 	initialMinerBalance := big.NewInt(0)
 
-	var prevMiner ethgo.Address
+	prevMiner := ethgo.ZeroAddress
 
 	for i, txn := range txns {
-		senderInitialBalance, _ := client.GetBalance(sender.Address(), ethgo.Latest)
-		receiverInitialBalance, _ := client.GetBalance(recipient, ethgo.Latest)
+		senderInitialBalance, _ := client.GetBalance(ethgo.Address(sender.Address()), ethgo.Latest)
+		receiverInitialBalance, _ := client.GetBalance(ethgo.Address(recipient), ethgo.Latest)
 		burnContractInitialBalance, _ := client.GetBalance(ethgo.Address(types.ZeroAddress), ethgo.Latest)
 
 		receipt, err := relayer.SendTransaction(txn, sender)
@@ -597,8 +597,8 @@ func TestE2E_Consensus_EIP1559Check(t *testing.T) {
 			prevMiner = block.Miner
 		}
 
-		senderFinalBalance, _ := client.GetBalance(sender.Address(), ethgo.Latest)
-		receiverFinalBalance, _ := client.GetBalance(recipient, ethgo.Latest)
+		senderFinalBalance, _ := client.GetBalance(ethgo.Address(sender.Address()), ethgo.Latest)
+		receiverFinalBalance, _ := client.GetBalance(ethgo.Address(recipient), ethgo.Latest)
 		burnContractFinalBalance, _ := client.GetBalance(ethgo.Address(types.ZeroAddress), ethgo.Latest)
 
 		diffReceiverBalance := new(big.Int).Sub(receiverFinalBalance, receiverInitialBalance)
@@ -645,7 +645,7 @@ func TestE2E_Consensus_ChangeVotingPowerByStakingPendingRewards(t *testing.T) {
 	validatorSecretFiles, err := genesis.GetValidatorKeyFiles(cluster.Config.TmpDir, cluster.Config.ValidatorPrefix)
 	require.NoError(t, err)
 
-	votingPowerChangeValidators := make([]ethgo.Address, votingPowerChanges)
+	votingPowerChangeValidators := make([]types.Address, votingPowerChanges)
 
 	for i := 0; i < votingPowerChanges; i++ {
 		validator, err := validatorHelper.GetAccountFromDir(path.Join(cluster.Config.TmpDir, validatorSecretFiles[i]))
@@ -678,7 +678,7 @@ func TestE2E_Consensus_ChangeVotingPowerByStakingPendingRewards(t *testing.T) {
 	bigZero := big.NewInt(0)
 
 	// validatorsMap holds only changed validators
-	validatorsMap := make(map[ethgo.Address]*polybft.ValidatorInfo, votingPowerChanges)
+	validatorsMap := make(map[types.Address]*polybft.ValidatorInfo, votingPowerChanges)
 
 	queryValidators(func(idx int, validator *polybft.ValidatorInfo) {
 		t.Logf("[Validator#%d] Voting power (original)=%d, rewards=%d\n",
@@ -731,13 +731,11 @@ func TestE2E_Consensus_ChangeVotingPowerByStakingPendingRewards(t *testing.T) {
 		}
 
 		for addr, validator := range validatorsMap {
-			a := types.Address(addr)
-
-			if !currentExtra.Validators.Updated.ContainsAddress(a) {
+			if !currentExtra.Validators.Updated.ContainsAddress(addr) {
 				continue
 			}
 
-			if currentExtra.Validators.Updated.GetValidatorMetadata(a).VotingPower.Cmp(validator.Stake) != 0 {
+			if currentExtra.Validators.Updated.GetValidatorMetadata(addr).VotingPower.Cmp(validator.Stake) != 0 {
 				continue
 			}
 		}
@@ -755,12 +753,10 @@ func TestE2E_Consensus_ChangeVotingPowerByStakingPendingRewards(t *testing.T) {
 func TestE2E_Deploy_Nested_Contract(t *testing.T) {
 	numberToPersist := big.NewInt(234586)
 
-	admin, err := wallet.GenerateKey()
+	admin, err := crypto.GenerateECDSAKey()
 	require.NoError(t, err)
 
-	adminAddr := types.Address(admin.Address())
-
-	cluster := framework.NewTestCluster(t, 5, framework.WithBladeAdmin(adminAddr.String()))
+	cluster := framework.NewTestCluster(t, 5, framework.WithBladeAdmin(admin.Address().String()))
 	defer cluster.Stop()
 
 	cluster.WaitForReady(t)
@@ -770,15 +766,12 @@ func TestE2E_Deploy_Nested_Contract(t *testing.T) {
 
 	// deploy Wrapper contract
 	receipt, err := txRelayer.SendTransaction(
-		&ethgo.Transaction{
-			To:    nil,
-			Input: contractsapi.Wrapper.Bytecode,
-		},
+		types.NewTx(&types.MixedTxn{Input: contractsapi.Wrapper.Bytecode}),
 		admin)
 	require.NoError(t, err)
 
 	// address of Wrapper contract
-	wrapperAddr := receipt.ContractAddress
+	wrapperAddr := types.Address(receipt.ContractAddress)
 
 	// getAddressFn returns address of the NumberPersister (nested) contract
 	getAddressFn := contractsapi.Wrapper.Abi.GetMethod("getAddress")
@@ -786,7 +779,7 @@ func TestE2E_Deploy_Nested_Contract(t *testing.T) {
 	getAddrInput, err := getAddressFn.Encode([]interface{}{})
 	require.NoError(t, err)
 
-	response, err := txRelayer.Call(ethgo.ZeroAddress, wrapperAddr, getAddrInput)
+	response, err := txRelayer.Call(types.ZeroAddress, wrapperAddr, getAddrInput)
 	require.NoError(t, err)
 
 	// address of the NumberPersister (nested) contract
@@ -799,11 +792,11 @@ func TestE2E_Deploy_Nested_Contract(t *testing.T) {
 	setValueInput, err := setNumberFn.Encode([]interface{}{numberToPersist})
 	require.NoError(t, err)
 
-	txn := &ethgo.Transaction{
+	txn := types.NewTx(&types.MixedTxn{
 		From:  admin.Address(),
 		To:    &wrapperAddr,
 		Input: setValueInput,
-	}
+	})
 
 	receipt, err = txRelayer.SendTransaction(txn, admin)
 	require.NoError(t, err)
@@ -815,7 +808,7 @@ func TestE2E_Deploy_Nested_Contract(t *testing.T) {
 	getNumberInput, err := getNumberFn.Encode([]interface{}{})
 	require.NoError(t, err)
 
-	response, err = txRelayer.Call(ethgo.ZeroAddress, wrapperAddr, getNumberInput)
+	response, err = txRelayer.Call(types.ZeroAddress, wrapperAddr, getNumberInput)
 	require.NoError(t, err)
 
 	parsedResponse, err := common.ParseUint256orHex(&response)

--- a/e2e-polybft/e2e/governance_test.go
+++ b/e2e-polybft/e2e/governance_test.go
@@ -337,7 +337,7 @@ func sendQueueProposalTransaction(t *testing.T,
 	input, err := queueFn.EncodeAbi()
 	require.NoError(t, err)
 
-	txn := types.NewTx(&types.MixedTxn{
+	txn := types.NewTx(&types.LegacyTx{
 		To:    &childGovernorAddr,
 		Input: input,
 	})
@@ -363,7 +363,7 @@ func sendExecuteProposalTransaction(t *testing.T,
 	input, err := executeFn.EncodeAbi()
 	require.NoError(t, err)
 
-	txn := types.NewTx(&types.MixedTxn{
+	txn := types.NewTx(&types.LegacyTx{
 		To:    &childGovernorAddr,
 		Input: input,
 	})
@@ -386,7 +386,7 @@ func sendVoteTransaction(t *testing.T, proposalID *big.Int, vote VoteType,
 	input, err := castVoteFn.EncodeAbi()
 	require.NoError(t, err)
 
-	txn := types.NewTx(&types.MixedTxn{
+	txn := types.NewTx(&types.LegacyTx{
 		To:    &childGovernorAddr,
 		Input: input,
 	})
@@ -412,7 +412,7 @@ func sendProposalTransaction(t *testing.T, txRelayer txrelayer.TxRelayer,
 	input, err := proposeFn.EncodeAbi()
 	require.NoError(t, err)
 
-	txn := types.NewTx(&types.MixedTxn{
+	txn := types.NewTx(&types.LegacyTx{
 		To:    &childGovernorAddr,
 		Input: input,
 	})

--- a/e2e-polybft/e2e/governance_test.go
+++ b/e2e-polybft/e2e/governance_test.go
@@ -136,7 +136,7 @@ func TestE2E_Governance_ProposeAndExecuteSimpleProposal(t *testing.T) {
 
 		// check if epoch size changed on NetworkParams
 		networkParamsResponse, err := ABICall(relayer, contractsapi.NetworkParams,
-			ethgo.Address(polybftCfg.GovernanceConfig.NetworkParamsAddr), ethgo.ZeroAddress, "epochSize")
+			polybftCfg.GovernanceConfig.NetworkParamsAddr, types.ZeroAddress, "epochSize")
 		require.NoError(t, err)
 
 		epochSizeOnNetworkParams, err := common.ParseUint256orHex(&networkParamsResponse)
@@ -291,7 +291,7 @@ func TestE2E_Governance_ProposeAndExecuteSimpleProposal(t *testing.T) {
 
 		// check if base fee change denom changed on NetworkParams
 		networkParamsResponse, err := ABICall(relayer, contractsapi.NetworkParams,
-			ethgo.Address(polybftCfg.GovernanceConfig.NetworkParamsAddr), ethgo.ZeroAddress, "baseFeeChangeDenom")
+			polybftCfg.GovernanceConfig.NetworkParamsAddr, types.ZeroAddress, "baseFeeChangeDenom")
 		require.NoError(t, err)
 
 		baseFeeDenomOnNetworkParams, err := common.ParseUint256orHex(&networkParamsResponse)
@@ -311,7 +311,7 @@ func getProposalState(t *testing.T, proposalID *big.Int, childGovernorAddr types
 	input, err := stateFn.EncodeAbi()
 	require.NoError(t, err)
 
-	response, err := txRelayer.Call(ethgo.ZeroAddress, ethgo.Address(childGovernorAddr), input)
+	response, err := txRelayer.Call(types.ZeroAddress, childGovernorAddr, input)
 	require.NoError(t, err)
 	require.NotEqual(t, "0x", response)
 
@@ -322,7 +322,7 @@ func getProposalState(t *testing.T, proposalID *big.Int, childGovernorAddr types
 }
 
 func sendQueueProposalTransaction(t *testing.T,
-	txRelayer txrelayer.TxRelayer, senderKey ethgo.Key,
+	txRelayer txrelayer.TxRelayer, senderKey crypto.Key,
 	childGovernorAddr, paramsContractAddr types.Address,
 	input []byte, description string) {
 	t.Helper()
@@ -337,11 +337,10 @@ func sendQueueProposalTransaction(t *testing.T,
 	input, err := queueFn.EncodeAbi()
 	require.NoError(t, err)
 
-	childGovernor := ethgo.Address(childGovernorAddr)
-	txn := &ethgo.Transaction{
-		To:    &childGovernor,
+	txn := types.NewTx(&types.MixedTxn{
+		To:    &childGovernorAddr,
 		Input: input,
-	}
+	})
 
 	receipt, err := txRelayer.SendTransaction(txn, senderKey)
 	require.NoError(t, err)
@@ -349,7 +348,7 @@ func sendQueueProposalTransaction(t *testing.T,
 }
 
 func sendExecuteProposalTransaction(t *testing.T,
-	txRelayer txrelayer.TxRelayer, senderKey ethgo.Key,
+	txRelayer txrelayer.TxRelayer, senderKey crypto.Key,
 	childGovernorAddr, paramsContractAddr types.Address,
 	input []byte, description string) {
 	t.Helper()
@@ -364,11 +363,10 @@ func sendExecuteProposalTransaction(t *testing.T,
 	input, err := executeFn.EncodeAbi()
 	require.NoError(t, err)
 
-	childGovernor := ethgo.Address(childGovernorAddr)
-	txn := &ethgo.Transaction{
-		To:    &childGovernor,
+	txn := types.NewTx(&types.MixedTxn{
+		To:    &childGovernorAddr,
 		Input: input,
-	}
+	})
 
 	receipt, err := txRelayer.SendTransaction(txn, senderKey)
 	require.NoError(t, err)
@@ -377,7 +375,7 @@ func sendExecuteProposalTransaction(t *testing.T,
 
 func sendVoteTransaction(t *testing.T, proposalID *big.Int, vote VoteType,
 	childGovernorAddr types.Address,
-	txRelayer txrelayer.TxRelayer, senderKey ethgo.Key) {
+	txRelayer txrelayer.TxRelayer, senderKey crypto.Key) {
 	t.Helper()
 
 	castVoteFn := &contractsapi.CastVoteChildGovernorFn{
@@ -388,11 +386,10 @@ func sendVoteTransaction(t *testing.T, proposalID *big.Int, vote VoteType,
 	input, err := castVoteFn.EncodeAbi()
 	require.NoError(t, err)
 
-	childGovernor := ethgo.Address(childGovernorAddr)
-	txn := &ethgo.Transaction{
-		To:    &childGovernor,
+	txn := types.NewTx(&types.MixedTxn{
+		To:    &childGovernorAddr,
 		Input: input,
-	}
+	})
 
 	receipt, err := txRelayer.SendTransaction(txn, senderKey)
 	require.NoError(t, err)
@@ -400,7 +397,7 @@ func sendVoteTransaction(t *testing.T, proposalID *big.Int, vote VoteType,
 }
 
 func sendProposalTransaction(t *testing.T, txRelayer txrelayer.TxRelayer,
-	senderKey ethgo.Key,
+	senderKey crypto.Key,
 	childGovernorAddr, paramsContractAddr types.Address,
 	input []byte, description string) *big.Int {
 	t.Helper()
@@ -415,11 +412,10 @@ func sendProposalTransaction(t *testing.T, txRelayer txrelayer.TxRelayer,
 	input, err := proposeFn.EncodeAbi()
 	require.NoError(t, err)
 
-	childGovernor := ethgo.Address(childGovernorAddr)
-	txn := &ethgo.Transaction{
-		To:    &childGovernor,
+	txn := types.NewTx(&types.MixedTxn{
+		To:    &childGovernorAddr,
 		Input: input,
-	}
+	})
 
 	receipt, err := txRelayer.SendTransaction(txn, senderKey)
 	require.NoError(t, err)

--- a/e2e-polybft/e2e/governance_test.go
+++ b/e2e-polybft/e2e/governance_test.go
@@ -337,12 +337,10 @@ func sendQueueProposalTransaction(t *testing.T,
 	input, err := queueFn.EncodeAbi()
 	require.NoError(t, err)
 
-	txn := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			To:    &childGovernorAddr,
-			Input: input,
-		},
-	})
+	txn := types.NewTx(types.NewLegacyTx(
+		types.WithTo(&childGovernorAddr),
+		types.WithInput(input),
+	))
 
 	receipt, err := txRelayer.SendTransaction(txn, senderKey)
 	require.NoError(t, err)
@@ -365,12 +363,10 @@ func sendExecuteProposalTransaction(t *testing.T,
 	input, err := executeFn.EncodeAbi()
 	require.NoError(t, err)
 
-	txn := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			To:    &childGovernorAddr,
-			Input: input,
-		},
-	})
+	txn := types.NewTx(types.NewLegacyTx(
+		types.WithTo(&childGovernorAddr),
+		types.WithInput(input),
+	))
 
 	receipt, err := txRelayer.SendTransaction(txn, senderKey)
 	require.NoError(t, err)
@@ -390,12 +386,10 @@ func sendVoteTransaction(t *testing.T, proposalID *big.Int, vote VoteType,
 	input, err := castVoteFn.EncodeAbi()
 	require.NoError(t, err)
 
-	txn := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			To:    &childGovernorAddr,
-			Input: input,
-		},
-	})
+	txn := types.NewTx(types.NewLegacyTx(
+		types.WithTo(&childGovernorAddr),
+		types.WithInput(input),
+	))
 
 	receipt, err := txRelayer.SendTransaction(txn, senderKey)
 	require.NoError(t, err)
@@ -418,12 +412,10 @@ func sendProposalTransaction(t *testing.T, txRelayer txrelayer.TxRelayer,
 	input, err := proposeFn.EncodeAbi()
 	require.NoError(t, err)
 
-	txn := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			To:    &childGovernorAddr,
-			Input: input,
-		},
-	})
+	txn := types.NewTx(types.NewLegacyTx(
+		types.WithTo(&childGovernorAddr),
+		types.WithInput(input),
+	))
 
 	receipt, err := txRelayer.SendTransaction(txn, senderKey)
 	require.NoError(t, err)

--- a/e2e-polybft/e2e/governance_test.go
+++ b/e2e-polybft/e2e/governance_test.go
@@ -338,8 +338,10 @@ func sendQueueProposalTransaction(t *testing.T,
 	require.NoError(t, err)
 
 	txn := types.NewTx(&types.LegacyTx{
-		To:    &childGovernorAddr,
-		Input: input,
+		BaseTx: &types.BaseTx{
+			To:    &childGovernorAddr,
+			Input: input,
+		},
 	})
 
 	receipt, err := txRelayer.SendTransaction(txn, senderKey)
@@ -364,8 +366,10 @@ func sendExecuteProposalTransaction(t *testing.T,
 	require.NoError(t, err)
 
 	txn := types.NewTx(&types.LegacyTx{
-		To:    &childGovernorAddr,
-		Input: input,
+		BaseTx: &types.BaseTx{
+			To:    &childGovernorAddr,
+			Input: input,
+		},
 	})
 
 	receipt, err := txRelayer.SendTransaction(txn, senderKey)
@@ -387,8 +391,10 @@ func sendVoteTransaction(t *testing.T, proposalID *big.Int, vote VoteType,
 	require.NoError(t, err)
 
 	txn := types.NewTx(&types.LegacyTx{
-		To:    &childGovernorAddr,
-		Input: input,
+		BaseTx: &types.BaseTx{
+			To:    &childGovernorAddr,
+			Input: input,
+		},
 	})
 
 	receipt, err := txRelayer.SendTransaction(txn, senderKey)
@@ -413,8 +419,10 @@ func sendProposalTransaction(t *testing.T, txRelayer txrelayer.TxRelayer,
 	require.NoError(t, err)
 
 	txn := types.NewTx(&types.LegacyTx{
-		To:    &childGovernorAddr,
-		Input: input,
+		BaseTx: &types.BaseTx{
+			To:    &childGovernorAddr,
+			Input: input,
+		},
 	})
 
 	receipt, err := txRelayer.SendTransaction(txn, senderKey)

--- a/e2e-polybft/e2e/helpers_test.go
+++ b/e2e-polybft/e2e/helpers_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
@@ -30,9 +31,9 @@ import (
 const nativeTokenNonMintableConfig = "Blade:BLD:18:false"
 
 // getCheckpointManagerValidators queries rootchain validator set on CheckpointManager contract
-func getCheckpointManagerValidators(relayer txrelayer.TxRelayer, checkpointManagerAddr ethgo.Address) ([]*polybft.ValidatorInfo, error) {
+func getCheckpointManagerValidators(relayer txrelayer.TxRelayer, checkpointManagerAddr types.Address) ([]*polybft.ValidatorInfo, error) {
 	validatorsCountRaw, err := ABICall(relayer, contractsapi.CheckpointManager,
-		checkpointManagerAddr, ethgo.ZeroAddress, "currentValidatorSetLength")
+		checkpointManagerAddr, types.ZeroAddress, "currentValidatorSetLength")
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +48,7 @@ func getCheckpointManagerValidators(relayer txrelayer.TxRelayer, checkpointManag
 
 	for i := 0; i < int(validatorsCount); i++ {
 		validatorRaw, err := ABICall(relayer, contractsapi.CheckpointManager,
-			checkpointManagerAddr, ethgo.ZeroAddress, "currentValidatorSet", i)
+			checkpointManagerAddr, types.ZeroAddress, "currentValidatorSet", i)
 		if err != nil {
 			return nil, err
 		}
@@ -68,7 +69,7 @@ func getCheckpointManagerValidators(relayer txrelayer.TxRelayer, checkpointManag
 		}
 
 		validators[i] = &polybft.ValidatorInfo{
-			Address: results["_address"].(ethgo.Address),
+			Address: types.Address(results["_address"].(ethgo.Address)),
 			Stake:   results["votingPower"].(*big.Int),
 		}
 	}
@@ -76,7 +77,7 @@ func getCheckpointManagerValidators(relayer txrelayer.TxRelayer, checkpointManag
 	return validators, nil
 }
 
-func ABICall(relayer txrelayer.TxRelayer, artifact *contracts.Artifact, contractAddress ethgo.Address, senderAddr ethgo.Address, method string, params ...interface{}) (string, error) {
+func ABICall(relayer txrelayer.TxRelayer, artifact *contracts.Artifact, contractAddress types.Address, senderAddr types.Address, method string, params ...interface{}) (string, error) {
 	input, err := artifact.Abi.GetMethod(method).Encode(params)
 	if err != nil {
 		return "", err
@@ -85,16 +86,18 @@ func ABICall(relayer txrelayer.TxRelayer, artifact *contracts.Artifact, contract
 	return relayer.Call(senderAddr, contractAddress, input)
 }
 
-func ABITransaction(relayer txrelayer.TxRelayer, key ethgo.Key, artifact *contracts.Artifact, contractAddress ethgo.Address, method string, params ...interface{}) (*ethgo.Receipt, error) {
+func ABITransaction(relayer txrelayer.TxRelayer, key crypto.Key, artifact *contracts.Artifact, contractAddress types.Address, method string, params ...interface{}) (*ethgo.Receipt, error) {
 	input, err := artifact.Abi.GetMethod(method).Encode(params)
 	if err != nil {
 		return nil, err
 	}
 
-	return relayer.SendTransaction(&ethgo.Transaction{
+	tx := types.NewTx(&types.MixedTxn{
 		To:    &contractAddress,
 		Input: input,
-	}, key)
+	})
+
+	return relayer.SendTransaction(tx, key)
 }
 
 func getExitProof(rpcAddress string, exitID uint64) (types.Proof, error) {
@@ -160,9 +163,9 @@ func checkStateSyncResultLogs(
 }
 
 // getCheckpointBlockNumber gets current checkpoint block number from checkpoint manager smart contract
-func getCheckpointBlockNumber(l1Relayer txrelayer.TxRelayer, checkpointManagerAddr ethgo.Address) (uint64, error) {
+func getCheckpointBlockNumber(l1Relayer txrelayer.TxRelayer, checkpointManagerAddr types.Address) (uint64, error) {
 	checkpointBlockNumRaw, err := ABICall(l1Relayer, contractsapi.CheckpointManager,
-		checkpointManagerAddr, ethgo.ZeroAddress, "currentCheckpointBlockNumber")
+		checkpointManagerAddr, types.ZeroAddress, "currentCheckpointBlockNumber")
 	if err != nil {
 		return 0, err
 	}
@@ -192,7 +195,7 @@ func waitForRootchainEpoch(targetEpoch uint64, timeout time.Duration,
 		}
 
 		rootchainEpochRaw, err := ABICall(rootchainTxRelayer, contractsapi.CheckpointManager,
-			ethgo.Address(checkpointManager), ethgo.ZeroAddress, "currentEpoch")
+			checkpointManager, types.ZeroAddress, "currentEpoch")
 		if err != nil {
 			return err
 		}
@@ -210,7 +213,7 @@ func waitForRootchainEpoch(targetEpoch uint64, timeout time.Duration,
 
 // setAccessListRole sets access list role to appropriate access list precompile
 func setAccessListRole(t *testing.T, cluster *framework.TestCluster, precompile, account types.Address,
-	role addresslist.Role, aclAdmin ethgo.Key) {
+	role addresslist.Role, aclAdmin *crypto.ECDSAKey) {
 	t.Helper()
 
 	var updateRoleFn *abi.Method
@@ -270,7 +273,7 @@ func erc20BalanceOf(t *testing.T, account types.Address, tokenAddr types.Address
 	balanceOfInput, err := balanceOfFn.EncodeAbi()
 	require.NoError(t, err)
 
-	balanceRaw, err := relayer.Call(ethgo.ZeroAddress, ethgo.Address(tokenAddr), balanceOfInput)
+	balanceRaw, err := relayer.Call(types.ZeroAddress, tokenAddr, balanceOfInput)
 	require.NoError(t, err)
 	balance, err := common.ParseUint256orHex(&balanceRaw)
 	require.NoError(t, err)
@@ -286,7 +289,7 @@ func erc721OwnerOf(t *testing.T, tokenID *big.Int, tokenAddr types.Address, rela
 	ownerOfInput, err := ownerOfFn.EncodeAbi()
 	require.NoError(t, err)
 
-	ownerRaw, err := relayer.Call(ethgo.ZeroAddress, ethgo.Address(tokenAddr), ownerOfInput)
+	ownerRaw, err := relayer.Call(types.ZeroAddress, tokenAddr, ownerOfInput)
 	require.NoError(t, err)
 
 	return types.StringToAddress(ownerRaw)
@@ -297,8 +300,8 @@ func queryNativeERC20Metadata(t *testing.T, funcName string, abiType *abi.Type, 
 	t.Helper()
 
 	valueHex, err := ABICall(relayer, contractsapi.NativeERC20Mintable,
-		ethgo.Address(contracts.NativeERC20TokenContract),
-		ethgo.ZeroAddress, funcName)
+		contracts.NativeERC20TokenContract,
+		types.ZeroAddress, funcName)
 	require.NoError(t, err)
 
 	valueRaw, err := hex.DecodeHex(valueHex)
@@ -323,7 +326,7 @@ func getChildToken(t *testing.T, predicateABI *abi.ABI, predicateAddr types.Addr
 	input, err := rootToChildTokenFn.Encode([]interface{}{rootToken})
 	require.NoError(t, err)
 
-	childTokenRaw, err := relayer.Call(ethgo.ZeroAddress, ethgo.Address(predicateAddr), input)
+	childTokenRaw, err := relayer.Call(types.ZeroAddress, predicateAddr, input)
 	require.NoError(t, err)
 
 	return types.StringToAddress(childTokenRaw)
@@ -337,7 +340,7 @@ func getLastExitEventID(t *testing.T, relayer txrelayer.TxRelayer) uint64 {
 	input, err := exitEventsCounterFn.Encode([]interface{}{})
 	require.NoError(t, err)
 
-	exitEventIDRaw, err := relayer.Call(ethgo.ZeroAddress, ethgo.Address(contracts.L2StateSenderContract), input)
+	exitEventIDRaw, err := relayer.Call(types.ZeroAddress, contracts.L2StateSenderContract, input)
 	require.NoError(t, err)
 
 	exitEventID, err := common.ParseUint64orHex(&exitEventIDRaw)
@@ -355,7 +358,7 @@ func isExitEventProcessed(t *testing.T, exitHelperAddr types.Address,
 	input, err := processedExitsFn.Encode([]interface{}{exitEventID})
 	require.NoError(t, err)
 
-	isProcessedRaw, err := relayer.Call(ethgo.ZeroAddress, ethgo.Address(exitHelperAddr), input)
+	isProcessedRaw, err := relayer.Call(types.ZeroAddress, exitHelperAddr, input)
 	require.NoError(t, err)
 
 	isProcessedAsNumber, err := common.ParseUint64orHex(&isProcessedRaw)

--- a/e2e-polybft/e2e/helpers_test.go
+++ b/e2e-polybft/e2e/helpers_test.go
@@ -92,7 +92,7 @@ func ABITransaction(relayer txrelayer.TxRelayer, key crypto.Key, artifact *contr
 		return nil, err
 	}
 
-	tx := types.NewTx(&types.MixedTxn{
+	tx := types.NewTx(&types.LegacyTx{
 		To:    &contractAddress,
 		Input: input,
 	})

--- a/e2e-polybft/e2e/helpers_test.go
+++ b/e2e-polybft/e2e/helpers_test.go
@@ -93,8 +93,10 @@ func ABITransaction(relayer txrelayer.TxRelayer, key crypto.Key, artifact *contr
 	}
 
 	tx := types.NewTx(&types.LegacyTx{
-		To:    &contractAddress,
-		Input: input,
+		BaseTx: &types.BaseTx{
+			To:    &contractAddress,
+			Input: input,
+		},
 	})
 
 	return relayer.SendTransaction(tx, key)

--- a/e2e-polybft/e2e/helpers_test.go
+++ b/e2e-polybft/e2e/helpers_test.go
@@ -39,12 +39,10 @@ func ABITransaction(relayer txrelayer.TxRelayer, key crypto.Key, artifact *contr
 		return nil, err
 	}
 
-	tx := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			To:    &contractAddress,
-			Input: input,
-		},
-	})
+	tx := types.NewTx(types.NewLegacyTx(
+		types.WithTo(&contractAddress),
+		types.WithInput(input),
+	))
 
 	return relayer.SendTransaction(tx, key)
 }

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -565,7 +565,7 @@ func TestE2E_JsonRPC_NewEthClient(t *testing.T) {
 		ethTxn, err := newEthClient.GetTransactionByHash(types.Hash(txn.Receipt().TransactionHash))
 		require.NoError(t, err)
 
-		require.Equal(t, ethTxn.From(), types.Address(preminedAcct.Address()))
+		require.Equal(t, ethTxn.From(), preminedAcct.Address())
 
 		receipt, err := newEthClient.GetTransactionReceipt(ethTxn.Hash())
 		require.NoError(t, err)
@@ -574,7 +574,7 @@ func TestE2E_JsonRPC_NewEthClient(t *testing.T) {
 	})
 
 	t.Run("eth_getTransactionCount", func(t *testing.T) {
-		nonce, err := newEthClient.GetNonce(types.Address(preminedAcct.Address()), bladeRPC.LatestBlockNumberOrHash)
+		nonce, err := newEthClient.GetNonce(preminedAcct.Address(), bladeRPC.LatestBlockNumberOrHash)
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, nonce, uint64(0)) // since we used this account in previous tests
 
@@ -582,13 +582,13 @@ func TestE2E_JsonRPC_NewEthClient(t *testing.T) {
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
-		newNonce, err := newEthClient.GetNonce(types.Address(preminedAcct.Address()), bladeRPC.LatestBlockNumberOrHash)
+		newNonce, err := newEthClient.GetNonce(preminedAcct.Address(), bladeRPC.LatestBlockNumberOrHash)
 		require.NoError(t, err)
 		require.Equal(t, nonce+1, newNonce)
 	})
 
 	t.Run("eth_getBalance", func(t *testing.T) {
-		balance, err := newEthClient.GetBalance(types.Address(preminedAcct.Address()), bladeRPC.LatestBlockNumberOrHash)
+		balance, err := newEthClient.GetBalance(preminedAcct.Address(), bladeRPC.LatestBlockNumberOrHash)
 		require.NoError(t, err)
 		require.True(t, balance.Cmp(big.NewInt(0)) >= 0)
 
@@ -615,7 +615,7 @@ func TestE2E_JsonRPC_NewEthClient(t *testing.T) {
 		input := contractsapi.TestSimple.Abi.GetMethod("getValue").ID()
 
 		estimatedGas, err := newEthClient.EstimateGas(&bladeRPC.CallMsg{
-			From: types.Address(preminedAcct.Address()),
+			From: preminedAcct.Address(),
 			To:   &target,
 			Data: input,
 		})

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/jsonrpc"
-	"github.com/umbracle/ethgo/wallet"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/crypto"
@@ -76,11 +75,11 @@ func TestE2E_JsonRPC(t *testing.T) {
 
 		input := contractsapi.TestSimple.Abi.GetMethod("getValue").ID()
 
-		acctZeroBalance, err := wallet.GenerateKey()
+		acctZeroBalance, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
 		resp, err := client.Call(&ethgo.CallMsg{
-			From: acctZeroBalance.Address(),
+			From: ethgo.Address(acctZeroBalance.Address()),
 			To:   &target,
 			Data: input,
 		}, ethgo.Latest)
@@ -114,11 +113,11 @@ func TestE2E_JsonRPC(t *testing.T) {
 		target := deployTxn.Receipt().ContractAddress
 		input := contractsapi.TestSimple.Abi.GetMethod("getValue").ID()
 
-		acctZeroBalance, err := wallet.GenerateKey()
+		acctZeroBalance, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
 		resp, err := client.EstimateGas(&ethgo.CallMsg{
-			From: acctZeroBalance.Address(),
+			From: ethgo.Address(acctZeroBalance.Address()),
 			To:   &target,
 			Data: input,
 		})
@@ -246,7 +245,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_getStorageAt", func(t *testing.T) {
-		key1, err := wallet.GenerateKey()
+		key1, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
 		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
@@ -331,7 +330,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_getBlockByHash", func(t *testing.T) {
-		key1, err := wallet.GenerateKey()
+		key1, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
 		require.NoError(t, txn.Wait())
@@ -345,7 +344,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_getBlockByNumber", func(t *testing.T) {
-		key1, err := wallet.GenerateKey()
+		key1, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
 		require.NoError(t, txn.Wait())
@@ -359,7 +358,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_getTransactionReceipt", func(t *testing.T) {
-		key1, err := wallet.GenerateKey()
+		key1, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
 		require.NoError(t, txn.Wait())
@@ -391,7 +390,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_getTransactionByHash", func(t *testing.T) {
-		key1, err := wallet.GenerateKey()
+		key1, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
 		// Test. We should be able to query the transaction by its hash
@@ -407,11 +406,11 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("debug_traceTransaction", func(t *testing.T) {
-		key1, err := wallet.GenerateKey()
+		key1, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
 		// Test. We should be able to query the transaction by its hash
-		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
+		txn := cluster.Transfer(t, senderKey, key1.Address(), one)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -146,11 +146,14 @@ func TestE2E_JsonRPC(t *testing.T) {
 		estimateGasFn(ethgo.Gwei(1))
 
 		// transfer some funds to zero balance account
-		valueTransferTxn := cluster.SendTxn(t, senderKey, types.NewTx(&types.LegacyTx{
-			From:  fundedAccountAddress,
-			To:    &nonFundedAccountAddress,
-			Value: ethgo.Gwei(10),
-		}))
+		valueTransferTxn := cluster.SendTxn(t, senderKey,
+			types.NewTx(&types.LegacyTx{
+				BaseTx: &types.BaseTx{
+					From:  fundedAccountAddress,
+					To:    &nonFundedAccountAddress,
+					Value: ethgo.Gwei(10),
+				},
+			}))
 
 		require.NoError(t, valueTransferTxn.Wait())
 		require.True(t, valueTransferTxn.Succeed())
@@ -197,9 +200,11 @@ func TestE2E_JsonRPC(t *testing.T) {
 		targetAddr := senderKey.Address()
 		txn = cluster.SendTxn(t, recipientKey,
 			types.NewTx(&types.LegacyTx{
-				To:    &targetAddr,
-				Value: amountToSend,
-				Gas:   estimatedGas,
+				BaseTx: &types.BaseTx{
+					To:    &targetAddr,
+					Value: amountToSend,
+					Gas:   estimatedGas,
+				},
 			}))
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
@@ -269,7 +274,8 @@ func TestE2E_JsonRPC(t *testing.T) {
 		input, err := setValueFn.Encode([]interface{}{newVal})
 		require.NoError(t, err)
 
-		txn = cluster.SendTxn(t, senderKey, types.NewTx(&types.LegacyTx{Input: input, To: (*types.Address)(&target)}))
+		txn = cluster.SendTxn(t, senderKey, types.NewTx(
+			&types.LegacyTx{BaseTx: &types.BaseTx{Input: input, To: (*types.Address)(&target)}}))
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -25,7 +25,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 4,
-		framework.WithPremine(types.Address(senderKey.Address())),
+		framework.WithPremine(senderKey.Address()),
 		framework.WithHTTPS("/etc/ssl/certs/localhost.pem", "/etc/ssl/private/localhost.key"),
 	)
 	defer cluster.Stop()

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -151,13 +151,11 @@ func TestE2E_JsonRPC(t *testing.T) {
 
 		// transfer some funds to zero balance account
 		valueTransferTxn := cluster.SendTxn(t, senderKey,
-			types.NewTx(&types.LegacyTx{
-				BaseTx: &types.BaseTx{
-					From:  fundedAccountAddress,
-					To:    &nonFundedAccountAddress,
-					Value: ethgo.Gwei(10),
-				},
-			}))
+			types.NewTx(types.NewLegacyTx(
+				types.WithFrom(fundedAccountAddress),
+				types.WithTo(&nonFundedAccountAddress),
+				types.WithValue(ethgo.Gwei(10)),
+			)))
 
 		require.NoError(t, valueTransferTxn.Wait())
 		require.True(t, valueTransferTxn.Succeed())
@@ -203,13 +201,11 @@ func TestE2E_JsonRPC(t *testing.T) {
 		amountToSend := new(big.Int).Sub(newBalance, big.NewInt(int64(txPrice)))
 		targetAddr := senderKey.Address()
 		txn = cluster.SendTxn(t, recipientKey,
-			types.NewTx(&types.LegacyTx{
-				BaseTx: &types.BaseTx{
-					To:    &targetAddr,
-					Value: amountToSend,
-					Gas:   estimatedGas,
-				},
-			}))
+			types.NewTx(types.NewLegacyTx(
+				types.WithTo(&targetAddr),
+				types.WithValue(amountToSend),
+				types.WithGas(estimatedGas),
+			)))
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/umbracle/ethgo/wallet"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/state"
@@ -21,11 +22,11 @@ var (
 )
 
 func TestE2E_JsonRPC(t *testing.T) {
-	acct, err := wallet.GenerateKey()
+	senderKey, err := crypto.GenerateECDSAKey()
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 4,
-		framework.WithPremine(types.Address(acct.Address())),
+		framework.WithPremine(types.Address(senderKey.Address())),
 		framework.WithHTTPS("/etc/ssl/certs/localhost.pem", "/etc/ssl/private/localhost.key"),
 	)
 	defer cluster.Stop()
@@ -38,7 +39,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 
 	// Test eth_call with override in state diff
 	t.Run("eth_call state override", func(t *testing.T) {
-		deployTxn := cluster.Deploy(t, acct, contractsapi.TestSimple.Bytecode)
+		deployTxn := cluster.Deploy(t, senderKey, contractsapi.TestSimple.Bytecode)
 		require.NoError(t, deployTxn.Wait())
 		require.True(t, deployTxn.Succeed())
 
@@ -67,7 +68,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 
 	// Test eth_call with zero account balance
 	t.Run("eth_call with zero-balance account", func(t *testing.T) {
-		deployTxn := cluster.Deploy(t, acct, contractsapi.TestSimple.Bytecode)
+		deployTxn := cluster.Deploy(t, senderKey, contractsapi.TestSimple.Bytecode)
 		require.NoError(t, deployTxn.Wait())
 		require.True(t, deployTxn.Succeed())
 
@@ -88,7 +89,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_estimateGas", func(t *testing.T) {
-		deployTxn := cluster.Deploy(t, acct, contractsapi.TestSimple.Bytecode)
+		deployTxn := cluster.Deploy(t, senderKey, contractsapi.TestSimple.Bytecode)
 		require.NoError(t, deployTxn.Wait())
 		require.True(t, deployTxn.Succeed())
 
@@ -97,7 +98,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		input := contractsapi.TestSimple.Abi.GetMethod("getValue").ID()
 
 		estimatedGas, err := client.EstimateGas(&ethgo.CallMsg{
-			From: acct.Address(),
+			From: ethgo.Address(senderKey.Address()),
 			To:   &target,
 			Data: input,
 		})
@@ -106,12 +107,11 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_estimateGas by zero-balance account", func(t *testing.T) {
-		deployTxn := cluster.Deploy(t, acct, contractsapi.TestSimple.Bytecode)
+		deployTxn := cluster.Deploy(t, senderKey, contractsapi.TestSimple.Bytecode)
 		require.NoError(t, deployTxn.Wait())
 		require.True(t, deployTxn.Succeed())
 
 		target := deployTxn.Receipt().ContractAddress
-
 		input := contractsapi.TestSimple.Abi.GetMethod("getValue").ID()
 
 		acctZeroBalance, err := wallet.GenerateKey()
@@ -127,16 +127,16 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_estimateGas by zero-balance account - simple value transfer", func(t *testing.T) {
-		acctZeroBalance, err := wallet.GenerateKey()
+		acctZeroBalance, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
-		fundedAccountAddress := acct.Address()
+		fundedAccountAddress := senderKey.Address()
 		nonFundedAccountAddress := acctZeroBalance.Address()
 
 		estimateGasFn := func(value *big.Int) {
 			resp, err := client.EstimateGas(&ethgo.CallMsg{
-				From:  nonFundedAccountAddress,
-				To:    &fundedAccountAddress,
+				From:  ethgo.Address(nonFundedAccountAddress),
+				To:    (*ethgo.Address)(&fundedAccountAddress),
 				Value: value,
 			})
 
@@ -147,11 +147,11 @@ func TestE2E_JsonRPC(t *testing.T) {
 		estimateGasFn(ethgo.Gwei(1))
 
 		// transfer some funds to zero balance account
-		valueTransferTxn := cluster.SendTxn(t, acct, &ethgo.Transaction{
+		valueTransferTxn := cluster.SendTxn(t, senderKey, types.NewTx(&types.MixedTxn{
 			From:  fundedAccountAddress,
 			To:    &nonFundedAccountAddress,
 			Value: ethgo.Gwei(10),
-		})
+		}))
 
 		require.NoError(t, valueTransferTxn.Wait())
 		require.True(t, valueTransferTxn.Succeed())
@@ -161,21 +161,23 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_getBalance", func(t *testing.T) {
-		key1, err := wallet.GenerateKey()
+		recipientKey, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
+		recipientAddr := ethgo.Address(recipientKey.Address())
+
 		// Test. return zero if the account does not exist
-		balance1, err := client.GetBalance(key1.Address(), ethgo.Latest)
+		balance1, err := client.GetBalance(recipientAddr, ethgo.Latest)
 		require.NoError(t, err)
 		require.Equal(t, balance1, big.NewInt(0))
 
 		// Test. return the balance of an account
 		newBalance := ethgo.Ether(1)
-		txn := cluster.Transfer(t, acct, types.Address(key1.Address()), newBalance)
+		txn := cluster.Transfer(t, senderKey, recipientKey.Address(), newBalance)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
-		balance1, err = client.GetBalance(key1.Address(), ethgo.Latest)
+		balance1, err = client.GetBalance(recipientAddr, ethgo.Latest)
 		require.NoError(t, err)
 		require.Equal(t, balance1, newBalance)
 
@@ -183,11 +185,9 @@ func TestE2E_JsonRPC(t *testing.T) {
 		gasPrice, err := client.GasPrice()
 		require.NoError(t, err)
 
-		toAddr := key1.Address()
-
 		estimatedGas, err := client.EstimateGas(&ethgo.CallMsg{
-			From:  acct.Address(),
-			To:    &toAddr,
+			From:  ethgo.Address(senderKey.Address()),
+			To:    &recipientAddr,
 			Value: newBalance,
 		})
 		require.NoError(t, err)
@@ -195,50 +195,53 @@ func TestE2E_JsonRPC(t *testing.T) {
 		// subtract gasPrice * estimatedGas from the balance and transfer the rest to the other account
 		// in order to leave no funds on the account
 		amountToSend := new(big.Int).Sub(newBalance, big.NewInt(int64(txPrice)))
-		targetAddr := acct.Address()
-		txn = cluster.SendTxn(t, key1, &ethgo.Transaction{
-			To:    &targetAddr,
-			Value: amountToSend,
-			Gas:   estimatedGas,
-		})
+		targetAddr := senderKey.Address()
+		txn = cluster.SendTxn(t, recipientKey,
+			types.NewTx(&types.MixedTxn{
+				To:    &targetAddr,
+				Value: amountToSend,
+				Gas:   estimatedGas,
+			}))
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
-		balance1, err = client.GetBalance(key1.Address(), ethgo.Latest)
+		balance1, err = client.GetBalance(ethgo.Address(recipientKey.Address()), ethgo.Latest)
 		require.NoError(t, err)
 		require.Equal(t, big.NewInt(0), balance1)
 	})
 
 	t.Run("eth_getTransactionCount", func(t *testing.T) {
-		key1, err := wallet.GenerateKey()
+		recipientKey, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
-		nonce, err := client.GetNonce(key1.Address(), ethgo.Latest)
+		recipient := ethgo.Address(recipientKey.Address())
+
+		nonce, err := client.GetNonce(recipient, ethgo.Latest)
 		require.Equal(t, uint64(0), nonce)
 		require.NoError(t, err)
 
-		txn := cluster.Transfer(t, acct, types.Address(key1.Address()), big.NewInt(10000000000000000))
+		txn := cluster.Transfer(t, senderKey, types.Address(recipient), big.NewInt(10000000000000000))
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
 		// Test. increase the nonce with new transactions
-		txn = cluster.Transfer(t, key1, types.ZeroAddress, big.NewInt(0))
+		txn = cluster.Transfer(t, recipientKey, types.ZeroAddress, big.NewInt(0))
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
-		nonce1, err := client.GetNonce(key1.Address(), ethgo.Latest)
+		nonce1, err := client.GetNonce(recipient, ethgo.Latest)
 		require.NoError(t, err)
 		require.Equal(t, nonce1, uint64(1))
 
 		// Test. you can query the nonce at any block number in time
-		nonce1, err = client.GetNonce(key1.Address(), ethgo.BlockNumber(txn.Receipt().BlockNumber-1))
+		nonce1, err = client.GetNonce(recipient, ethgo.BlockNumber(txn.Receipt().BlockNumber-1))
 		require.NoError(t, err)
 		require.Equal(t, nonce1, uint64(0))
 
 		block, err := client.GetBlockByNumber(ethgo.BlockNumber(txn.Receipt().BlockNumber)-1, false)
 		require.NoError(t, err)
 
-		_, err = client.GetNonce(key1.Address(), ethgo.BlockNumber(block.Number))
+		_, err = client.GetNonce(recipient, ethgo.BlockNumber(block.Number))
 		require.NoError(t, err)
 	})
 
@@ -246,11 +249,11 @@ func TestE2E_JsonRPC(t *testing.T) {
 		key1, err := wallet.GenerateKey()
 		require.NoError(t, err)
 
-		txn := cluster.Transfer(t, acct, types.Address(key1.Address()), one)
+		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
-		txn = cluster.Deploy(t, acct, contractsapi.TestSimple.Bytecode)
+		txn = cluster.Deploy(t, senderKey, contractsapi.TestSimple.Bytecode)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
@@ -267,7 +270,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		input, err := setValueFn.Encode([]interface{}{newVal})
 		require.NoError(t, err)
 
-		txn = cluster.SendTxn(t, acct, &ethgo.Transaction{Input: input, To: &target})
+		txn = cluster.SendTxn(t, senderKey, types.NewTx(&types.MixedTxn{Input: input, To: (*types.Address)(&target)}))
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
@@ -281,11 +284,11 @@ func TestE2E_JsonRPC(t *testing.T) {
 		// Note that in order to work, this private key should only be used for this test.
 		priv, err := hex.DecodeString("2c15bd0dc992a47ca660983ae4b611f4ffb6178e14e04e2b34d153f3a74ce741")
 		require.NoError(t, err)
-		key1, err := wallet.NewWalletFromPrivKey(priv)
+		key1, err := crypto.NewECDSAKeyFromRawPrivECDSA(priv)
 		require.NoError(t, err)
 
 		// fund the account so that it can deploy a contract
-		txn := cluster.Transfer(t, acct, types.Address(key1.Address()), big.NewInt(10000000000000000))
+		txn := cluster.Transfer(t, senderKey, key1.Address(), ethgo.Ether(1))
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
@@ -330,7 +333,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	t.Run("eth_getBlockByHash", func(t *testing.T) {
 		key1, err := wallet.GenerateKey()
 		require.NoError(t, err)
-		txn := cluster.Transfer(t, acct, types.Address(key1.Address()), one)
+		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 		txReceipt := txn.Receipt()
@@ -344,7 +347,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	t.Run("eth_getBlockByNumber", func(t *testing.T) {
 		key1, err := wallet.GenerateKey()
 		require.NoError(t, err)
-		txn := cluster.Transfer(t, acct, types.Address(key1.Address()), one)
+		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 		txReceipt := txn.Receipt()
@@ -358,7 +361,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	t.Run("eth_getTransactionReceipt", func(t *testing.T) {
 		key1, err := wallet.GenerateKey()
 		require.NoError(t, err)
-		txn := cluster.Transfer(t, acct, types.Address(key1.Address()), one)
+		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
@@ -380,7 +383,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		require.Equal(t, receipt.BlockHash, block.Hash)
 
 		// Test. The receipt of a deployed contract has the 'ContractAddress' field.
-		txn = cluster.Deploy(t, acct, contractsapi.TestSimple.Bytecode)
+		txn = cluster.Deploy(t, senderKey, contractsapi.TestSimple.Bytecode)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
@@ -392,7 +395,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		require.NoError(t, err)
 
 		// Test. We should be able to query the transaction by its hash
-		txn := cluster.Transfer(t, acct, types.Address(key1.Address()), one)
+		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
@@ -408,7 +411,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		require.NoError(t, err)
 
 		// Test. We should be able to query the transaction by its hash
-		txn := cluster.Transfer(t, acct, types.Address(key1.Address()), one)
+		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -248,7 +248,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		key1, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
-		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
+		txn := cluster.Transfer(t, senderKey, key1.Address(), one)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
@@ -332,7 +332,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	t.Run("eth_getBlockByHash", func(t *testing.T) {
 		key1, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
-		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
+		txn := cluster.Transfer(t, senderKey, key1.Address(), one)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 		txReceipt := txn.Receipt()
@@ -346,7 +346,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	t.Run("eth_getBlockByNumber", func(t *testing.T) {
 		key1, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
-		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
+		txn := cluster.Transfer(t, senderKey, key1.Address(), one)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 		txReceipt := txn.Receipt()
@@ -360,7 +360,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	t.Run("eth_getTransactionReceipt", func(t *testing.T) {
 		key1, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
-		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
+		txn := cluster.Transfer(t, senderKey, key1.Address(), one)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 
@@ -394,7 +394,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		require.NoError(t, err)
 
 		// Test. We should be able to query the transaction by its hash
-		txn := cluster.Transfer(t, senderKey, types.Address(key1.Address()), one)
+		txn := cluster.Transfer(t, senderKey, key1.Address(), one)
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -146,7 +146,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		estimateGasFn(ethgo.Gwei(1))
 
 		// transfer some funds to zero balance account
-		valueTransferTxn := cluster.SendTxn(t, senderKey, types.NewTx(&types.MixedTxn{
+		valueTransferTxn := cluster.SendTxn(t, senderKey, types.NewTx(&types.LegacyTx{
 			From:  fundedAccountAddress,
 			To:    &nonFundedAccountAddress,
 			Value: ethgo.Gwei(10),
@@ -196,7 +196,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		amountToSend := new(big.Int).Sub(newBalance, big.NewInt(int64(txPrice)))
 		targetAddr := senderKey.Address()
 		txn = cluster.SendTxn(t, recipientKey,
-			types.NewTx(&types.MixedTxn{
+			types.NewTx(&types.LegacyTx{
 				To:    &targetAddr,
 				Value: amountToSend,
 				Gas:   estimatedGas,
@@ -269,7 +269,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		input, err := setValueFn.Encode([]interface{}{newVal})
 		require.NoError(t, err)
 
-		txn = cluster.SendTxn(t, senderKey, types.NewTx(&types.MixedTxn{Input: input, To: (*types.Address)(&target)}))
+		txn = cluster.SendTxn(t, senderKey, types.NewTx(&types.LegacyTx{Input: input, To: (*types.Address)(&target)}))
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())
 

--- a/e2e-polybft/e2e/migration_test.go
+++ b/e2e-polybft/e2e/migration_test.go
@@ -80,7 +80,6 @@ func TestE2E_Migration(t *testing.T) {
 	tx = types.NewTx(&types.LegacyTx{
 		BaseTx: &types.BaseTx{
 			From:  userKey.Address(),
-			To:    userKey2.Address().Ptr(),
 			Gas:   1000000,
 			Input: contractsapi.TestWriteBlockMetadata.Bytecode,
 		},

--- a/e2e-polybft/e2e/migration_test.go
+++ b/e2e-polybft/e2e/migration_test.go
@@ -64,10 +64,12 @@ func TestE2E_Migration(t *testing.T) {
 	// send transaction to user2
 	sendAmount := ethgo.Gwei(10000)
 	tx := types.NewTx(&types.LegacyTx{
-		From:     userKey.Address(),
-		To:       userKey2.Address().Ptr(),
-		Gas:      1000000,
-		Value:    sendAmount,
+		BaseTx: &types.BaseTx{
+			From:  userKey.Address(),
+			To:    userKey2.Address().Ptr(),
+			Gas:   1000000,
+			Value: sendAmount,
+		},
 		GasPrice: ethgo.Gwei(2),
 	})
 
@@ -76,10 +78,12 @@ func TestE2E_Migration(t *testing.T) {
 	require.NotNil(t, receipt)
 
 	tx = types.NewTx(&types.LegacyTx{
-		From:     userKey.Address(),
-		To:       userKey2.Address().Ptr(),
-		Gas:      1000000,
-		Input:    contractsapi.TestWriteBlockMetadata.Bytecode,
+		BaseTx: &types.BaseTx{
+			From:  userKey.Address(),
+			To:    userKey2.Address().Ptr(),
+			Gas:   1000000,
+			Input: contractsapi.TestWriteBlockMetadata.Bytecode,
+		},
 		GasPrice: ethgo.Gwei(2),
 	})
 

--- a/e2e-polybft/e2e/migration_test.go
+++ b/e2e-polybft/e2e/migration_test.go
@@ -63,7 +63,7 @@ func TestE2E_Migration(t *testing.T) {
 
 	// send transaction to user2
 	sendAmount := ethgo.Gwei(10000)
-	tx := types.NewTx(&types.MixedTxn{
+	tx := types.NewTx(&types.LegacyTx{
 		From:     userKey.Address(),
 		To:       userKey2.Address().Ptr(),
 		Gas:      1000000,
@@ -75,7 +75,7 @@ func TestE2E_Migration(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, receipt)
 
-	tx = types.NewTx(&types.MixedTxn{
+	tx = types.NewTx(&types.LegacyTx{
 		From:     userKey.Address(),
 		To:       userKey2.Address().Ptr(),
 		Gas:      1000000,

--- a/e2e-polybft/e2e/migration_test.go
+++ b/e2e-polybft/e2e/migration_test.go
@@ -7,26 +7,26 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/umbracle/ethgo"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	frameworkpolybft "github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
 	"github.com/0xPolygon/polygon-edge/e2e/framework"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/stretchr/testify/require"
-	"github.com/syndtr/goleveldb/leveldb"
-	"github.com/umbracle/ethgo"
-	"github.com/umbracle/ethgo/wallet"
 )
 
 func TestE2E_Migration(t *testing.T) {
-	userKey, _ := wallet.GenerateKey()
-	userAddr := userKey.Address()
-	userKey2, _ := wallet.GenerateKey()
-	userAddr2 := userKey2.Address()
+	userKey, _ := crypto.GenerateECDSAKey()
+	userAddr := ethgo.Address(userKey.Address())
+	userKey2, _ := crypto.GenerateECDSAKey()
+	userAddr2 := ethgo.Address(userKey2.Address())
 
 	initialBalance := ethgo.Ether(10)
 	srvs := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
@@ -61,32 +61,36 @@ func TestE2E_Migration(t *testing.T) {
 	relayer, err := txrelayer.NewTxRelayer(txrelayer.WithClient(rpcClient))
 	require.NoError(t, err)
 
-	//send transaction to user2
+	// send transaction to user2
 	sendAmount := ethgo.Gwei(10000)
-	receipt, err := relayer.SendTransaction(
-		&ethgo.Transaction{
-			From:     userAddr,
-			To:       &userAddr2,
-			Gas:      1000000,
-			Value:    sendAmount,
-			GasPrice: ethgo.Gwei(2).Uint64(),
-		}, userKey)
+	tx := types.NewTx(&types.MixedTxn{
+		From:     userKey.Address(),
+		To:       userKey2.Address().Ptr(),
+		Gas:      1000000,
+		Value:    sendAmount,
+		GasPrice: ethgo.Gwei(2),
+	})
+
+	receipt, err := relayer.SendTransaction(tx, userKey)
 	require.NoError(t, err)
 	require.NotNil(t, receipt)
 
-	receipt, err = relayer.SendTransaction(&ethgo.Transaction{
-		From:     userAddr,
+	tx = types.NewTx(&types.MixedTxn{
+		From:     userKey.Address(),
+		To:       userKey2.Address().Ptr(),
 		Gas:      1000000,
-		GasPrice: ethgo.Gwei(2).Uint64(),
 		Input:    contractsapi.TestWriteBlockMetadata.Bytecode,
-	}, userKey)
+		GasPrice: ethgo.Gwei(2),
+	})
+
+	receipt, err = relayer.SendTransaction(tx, userKey)
 	require.NoError(t, err)
 	require.NotNil(t, receipt)
 	require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
 
 	deployedContractBalance := receipt.ContractAddress
 
-	initReceipt, err := ABITransaction(relayer, userKey, contractsapi.TestWriteBlockMetadata, receipt.ContractAddress, "init")
+	initReceipt, err := ABITransaction(relayer, userKey, contractsapi.TestWriteBlockMetadata, types.Address(receipt.ContractAddress), "init")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/e2e-polybft/e2e/txpool_test.go
+++ b/e2e-polybft/e2e/txpool_test.go
@@ -331,8 +331,7 @@ func sendTransaction(t *testing.T, client *jsonrpc.Eth, sender crypto.Key, txn *
 		txn.SetChainID(chainID)
 	}
 
-	signer := crypto.NewLondonOrBerlinSigner(chainID.Uint64(), true,
-		crypto.NewEIP155Signer(chainID.Uint64(), true))
+	signer := crypto.NewLondonSigner(chainID.Uint64())
 
 	signedTxn, err := signer.SignTxWithCallback(txn,
 		func(hash types.Hash) (sig []byte, err error) {

--- a/e2e-polybft/e2e/txpool_test.go
+++ b/e2e-polybft/e2e/txpool_test.go
@@ -57,28 +57,24 @@ func TestE2E_TxPool_Transfer(t *testing.T) {
 
 			// Send every second transaction as a dynamic fees one
 			if i%2 == 0 {
-				txData = &types.DynamicFeeTx{
-					BaseTx: &types.BaseTx{
-						From:  sender.Address(),
-						To:    (*types.Address)(&to),
-						Gas:   30000, // enough to send a transfer
-						Value: big.NewInt(int64(sendAmount)),
-						Nonce: uint64(i),
-					},
-					GasFeeCap: big.NewInt(1000000000),
-					GasTipCap: big.NewInt(100000000),
-				}
+				txData = types.NewDynamicFeeTx(
+					types.WithFrom(sender.Address()),
+					types.WithTo((*types.Address)(&to)),
+					types.WithGas(30000), // enough to send a transfer
+					types.WithValue(big.NewInt(int64(sendAmount))),
+					types.WithNonce(uint64(i)),
+					types.WithGasFeeCap(big.NewInt(1000000000)),
+					types.WithGasTipCap(big.NewInt(100000000)),
+				)
 			} else {
-				txData = &types.LegacyTx{
-					BaseTx: &types.BaseTx{
-						From:  sender.Address(),
-						To:    (*types.Address)(&to),
-						Gas:   30000, // enough to send a transfer
-						Value: big.NewInt(int64(sendAmount)),
-						Nonce: uint64(i),
-					},
-					GasPrice: ethgo.Gwei(2),
-				}
+				txData = types.NewLegacyTx(
+					types.WithFrom(sender.Address()),
+					types.WithTo((*types.Address)(&to)),
+					types.WithGas(30000),
+					types.WithValue(big.NewInt(int64(sendAmount))),
+					types.WithNonce(uint64(i)),
+					types.WithGasPrice(ethgo.Gwei(2)),
+				)
 			}
 
 			txn := types.NewTx(txData)
@@ -163,24 +159,20 @@ func TestE2E_TxPool_Transfer_Linear(t *testing.T) {
 		var txData types.TxData
 
 		if i%2 == 0 {
-			txData = &types.DynamicFeeTx{
-				BaseTx: &types.BaseTx{
-					Value: big.NewInt(int64(sendAmount * (num - i))),
-					To:    &recipient,
-					Gas:   21000,
-				},
-				GasFeeCap: big.NewInt(1000000000),
-				GasTipCap: big.NewInt(1000000000),
-			}
+			txData = types.NewDynamicFeeTx(
+				types.WithValue(big.NewInt(int64(sendAmount*(num-i)))),
+				types.WithTo(&recipient),
+				types.WithGas(21000),
+				types.WithGasFeeCap(big.NewInt(1000000000)),
+				types.WithGasTipCap(big.NewInt(1000000000)),
+			)
 		} else {
-			txData = &types.LegacyTx{
-				BaseTx: &types.BaseTx{
-					Value: big.NewInt(int64(sendAmount * (num - i))),
-					To:    &recipient,
-					Gas:   21000,
-				},
-				GasPrice: ethgo.Gwei(1),
-			}
+			txData = types.NewLegacyTx(
+				types.WithValue(big.NewInt(int64(sendAmount*(num-i)))),
+				types.WithTo(&recipient),
+				types.WithGas(21000),
+				types.WithGasPrice(ethgo.Gwei(1)),
+			)
 		}
 
 		txn := types.NewTx(txData)
@@ -216,10 +208,9 @@ func TestE2E_TxPool_TransactionWithHeaderInstructions(t *testing.T) {
 	relayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(cluster.Servers[0].JSONRPCAddr()))
 	require.NoError(t, err)
 
-	tx := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			Input: contractsapi.TestWriteBlockMetadata.Bytecode,
-		}})
+	tx := types.NewTx(types.NewLegacyTx(
+		types.WithInput(contractsapi.TestWriteBlockMetadata.Bytecode),
+	))
 
 	receipt, err := relayer.SendTransaction(tx, sidechainKey)
 	require.NoError(t, err)
@@ -274,26 +265,22 @@ func TestE2E_TxPool_BroadcastTransactions(t *testing.T) {
 
 	for i := 0; i < txNum; i++ {
 		if i%2 == 0 {
-			txData = &types.DynamicFeeTx{
-				BaseTx: &types.BaseTx{
-					Value: sendAmount,
-					To:    &recipient,
-					Gas:   21000,
-					Nonce: nonce,
-				},
-				GasFeeCap: big.NewInt(1000000000),
-				GasTipCap: big.NewInt(100000000),
-			}
+			txData = types.NewDynamicFeeTx(
+				types.WithValue(sendAmount),
+				types.WithTo(&recipient),
+				types.WithGas(21000),
+				types.WithNonce(nonce),
+				types.WithGasFeeCap(big.NewInt(1000000000)),
+				types.WithGasTipCap(big.NewInt(100000000)),
+			)
 		} else {
-			txData = &types.LegacyTx{
-				BaseTx: &types.BaseTx{
-					Value: sendAmount,
-					To:    &recipient,
-					Gas:   21000,
-					Nonce: nonce,
-				},
-				GasPrice: ethgo.Gwei(2),
-			}
+			txData = types.NewLegacyTx(
+				types.WithValue(sendAmount),
+				types.WithTo(&recipient),
+				types.WithGas(21000),
+				types.WithNonce(nonce),
+				types.WithGasPrice(ethgo.Gwei(2)),
+			)
 		}
 
 		txn := types.NewTx(txData)

--- a/e2e-polybft/e2e/txpool_test.go
+++ b/e2e-polybft/e2e/txpool_test.go
@@ -218,7 +218,7 @@ func TestE2E_TxPool_TransactionWithHeaderInstructions(t *testing.T) {
 
 	tx := types.NewTx(&types.LegacyTx{
 		BaseTx: &types.BaseTx{
-			Input: contractsapi.TestRewardToken.Bytecode,
+			Input: contractsapi.TestWriteBlockMetadata.Bytecode,
 		}})
 
 	receipt, err := relayer.SendTransaction(tx, sidechainKey)

--- a/e2e-polybft/e2e/txpool_test.go
+++ b/e2e-polybft/e2e/txpool_test.go
@@ -58,21 +58,25 @@ func TestE2E_TxPool_Transfer(t *testing.T) {
 			// Send every second transaction as a dynamic fees one
 			if i%2 == 0 {
 				txData = &types.DynamicFeeTx{
-					From:      sender.Address(),
-					To:        (*types.Address)(&to),
-					Gas:       30000, // enough to send a transfer
-					Value:     big.NewInt(int64(sendAmount)),
-					Nonce:     uint64(i),
+					BaseTx: &types.BaseTx{
+						From:  sender.Address(),
+						To:    (*types.Address)(&to),
+						Gas:   30000, // enough to send a transfer
+						Value: big.NewInt(int64(sendAmount)),
+						Nonce: uint64(i),
+					},
 					GasFeeCap: big.NewInt(1000000000),
 					GasTipCap: big.NewInt(100000000),
 				}
 			} else {
 				txData = &types.LegacyTx{
-					From:     sender.Address(),
-					To:       (*types.Address)(&to),
-					Gas:      30000, // enough to send a transfer
-					Value:    big.NewInt(int64(sendAmount)),
-					Nonce:    uint64(i),
+					BaseTx: &types.BaseTx{
+						From:  sender.Address(),
+						To:    (*types.Address)(&to),
+						Gas:   30000, // enough to send a transfer
+						Value: big.NewInt(int64(sendAmount)),
+						Nonce: uint64(i),
+					},
 					GasPrice: ethgo.Gwei(2),
 				}
 			}
@@ -160,17 +164,21 @@ func TestE2E_TxPool_Transfer_Linear(t *testing.T) {
 
 		if i%2 == 0 {
 			txData = &types.DynamicFeeTx{
-				Value:     big.NewInt(int64(sendAmount * (num - i))),
-				To:        &recipient,
-				Gas:       21000,
+				BaseTx: &types.BaseTx{
+					Value: big.NewInt(int64(sendAmount * (num - i))),
+					To:    &recipient,
+					Gas:   21000,
+				},
 				GasFeeCap: big.NewInt(1000000000),
 				GasTipCap: big.NewInt(1000000000),
 			}
 		} else {
 			txData = &types.LegacyTx{
-				Value:    big.NewInt(int64(sendAmount * (num - i))),
-				To:       &recipient,
-				Gas:      21000,
+				BaseTx: &types.BaseTx{
+					Value: big.NewInt(int64(sendAmount * (num - i))),
+					To:    &recipient,
+					Gas:   21000,
+				},
 				GasPrice: ethgo.Gwei(1),
 			}
 		}
@@ -208,7 +216,10 @@ func TestE2E_TxPool_TransactionWithHeaderInstructions(t *testing.T) {
 	relayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(cluster.Servers[0].JSONRPCAddr()))
 	require.NoError(t, err)
 
-	tx := types.NewTx(&types.LegacyTx{Input: contractsapi.TestRewardToken.Bytecode})
+	tx := types.NewTx(&types.LegacyTx{
+		BaseTx: &types.BaseTx{
+			Input: contractsapi.TestRewardToken.Bytecode,
+		}})
 
 	receipt, err := relayer.SendTransaction(tx, sidechainKey)
 	require.NoError(t, err)
@@ -264,19 +275,23 @@ func TestE2E_TxPool_BroadcastTransactions(t *testing.T) {
 	for i := 0; i < txNum; i++ {
 		if i%2 == 0 {
 			txData = &types.DynamicFeeTx{
-				Value:     sendAmount,
-				To:        &recipient,
-				Gas:       21000,
-				Nonce:     nonce,
+				BaseTx: &types.BaseTx{
+					Value: sendAmount,
+					To:    &recipient,
+					Gas:   21000,
+					Nonce: nonce,
+				},
 				GasFeeCap: big.NewInt(1000000000),
 				GasTipCap: big.NewInt(100000000),
 			}
 		} else {
 			txData = &types.LegacyTx{
-				Value:    sendAmount,
-				To:       &recipient,
-				Gas:      21000,
-				Nonce:    nonce,
+				BaseTx: &types.BaseTx{
+					Value: sendAmount,
+					To:    &recipient,
+					Gas:   21000,
+					Nonce: nonce,
+				},
 				GasPrice: ethgo.Gwei(2),
 			}
 		}

--- a/e2e-polybft/e2e/txpool_test.go
+++ b/e2e-polybft/e2e/txpool_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/jsonrpc"
-	"github.com/umbracle/ethgo/wallet"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
@@ -22,7 +21,7 @@ import (
 
 func TestE2E_TxPool_Transfer(t *testing.T) {
 	// premine an account in the genesis file
-	sender, err := wallet.GenerateKey()
+	sender, err := crypto.GenerateECDSAKey()
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 5,
@@ -41,10 +40,10 @@ func TestE2E_TxPool_Transfer(t *testing.T) {
 	receivers := []ethgo.Address{}
 
 	for i := 0; i < num; i++ {
-		key, err := wallet.GenerateKey()
+		key, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
-		receivers = append(receivers, key.Address())
+		receivers = append(receivers, ethgo.Address(key.Address()))
 	}
 
 	var wg sync.WaitGroup
@@ -54,22 +53,22 @@ func TestE2E_TxPool_Transfer(t *testing.T) {
 		go func(i int, to ethgo.Address) {
 			defer wg.Done()
 
-			txn := &ethgo.Transaction{
+			txn := types.NewTx(&types.MixedTxn{
 				From:  sender.Address(),
-				To:    &to,
+				To:    (*types.Address)(&to),
 				Gas:   30000, // enough to send a transfer
 				Value: big.NewInt(int64(sendAmount)),
 				Nonce: uint64(i),
-			}
+			})
 
 			// Send every second transaction as a dynamic fees one
 			if i%2 == 0 {
-				txn.Type = ethgo.TransactionDynamicFee
-				txn.MaxFeePerGas = big.NewInt(1000000000)
-				txn.MaxPriorityFeePerGas = big.NewInt(100000000)
+				txn.SetTransactionType(types.DynamicFeeTx)
+				txn.SetGasFeeCap(big.NewInt(1000000000))
+				txn.SetGasTipCap(big.NewInt(100000000))
 			} else {
-				txn.Type = ethgo.TransactionLegacy
-				txn.GasPrice = ethgo.Gwei(2).Uint64()
+				txn.SetTransactionType(types.LegacyTx)
+				txn.SetGasPrice(ethgo.Gwei(2))
 			}
 
 			sendTransaction(t, client, sender, txn)
@@ -97,7 +96,7 @@ func TestE2E_TxPool_Transfer(t *testing.T) {
 
 // First account send some amount to second one and then second one to third account
 func TestE2E_TxPool_Transfer_Linear(t *testing.T) {
-	premine, err := wallet.GenerateKey()
+	premine, err := crypto.GenerateECDSAKey()
 	require.NoError(t, err)
 
 	// first account should have some matics premined
@@ -124,24 +123,24 @@ func TestE2E_TxPool_Transfer_Linear(t *testing.T) {
 		return err
 	}
 
-	populateTxFees := func(txn *ethgo.Transaction, i int) {
+	populateTxFees := func(txn *types.Transaction, i int) {
 		if i%2 == 0 {
-			txn.Type = ethgo.TransactionDynamicFee
-			txn.MaxFeePerGas = big.NewInt(1000000000)
-			txn.MaxPriorityFeePerGas = big.NewInt(1000000000)
+			txn.SetTransactionType(types.DynamicFeeTx)
+			txn.SetGasFeeCap(big.NewInt(1000000000))
+			txn.SetGasTipCap(big.NewInt(1000000000))
 		} else {
-			txn.Type = ethgo.TransactionLegacy
-			txn.GasPrice = ethgo.Gwei(1).Uint64()
+			txn.SetTransactionType(types.LegacyTx)
+			txn.SetGasPrice(ethgo.Gwei(1))
 		}
 	}
 
 	num := 4
-	receivers := []*wallet.Key{
+	receivers := []crypto.Key{
 		premine,
 	}
 
 	for i := 0; i < num-1; i++ {
-		key, err := wallet.GenerateKey()
+		key, err := crypto.GenerateECDSAKey()
 		assert.NoError(t, err)
 
 		receivers = append(receivers, key)
@@ -159,27 +158,28 @@ func TestE2E_TxPool_Transfer_Linear(t *testing.T) {
 		// This means that since gasCost and sendAmount are fixed, account C must receive gasCost * 2
 		// (to cover two more transfers C->D and D->E) + sendAmount * 3 (one bundle for each C,D and E).
 		recipient := receivers[i].Address()
-		txn := &ethgo.Transaction{
+
+		txn := types.NewTx(&types.MixedTxn{
 			Value: big.NewInt(int64(sendAmount * (num - i))),
 			To:    &recipient,
 			Gas:   21000,
-		}
+		})
 
 		// Populate fees fields for the current transaction
 		populateTxFees(txn, i-1)
 
 		// Add remaining fees to finish the cycle
 		gasCostTotal := new(big.Int).Mul(txCost(txn), new(big.Int).SetInt64(int64(num-i-1)))
-		txn.Value = txn.Value.Add(txn.Value, gasCostTotal)
+		txn.SetValue(txn.Value().Add(txn.Value(), gasCostTotal))
 
 		sendTransaction(t, client, receivers[i-1], txn)
 
-		err := waitUntilBalancesChanged(receivers[i].Address())
+		err := waitUntilBalancesChanged(ethgo.Address(receivers[i].Address()))
 		require.NoError(t, err)
 	}
 
 	for i := 1; i < num; i++ {
-		balance, err := client.GetBalance(receivers[i].Address(), ethgo.Latest)
+		balance, err := client.GetBalance(ethgo.Address(receivers[i].Address()), ethgo.Latest)
 		require.NoError(t, err)
 		require.Equal(t, uint64(sendAmount), balance.Uint64())
 	}
@@ -224,7 +224,7 @@ func TestE2E_TxPool_BroadcastTransactions(t *testing.T) {
 	)
 
 	// Create recipient key
-	key, err := wallet.GenerateKey()
+	key, err := crypto.GenerateECDSAKey()
 	assert.NoError(t, err)
 
 	recipient := key.Address()
@@ -232,7 +232,7 @@ func TestE2E_TxPool_BroadcastTransactions(t *testing.T) {
 	t.Logf("Recipient %s\n", recipient)
 
 	// Create pre-mined balance for sender
-	sender, err := wallet.GenerateKey()
+	sender, err := crypto.GenerateECDSAKey()
 	require.NoError(t, err)
 
 	// First account should have some matics premined
@@ -251,31 +251,31 @@ func TestE2E_TxPool_BroadcastTransactions(t *testing.T) {
 	nonce := uint64(0)
 
 	for i := 0; i < txNum; i++ {
-		txn := &ethgo.Transaction{
+		txn := types.NewTx(&types.MixedTxn{
 			Value: sendAmount,
 			To:    &recipient,
 			Gas:   21000,
 			Nonce: nonce,
-		}
+		})
 
 		if i%2 == 0 {
-			txn.Type = ethgo.TransactionDynamicFee
-			txn.MaxFeePerGas = big.NewInt(1000000000)
-			txn.MaxPriorityFeePerGas = big.NewInt(100000000)
+			txn.SetTransactionType(types.DynamicFeeTx)
+			txn.SetGasFeeCap(big.NewInt(1000000000))
+			txn.SetGasTipCap(big.NewInt(100000000))
 		} else {
-			txn.Type = ethgo.TransactionLegacy
-			txn.GasPrice = ethgo.Gwei(2).Uint64()
+			txn.SetTransactionType(types.LegacyTx)
+			txn.SetGasPrice(ethgo.Gwei(2))
 		}
 
 		sendTransaction(t, client, sender, txn)
-		sentAmount = sentAmount.Add(sentAmount, txn.Value)
+		sentAmount = sentAmount.Add(sentAmount, txn.Value())
 		nonce++
 	}
 
 	// Wait until the balance has changed on all nodes in the cluster
 	err = cluster.WaitUntil(time.Minute, time.Second*3, func() bool {
 		for _, srv := range cluster.Servers {
-			balance, err := srv.WaitForNonZeroBalance(recipient, time.Second*10)
+			balance, err := srv.WaitForNonZeroBalance(ethgo.Address(recipient), time.Second*10)
 			assert.NoError(t, err)
 			if balance != nil && balance.BitLen() > 0 {
 				assert.Equal(t, sentAmount, balance)
@@ -290,35 +290,40 @@ func TestE2E_TxPool_BroadcastTransactions(t *testing.T) {
 }
 
 // sendTransaction is a helper function which signs transaction with provided private key and sends it
-func sendTransaction(t *testing.T, client *jsonrpc.Eth, sender *wallet.Key, txn *ethgo.Transaction) {
+func sendTransaction(t *testing.T, client *jsonrpc.Eth, sender crypto.Key, txn *types.Transaction) {
 	t.Helper()
 
 	chainID, err := client.ChainID()
 	require.NoError(t, err)
 
-	if txn.Type == ethgo.TransactionDynamicFee {
-		txn.ChainID = chainID
+	if txn.Type() == types.DynamicFeeTx {
+		txn.SetChainID(chainID)
 	}
 
-	signer := wallet.NewEIP155Signer(chainID.Uint64())
-	signedTxn, err := signer.SignTx(txn, sender)
+	signer := crypto.NewLondonOrBerlinSigner(chainID.Uint64(), true,
+		crypto.NewEIP155Signer(chainID.Uint64(), true))
+
+	signedTxn, err := signer.SignTxWithCallback(txn,
+		func(hash types.Hash) (sig []byte, err error) {
+			return sender.Sign(hash[:])
+		})
 	require.NoError(t, err)
 
-	txnRaw, err := signedTxn.MarshalRLPTo(nil)
+	txnRlp := signedTxn.MarshalRLPTo(nil)
 	require.NoError(t, err)
 
-	_, err = client.SendRawTransaction(txnRaw)
+	_, err = client.SendRawTransaction(txnRlp)
 	require.NoError(t, err)
 }
 
-func txCost(t *ethgo.Transaction) *big.Int {
+func txCost(t *types.Transaction) *big.Int {
 	var factor *big.Int
 
-	if t.Type == ethgo.TransactionDynamicFee {
-		factor = new(big.Int).Set(t.MaxFeePerGas)
+	if t.Type() == types.DynamicFeeTx {
+		factor = new(big.Int).Set(t.GasFeeCap())
 	} else {
-		factor = new(big.Int).SetUint64(t.GasPrice)
+		factor = new(big.Int).Set(t.GasPrice())
 	}
 
-	return new(big.Int).Mul(factor, new(big.Int).SetUint64(t.Gas))
+	return new(big.Int).Mul(factor, new(big.Int).SetUint64(t.Gas()))
 }

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -1058,13 +1058,11 @@ func (c *TestCluster) Deploy(t *testing.T, sender *crypto.ECDSAKey, bytecode []b
 func (c *TestCluster) Transfer(t *testing.T, sender *crypto.ECDSAKey, target types.Address, value *big.Int) *TestTxn {
 	t.Helper()
 
-	tx := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			From:  sender.Address(),
-			Value: value,
-			To:    &target,
-		},
-	})
+	tx := types.NewTx(types.NewLegacyTx(
+		types.WithFrom(sender.Address()),
+		types.WithValue(value),
+		types.WithTo(&target),
+	))
 
 	return c.SendTxn(t, sender, tx)
 }
@@ -1072,13 +1070,11 @@ func (c *TestCluster) Transfer(t *testing.T, sender *crypto.ECDSAKey, target typ
 func (c *TestCluster) MethodTxn(t *testing.T, sender *crypto.ECDSAKey, target types.Address, input []byte) *TestTxn {
 	t.Helper()
 
-	tx := types.NewTx(&types.LegacyTx{
-		BaseTx: &types.BaseTx{
-			From:  sender.Address(),
-			Input: input,
-			To:    &target,
-		},
-	})
+	tx := types.NewTx(types.NewLegacyTx(
+		types.WithFrom(sender.Address()),
+		types.WithInput(input),
+		types.WithTo(&target),
+	))
 
 	return c.SendTxn(t, sender, tx)
 }

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -1128,8 +1128,7 @@ func (c *TestCluster) SendTxn(t *testing.T, sender *crypto.ECDSAKey, txn *types.
 	chainID, err := client.Eth().ChainID()
 	require.NoError(t, err)
 
-	signer := crypto.NewLondonOrBerlinSigner(chainID.Uint64(), true,
-		crypto.NewEIP155Signer(chainID.Uint64(), true))
+	signer := crypto.NewLondonSigner(chainID.Uint64())
 	signedTxn, err := signer.SignTxWithCallback(txn,
 		func(hash types.Hash) (sig []byte, err error) {
 			return sender.Sign(hash.Bytes())

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -1105,7 +1105,7 @@ func (c *TestCluster) SendTxn(t *testing.T, sender *crypto.ECDSAKey, txn *types.
 		txn.SetNonce(nonce)
 	}
 
-	if txn.GasPrice() == big.NewInt(0) {
+	if txn.GasPrice() == nil || txn.GasPrice() == big.NewInt(0) {
 		gasPrice, err := client.Eth().GasPrice()
 		require.NoError(t, err)
 

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -1122,7 +1122,8 @@ func (c *TestCluster) SendTxn(t *testing.T, sender *crypto.ECDSAKey, txn *types.
 	chainID, err := client.Eth().ChainID()
 	require.NoError(t, err)
 
-	signer := crypto.NewEIP155Signer(chainID.Uint64(), true)
+	signer := crypto.NewLondonOrBerlinSigner(chainID.Uint64(), true,
+		crypto.NewEIP155Signer(chainID.Uint64(), true))
 	signedTxn, err := signer.SignTxWithCallback(txn,
 		func(hash types.Hash) (sig []byte, err error) {
 			return sender.Sign(hash.Bytes())

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -1046,8 +1046,10 @@ func (c *TestCluster) Deploy(t *testing.T, sender *crypto.ECDSAKey, bytecode []b
 	t.Helper()
 
 	tx := types.NewTx(&types.LegacyTx{
-		From:  sender.Address(),
-		Input: bytecode,
+		BaseTx: &types.BaseTx{
+			From:  sender.Address(),
+			Input: bytecode,
+		},
 	})
 
 	return c.SendTxn(t, sender, tx)
@@ -1057,9 +1059,11 @@ func (c *TestCluster) Transfer(t *testing.T, sender *crypto.ECDSAKey, target typ
 	t.Helper()
 
 	tx := types.NewTx(&types.LegacyTx{
-		From:  sender.Address(),
-		Value: value,
-		To:    &target,
+		BaseTx: &types.BaseTx{
+			From:  sender.Address(),
+			Value: value,
+			To:    &target,
+		},
 	})
 
 	return c.SendTxn(t, sender, tx)
@@ -1069,9 +1073,11 @@ func (c *TestCluster) MethodTxn(t *testing.T, sender *crypto.ECDSAKey, target ty
 	t.Helper()
 
 	tx := types.NewTx(&types.LegacyTx{
-		From:  sender.Address(),
-		Input: input,
-		To:    &target,
+		BaseTx: &types.BaseTx{
+			From:  sender.Address(),
+			Input: input,
+			To:    &target,
+		},
 	})
 
 	return c.SendTxn(t, sender, tx)

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -1124,14 +1124,14 @@ func (c *TestCluster) SendTxn(t *testing.T, sender *crypto.ECDSAKey, txn *types.
 
 	signer := crypto.NewEIP155Signer(chainID.Uint64(), true)
 	signedTxn, err := signer.SignTxWithCallback(txn,
-		func(hash []byte) (sig []byte, err error) {
-			return sender.Sign(hash)
+		func(hash types.Hash) (sig []byte, err error) {
+			return sender.Sign(hash.Bytes())
 		})
 	require.NoError(t, err)
 
-	txnRaw := signedTxn.MarshalRLPTo(nil)
+	rlpTxn := signedTxn.MarshalRLPTo(nil)
 
-	hash, err := client.Eth().SendRawTransaction(txnRaw)
+	hash, err := client.Eth().SendRawTransaction(rlpTxn)
 	require.NoError(t, err)
 
 	return &TestTxn{

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -21,6 +21,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/genesis"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -28,7 +29,6 @@ import (
 	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/abi"
 	"github.com/umbracle/ethgo/jsonrpc"
-	"github.com/umbracle/ethgo/wallet"
 )
 
 const (
@@ -1042,30 +1042,43 @@ func (c *TestCluster) Call(t *testing.T, to types.Address, method *abi.Method,
 	return output
 }
 
-func (c *TestCluster) Deploy(t *testing.T, sender ethgo.Key, bytecode []byte) *TestTxn {
+func (c *TestCluster) Deploy(t *testing.T, sender *crypto.ECDSAKey, bytecode []byte) *TestTxn {
 	t.Helper()
 
-	return c.SendTxn(t, sender, &ethgo.Transaction{From: sender.Address(), Input: bytecode})
+	tx := types.NewTx(&types.MixedTxn{
+		From:  sender.Address(),
+		Input: bytecode,
+	})
+
+	return c.SendTxn(t, sender, tx)
 }
 
-func (c *TestCluster) Transfer(t *testing.T, sender ethgo.Key, target types.Address, value *big.Int) *TestTxn {
+func (c *TestCluster) Transfer(t *testing.T, sender *crypto.ECDSAKey, target types.Address, value *big.Int) *TestTxn {
 	t.Helper()
 
-	targetAddr := ethgo.Address(target)
+	tx := types.NewTx(&types.MixedTxn{
+		From:  sender.Address(),
+		Value: value,
+		To:    &target,
+	})
 
-	return c.SendTxn(t, sender, &ethgo.Transaction{From: sender.Address(), To: &targetAddr, Value: value})
+	return c.SendTxn(t, sender, tx)
 }
 
-func (c *TestCluster) MethodTxn(t *testing.T, sender ethgo.Key, target types.Address, input []byte) *TestTxn {
+func (c *TestCluster) MethodTxn(t *testing.T, sender *crypto.ECDSAKey, target types.Address, input []byte) *TestTxn {
 	t.Helper()
 
-	targetAddr := ethgo.Address(target)
+	tx := types.NewTx(&types.MixedTxn{
+		From:  sender.Address(),
+		Input: input,
+		To:    &target,
+	})
 
-	return c.SendTxn(t, sender, &ethgo.Transaction{From: sender.Address(), To: &targetAddr, Input: input})
+	return c.SendTxn(t, sender, tx)
 }
 
 // SendTxn sends a transaction
-func (c *TestCluster) SendTxn(t *testing.T, sender ethgo.Key, txn *ethgo.Transaction) *TestTxn {
+func (c *TestCluster) SendTxn(t *testing.T, sender *crypto.ECDSAKey, txn *types.Transaction) *TestTxn {
 	t.Helper()
 
 	// since we might use get nonce to query the latest nonce and that value is only
@@ -1079,42 +1092,44 @@ func (c *TestCluster) SendTxn(t *testing.T, sender ethgo.Key, txn *ethgo.Transac
 	require.NoError(t, err)
 
 	// initialize transaction values if not set
-	if txn.Nonce == 0 {
-		nonce, err := client.Eth().GetNonce(sender.Address(), ethgo.Latest)
+	if txn.Nonce() == 0 {
+		nonce, err := client.Eth().GetNonce(ethgo.Address(sender.Address()), ethgo.Latest)
 		require.NoError(t, err)
 
-		txn.Nonce = nonce
+		txn.SetNonce(nonce)
 	}
 
-	if txn.GasPrice == 0 {
+	if txn.GasPrice() == big.NewInt(0) {
 		gasPrice, err := client.Eth().GasPrice()
 		require.NoError(t, err)
 
-		txn.GasPrice = gasPrice
+		txn.SetGasPrice(new(big.Int).SetUint64(gasPrice))
 	}
 
-	if txn.Gas == 0 {
+	if txn.Gas() == 0 {
 		callMsg := txrelayer.ConvertTxnToCallMsg(txn)
 
 		gasLimit, err := client.Eth().EstimateGas(callMsg)
 		if err != nil {
 			// gas estimation can fail in case an account is not allow-listed
 			// (fallback it to default gas limit in that case)
-			txn.Gas = txrelayer.DefaultGasLimit
+			txn.SetGas(txrelayer.DefaultGasLimit)
 		} else {
-			txn.Gas = gasLimit
+			txn.SetGas(gasLimit)
 		}
 	}
 
 	chainID, err := client.Eth().ChainID()
 	require.NoError(t, err)
 
-	signer := wallet.NewEIP155Signer(chainID.Uint64())
-	signedTxn, err := signer.SignTx(txn, sender)
+	signer := crypto.NewEIP155Signer(chainID.Uint64(), true)
+	signedTxn, err := signer.SignTxWithCallback(txn,
+		func(hash []byte) (sig []byte, err error) {
+			return sender.Sign(hash)
+		})
 	require.NoError(t, err)
 
-	txnRaw, err := signedTxn.MarshalRLPTo(nil)
-	require.NoError(t, err)
+	txnRaw := signedTxn.MarshalRLPTo(nil)
 
 	hash, err := client.Eth().SendRawTransaction(txnRaw)
 	require.NoError(t, err)
@@ -1129,12 +1144,12 @@ func (c *TestCluster) SendTxn(t *testing.T, sender ethgo.Key, txn *ethgo.Transac
 type TestTxn struct {
 	client  *jsonrpc.Eth
 	hash    ethgo.Hash
-	txn     *ethgo.Transaction
+	txn     *types.Transaction
 	receipt *ethgo.Receipt
 }
 
 // Txn returns the raw transaction that was sent
-func (t *TestTxn) Txn() *ethgo.Transaction {
+func (t *TestTxn) Txn() *types.Transaction {
 	return t.txn
 }
 
@@ -1156,7 +1171,7 @@ func (t *TestTxn) Failed() bool {
 // Reverted returns whether the transaction failed and was reverted consuming
 // all the gas from the call
 func (t *TestTxn) Reverted() bool {
-	return t.receipt.Status == uint64(types.ReceiptFailed) && t.txn.Gas == t.receipt.GasUsed
+	return t.receipt.Status == uint64(types.ReceiptFailed) && t.txn.Gas() == t.receipt.GasUsed
 }
 
 // Wait waits for the transaction to be executed

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -1045,7 +1045,7 @@ func (c *TestCluster) Call(t *testing.T, to types.Address, method *abi.Method,
 func (c *TestCluster) Deploy(t *testing.T, sender *crypto.ECDSAKey, bytecode []byte) *TestTxn {
 	t.Helper()
 
-	tx := types.NewTx(&types.MixedTxn{
+	tx := types.NewTx(&types.LegacyTx{
 		From:  sender.Address(),
 		Input: bytecode,
 	})
@@ -1056,7 +1056,7 @@ func (c *TestCluster) Deploy(t *testing.T, sender *crypto.ECDSAKey, bytecode []b
 func (c *TestCluster) Transfer(t *testing.T, sender *crypto.ECDSAKey, target types.Address, value *big.Int) *TestTxn {
 	t.Helper()
 
-	tx := types.NewTx(&types.MixedTxn{
+	tx := types.NewTx(&types.LegacyTx{
 		From:  sender.Address(),
 		Value: value,
 		To:    &target,
@@ -1068,7 +1068,7 @@ func (c *TestCluster) Transfer(t *testing.T, sender *crypto.ECDSAKey, target typ
 func (c *TestCluster) MethodTxn(t *testing.T, sender *crypto.ECDSAKey, target types.Address, input []byte) *TestTxn {
 	t.Helper()
 
-	tx := types.NewTx(&types.MixedTxn{
+	tx := types.NewTx(&types.LegacyTx{
 		From:  sender.Address(),
 		Input: input,
 		To:    &target,

--- a/helper/tests/testing.go
+++ b/helper/tests/testing.go
@@ -31,7 +31,7 @@ var (
 func GenerateKeyAndAddr(t *testing.T) (*ecdsa.PrivateKey, types.Address) {
 	t.Helper()
 
-	key, err := crypto.GenerateECDSAKey()
+	key, err := crypto.GenerateECDSAPrivateKey()
 
 	assert.NoError(t, err)
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -572,6 +572,7 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 
 	// Check if the transaction is signed properly
 
+	fmt.Printf("Arrived tx to tx pool %+v\n", tx.Inner)
 	// Extract the sender
 	from, signerErr := p.signer.Sender(tx)
 	if signerErr != nil {

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -571,8 +571,6 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 	}
 
 	// Check if the transaction is signed properly
-
-	fmt.Printf("Arrived tx to tx pool %+v\n", tx.Inner)
 	// Extract the sender
 	from, signerErr := p.signer.Sender(tx)
 	if signerErr != nil {

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -3537,7 +3537,7 @@ func TestAddTxsInOrder(t *testing.T) {
 	addrsTxs := [accountCount]container{}
 
 	for i := 0; i < accountCount; i++ {
-		key, err := crypto.GenerateECDSAKey()
+		key, err := crypto.GenerateECDSAPrivateKey()
 		require.NoError(t, err)
 
 		addrsTxs[i] = container{
@@ -3774,7 +3774,7 @@ func BenchmarkAddTxTime(b *testing.B) {
 	b.Run("benchmark add one tx", func(b *testing.B) {
 		signer := crypto.NewEIP155Signer(100)
 
-		key, err := crypto.GenerateECDSAKey()
+		key, err := crypto.GenerateECDSAPrivateKey()
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -3802,7 +3802,7 @@ func BenchmarkAddTxTime(b *testing.B) {
 	b.Run("benchmark fill account", func(b *testing.B) {
 		signer := crypto.NewEIP155Signer(100)
 
-		key, err := crypto.GenerateECDSAKey()
+		key, err := crypto.GenerateECDSAPrivateKey()
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -301,11 +301,13 @@ func ConvertTxnToCallMsg(txn *types.Transaction) *ethgo.CallMsg {
 // convertTxn converts transaction from types.Transaction to ethgo.Transaction
 func convertTxn(tx *types.Transaction) *ethgo.Transaction {
 	v, r, s := tx.RawSignatureValues()
-	accessList := make(ethgo.AccessList, 0)
+
 	gasPrice := uint64(0)
 	if tx.GasPrice() != nil {
 		gasPrice = tx.GasPrice().Uint64()
 	}
+
+	accessList := make(ethgo.AccessList, 0)
 
 	for _, e := range tx.AccessList() {
 		storageKeys := make([]ethgo.Hash, 0)

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -323,6 +323,18 @@ func convertTxn(tx *types.Transaction) *ethgo.Transaction {
 			})
 	}
 
+	var (
+		vRaw []byte
+		rRaw []byte
+		sRaw []byte
+	)
+
+	if v != nil && r != nil && s != nil {
+		vRaw = v.Bytes()
+		rRaw = r.Bytes()
+		sRaw = s.Bytes()
+	}
+
 	return &ethgo.Transaction{
 		Hash:                 ethgo.Hash(tx.Hash()),
 		From:                 ethgo.Address(tx.From()),
@@ -332,9 +344,9 @@ func convertTxn(tx *types.Transaction) *ethgo.Transaction {
 		Gas:                  tx.Gas(),
 		Value:                tx.Value(),
 		Nonce:                tx.Nonce(),
-		V:                    v.Bytes(),
-		R:                    r.Bytes(),
-		S:                    s.Bytes(),
+		V:                    vRaw,
+		R:                    rRaw,
+		S:                    sRaw,
 		ChainID:              tx.ChainID(),
 		AccessList:           accessList,
 		MaxPriorityFeePerGas: tx.GasTipCap(),

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -322,6 +322,7 @@ func convertTxn(tx *types.Transaction) *ethgo.Transaction {
 					Storage: storageKeys,
 				})
 		}
+
 		return accessList
 	}
 

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -177,7 +177,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *types.Transaction, key crypto
 			compMaxFeePerGas = compMaxFeePerGas.Div(compMaxFeePerGas, big.NewInt(100))
 			txn.SetGasFeeCap(new(big.Int).Add(maxFeePerGas, compMaxFeePerGas))
 		}
-	} else if txn.GasPrice().Uint64() == 0 || txn.GasPrice() == nil {
+	} else if txn.GasPrice() == nil || txn.GasPrice().Uint64() == 0 {
 		gasPrice, err := t.Client().Eth().GasPrice()
 		if err != nil {
 			return ethgo.ZeroHash, fmt.Errorf("failed to get gas price: %w", err)

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -197,8 +197,8 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *types.Transaction, key crypto
 		txn.SetGas(gasLimit + (gasLimit * gasLimitIncreasePercentage / 100))
 	}
 
-	signer := crypto.NewLondonOrBerlinSigner(
-		chainID.Uint64(), true, crypto.NewEIP155Signer(chainID.Uint64(), true))
+	signer := crypto.NewLondonSigner(
+		chainID.Uint64())
 	signedTxn, err := signer.SignTxWithCallback(txn,
 		func(hash types.Hash) (sig []byte, err error) {
 			return key.Sign(hash.Bytes())

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -190,10 +190,11 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *types.Transaction, key crypto
 		txn.SetGas(gasLimit + (gasLimit * gasLimitIncreasePercentage / 100))
 	}
 
-	signer := crypto.NewEIP155Signer(chainID.Uint64(), true)
+	signer := crypto.NewLondonOrBerlinSigner(
+		chainID.Uint64(), true, crypto.NewEIP155Signer(chainID.Uint64(), true))
 	signedTxn, err := signer.SignTxWithCallback(txn,
-		func(hash []byte) (sig []byte, err error) {
-			return key.Sign(hash)
+		func(hash types.Hash) (sig []byte, err error) {
+			return key.Sign(hash.Bytes())
 		})
 	if err != nil {
 		return ethgo.ZeroHash, err

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -281,11 +281,16 @@ func (t *TxRelayerImpl) waitForReceipt(hash ethgo.Hash) (*ethgo.Receipt, error) 
 
 // ConvertTxnToCallMsg converts txn instance to call message
 func ConvertTxnToCallMsg(txn *types.Transaction) *ethgo.CallMsg {
+	gasPrice := uint64(0)
+	if txn.GasPrice() != nil {
+		gasPrice = txn.GasPrice().Uint64()
+	}
+
 	return &ethgo.CallMsg{
 		From:     ethgo.Address(txn.From()),
 		To:       (*ethgo.Address)(txn.To()),
 		Data:     txn.Input(),
-		GasPrice: txn.GasPrice().Uint64(),
+		GasPrice: gasPrice,
 		Value:    txn.Value(),
 		Gas:      new(big.Int).SetUint64(txn.Gas()),
 	}
@@ -295,6 +300,10 @@ func ConvertTxnToCallMsg(txn *types.Transaction) *ethgo.CallMsg {
 func convertTxn(tx *types.Transaction) *ethgo.Transaction {
 	v, r, s := tx.RawSignatureValues()
 	accessList := make(ethgo.AccessList, 0)
+	gasPrice := uint64(0)
+	if tx.GasPrice() != nil {
+		gasPrice = tx.GasPrice().Uint64()
+	}
 
 	for _, e := range tx.AccessList() {
 		storageKeys := make([]ethgo.Hash, 0)
@@ -315,7 +324,7 @@ func convertTxn(tx *types.Transaction) *ethgo.Transaction {
 		From:                 ethgo.Address(tx.From()),
 		To:                   (*ethgo.Address)(tx.To()),
 		Input:                tx.Input(),
-		GasPrice:             tx.GasPrice().Uint64(),
+		GasPrice:             gasPrice,
 		Gas:                  tx.Gas(),
 		Value:                tx.Value(),
 		Nonce:                tx.Nonce(),

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -9,10 +9,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/jsonrpc"
-	"github.com/umbracle/ethgo/wallet"
+
+	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/types"
 )
 
 const (
@@ -35,12 +36,12 @@ var (
 
 type TxRelayer interface {
 	// Call executes a message call immediately without creating a transaction on the blockchain
-	Call(from ethgo.Address, to ethgo.Address, input []byte) (string, error)
+	Call(from types.Address, to types.Address, input []byte) (string, error)
 	// SendTransaction signs given transaction by provided key and sends it to the blockchain
-	SendTransaction(txn *ethgo.Transaction, key ethgo.Key) (*ethgo.Receipt, error)
+	SendTransaction(txn *types.Transaction, key crypto.Key) (*ethgo.Receipt, error)
 	// SendTransactionLocal sends non-signed transaction
 	// (this function is meant only for testing purposes and is about to be removed at some point)
-	SendTransactionLocal(txn *ethgo.Transaction) (*ethgo.Receipt, error)
+	SendTransactionLocal(txn *types.Transaction) (*ethgo.Receipt, error)
 	// Client returns jsonrpc client
 	Client() *jsonrpc.Client
 }
@@ -81,10 +82,10 @@ func NewTxRelayer(opts ...TxRelayerOption) (TxRelayer, error) {
 }
 
 // Call executes a message call immediately without creating a transaction on the blockchain
-func (t *TxRelayerImpl) Call(from ethgo.Address, to ethgo.Address, input []byte) (string, error) {
+func (t *TxRelayerImpl) Call(from types.Address, to types.Address, input []byte) (string, error) {
 	callMsg := &ethgo.CallMsg{
-		From: from,
-		To:   &to,
+		From: ethgo.Address(from),
+		To:   (*ethgo.Address)(&to),
 		Data: input,
 	}
 
@@ -92,17 +93,17 @@ func (t *TxRelayerImpl) Call(from ethgo.Address, to ethgo.Address, input []byte)
 }
 
 // SendTransaction signs given transaction by provided key and sends it to the blockchain
-func (t *TxRelayerImpl) SendTransaction(txn *ethgo.Transaction, key ethgo.Key) (*ethgo.Receipt, error) {
+func (t *TxRelayerImpl) SendTransaction(txn *types.Transaction, key crypto.Key) (*ethgo.Receipt, error) {
 	txnHash, err := t.sendTransactionLocked(txn, key)
 	if err != nil {
-		if txn.Type != ethgo.TransactionLegacy {
+		if txn.Type() != types.LegacyTx {
 			for _, fallbackErr := range dynamicFeeTxFallbackErrs {
 				if strings.Contains(
 					strings.ToLower(err.Error()),
 					strings.ToLower(fallbackErr.Error())) {
 					// "downgrade" transaction to the legacy tx type and resend it
-					txn.Type = ethgo.TransactionLegacy
-					txn.GasPrice = 0
+					txn.SetTransactionType(types.LegacyTx)
+					txn.SetGasPrice(big.NewInt(0))
 
 					return t.SendTransaction(txn, key)
 				}
@@ -120,11 +121,11 @@ func (t *TxRelayerImpl) Client() *jsonrpc.Client {
 	return t.client
 }
 
-func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.Key) (ethgo.Hash, error) {
+func (t *TxRelayerImpl) sendTransactionLocked(txn *types.Transaction, key crypto.Key) (ethgo.Hash, error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	nonce, err := t.client.Eth().GetNonce(key.Address(), ethgo.Pending)
+	nonce, err := t.client.Eth().GetNonce(ethgo.Address(key.Address()), ethgo.Pending)
 	if err != nil {
 		return ethgo.ZeroHash, fmt.Errorf("failed to get nonce: %w", err)
 	}
@@ -134,15 +135,15 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 		return ethgo.ZeroHash, err
 	}
 
-	txn.ChainID = chainID
-	txn.Nonce = nonce
+	txn.SetChainID(chainID)
+	txn.SetNonce(nonce)
 
-	if txn.From == ethgo.ZeroAddress {
-		txn.From = key.Address()
+	if txn.From() == types.ZeroAddress {
+		txn.SetFrom(key.Address())
 	}
 
-	if txn.Type == ethgo.TransactionDynamicFee {
-		maxPriorityFee := txn.MaxPriorityFeePerGas
+	if txn.Type() == types.DynamicFeeTx {
+		maxPriorityFee := txn.GetGasTipCap()
 		if maxPriorityFee == nil {
 			// retrieve the max priority fee per gas
 			if maxPriorityFee, err = t.Client().Eth().MaxPriorityFeePerGas(); err != nil {
@@ -152,10 +153,10 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 			// set retrieved max priority fee per gas increased by certain percentage
 			compMaxPriorityFee := new(big.Int).Mul(maxPriorityFee, big.NewInt(feeIncreasePercentage))
 			compMaxPriorityFee = compMaxPriorityFee.Div(compMaxPriorityFee, big.NewInt(100))
-			txn.MaxPriorityFeePerGas = new(big.Int).Add(maxPriorityFee, compMaxPriorityFee)
+			txn.SetGasTipCap(new(big.Int).Add(maxPriorityFee, compMaxPriorityFee))
 		}
 
-		if txn.MaxFeePerGas == nil {
+		if txn.GetGasFeeCap() == nil {
 			// retrieve the latest base fee
 			feeHist, err := t.Client().Eth().FeeHistory(1, ethgo.Latest, nil)
 			if err != nil {
@@ -168,57 +169,58 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 			maxFeePerGas := new(big.Int).Add(baseFee, maxPriorityFee)
 			compMaxFeePerGas := new(big.Int).Mul(maxFeePerGas, big.NewInt(feeIncreasePercentage))
 			compMaxFeePerGas = compMaxFeePerGas.Div(compMaxFeePerGas, big.NewInt(100))
-			txn.MaxFeePerGas = new(big.Int).Add(maxFeePerGas, compMaxFeePerGas)
+			txn.SetGasFeeCap(new(big.Int).Add(maxFeePerGas, compMaxFeePerGas))
 		}
-	} else if txn.GasPrice == 0 {
+	} else if txn.GasPrice() == big.NewInt(0) {
 		gasPrice, err := t.Client().Eth().GasPrice()
 		if err != nil {
 			return ethgo.ZeroHash, fmt.Errorf("failed to get gas price: %w", err)
 		}
 
-		txn.GasPrice = gasPrice + (gasPrice * feeIncreasePercentage / 100)
+		gasPriceBigInt := new(big.Int).SetUint64(gasPrice + (gasPrice * feeIncreasePercentage / 100))
+		txn.SetGasPrice(gasPriceBigInt)
 	}
 
-	if txn.Gas == 0 {
+	if txn.Gas() == 0 {
 		gasLimit, err := t.client.Eth().EstimateGas(ConvertTxnToCallMsg(txn))
 		if err != nil {
 			return ethgo.ZeroHash, fmt.Errorf("failed to estimate gas: %w", err)
 		}
 
-		txn.Gas = gasLimit + (gasLimit * gasLimitIncreasePercentage / 100)
+		txn.SetGas(gasLimit + (gasLimit * gasLimitIncreasePercentage / 100))
 	}
 
-	signer := wallet.NewEIP155Signer(chainID.Uint64())
-	if txn, err = signer.SignTx(txn, key); err != nil {
+	signer := crypto.NewEIP155Signer(chainID.Uint64(), true)
+	if txn, err = signer.SignTxWithCallback(txn,
+		func(hash []byte) (sig []byte, err error) {
+			return key.Sign(hash)
+		}); err != nil {
 		return ethgo.ZeroHash, err
 	}
 
-	data, err := txn.MarshalRLPTo(nil)
-	if err != nil {
-		return ethgo.ZeroHash, err
-	}
+	rlpTxn := txn.MarshalRLPTo(nil)
 
 	if t.writer != nil {
 		var msg string
 
-		if txn.Type == ethgo.TransactionDynamicFee {
+		if txn.Type() == types.DynamicFeeTx {
 			msg = fmt.Sprintf("[TxRelayer.SendTransaction]\nFrom = %s\nGas = %d\n"+
 				"Max Fee Per Gas = %d\nMax Priority Fee Per Gas = %d\n",
-				txn.From, txn.Gas, txn.MaxFeePerGas, txn.MaxPriorityFeePerGas)
+				txn.From(), txn.Gas(), txn.GasFeeCap(), txn.GasTipCap())
 		} else {
 			msg = fmt.Sprintf("[TxRelayer.SendTransaction]\nFrom = %s\nGas = %d\nGas Price = %d\n",
-				txn.From, txn.Gas, txn.GasPrice)
+				txn.From(), txn.Gas(), txn.GasPrice())
 		}
 
 		_, _ = t.writer.Write([]byte(msg))
 	}
 
-	return t.client.Eth().SendRawTransaction(data)
+	return t.client.Eth().SendRawTransaction(rlpTxn)
 }
 
 // SendTransactionLocal sends non-signed transaction
 // (this function is meant only for testing purposes and is about to be removed at some point)
-func (t *TxRelayerImpl) SendTransactionLocal(txn *ethgo.Transaction) (*ethgo.Receipt, error) {
+func (t *TxRelayerImpl) SendTransactionLocal(txn *types.Transaction) (*ethgo.Receipt, error) {
 	txnHash, err := t.sendTransactionLocalLocked(txn)
 	if err != nil {
 		return nil, err
@@ -227,7 +229,7 @@ func (t *TxRelayerImpl) SendTransactionLocal(txn *ethgo.Transaction) (*ethgo.Rec
 	return t.waitForReceipt(txnHash)
 }
 
-func (t *TxRelayerImpl) sendTransactionLocalLocked(txn *ethgo.Transaction) (ethgo.Hash, error) {
+func (t *TxRelayerImpl) sendTransactionLocalLocked(txn *types.Transaction) (ethgo.Hash, error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
@@ -240,17 +242,17 @@ func (t *TxRelayerImpl) sendTransactionLocalLocked(txn *ethgo.Transaction) (ethg
 		return ethgo.ZeroHash, errNoAccounts
 	}
 
-	txn.From = accounts[0]
+	txn.SetFrom(types.Address(accounts[0]))
 
 	gasLimit, err := t.client.Eth().EstimateGas(ConvertTxnToCallMsg(txn))
 	if err != nil {
 		return ethgo.ZeroHash, err
 	}
 
-	txn.Gas = gasLimit
-	txn.GasPrice = defaultGasPrice
+	txn.SetGas(gasLimit)
+	txn.SetGasPrice(new(big.Int).SetUint64(defaultGasPrice))
 
-	return t.client.Eth().SendTransaction(txn)
+	return t.client.Eth().SendTransaction(convertTxn(txn))
 }
 
 func (t *TxRelayerImpl) waitForReceipt(hash ethgo.Hash) (*ethgo.Receipt, error) {
@@ -278,14 +280,52 @@ func (t *TxRelayerImpl) waitForReceipt(hash ethgo.Hash) (*ethgo.Receipt, error) 
 }
 
 // ConvertTxnToCallMsg converts txn instance to call message
-func ConvertTxnToCallMsg(txn *ethgo.Transaction) *ethgo.CallMsg {
+func ConvertTxnToCallMsg(txn *types.Transaction) *ethgo.CallMsg {
 	return &ethgo.CallMsg{
-		From:     txn.From,
-		To:       txn.To,
-		Data:     txn.Input,
-		GasPrice: txn.GasPrice,
-		Value:    txn.Value,
-		Gas:      new(big.Int).SetUint64(txn.Gas),
+		From:     ethgo.Address(txn.From()),
+		To:       (*ethgo.Address)(txn.To()),
+		Data:     txn.Input(),
+		GasPrice: txn.GasPrice().Uint64(),
+		Value:    txn.Value(),
+		Gas:      new(big.Int).SetUint64(txn.Gas()),
+	}
+}
+
+// convertTxn converts transaction from types.Transaction to ethgo.Transaction
+func convertTxn(tx *types.Transaction) *ethgo.Transaction {
+	v, r, s := tx.RawSignatureValues()
+	accessList := make(ethgo.AccessList, 0)
+
+	for _, e := range tx.AccessList() {
+		storageKeys := make([]ethgo.Hash, 0)
+
+		for _, sk := range e.StorageKeys {
+			storageKeys = append(storageKeys, ethgo.Hash(sk))
+		}
+
+		accessList = append(accessList,
+			ethgo.AccessEntry{
+				Address: ethgo.Address(e.Address),
+				Storage: storageKeys,
+			})
+	}
+
+	return &ethgo.Transaction{
+		Hash:                 ethgo.Hash(tx.Hash()),
+		From:                 ethgo.Address(tx.From()),
+		To:                   (*ethgo.Address)(tx.To()),
+		Input:                tx.Input(),
+		GasPrice:             tx.GasPrice().Uint64(),
+		Gas:                  tx.Gas(),
+		Value:                tx.Value(),
+		Nonce:                tx.Nonce(),
+		V:                    v.Bytes(),
+		R:                    r.Bytes(),
+		S:                    s.Bytes(),
+		ChainID:              tx.ChainID(),
+		AccessList:           accessList,
+		MaxPriorityFeePerGas: tx.GasTipCap(),
+		MaxFeePerGas:         tx.GasFeeCap(),
 	}
 }
 

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -181,6 +181,15 @@ func (t *Transaction) SetSignatureValues(v, r, s *big.Int) {
 	t.Inner.setSignatureValues(v, r, s)
 }
 
+// SplitToRawSignatureValues splits signature to v, r and s components and sets it to the transaction
+func (t *Transaction) SplitToRawSignatureValues(signature, vRaw []byte) {
+	r := new(big.Int).SetBytes(signature[:HashLength])
+	s := new(big.Int).SetBytes(signature[HashLength : 2*HashLength])
+	v := new(big.Int).SetBytes(vRaw)
+
+	t.SetSignatureValues(v, r, s)
+}
+
 func (t *Transaction) SetFrom(addr Address) {
 	t.Inner.setFrom(addr)
 }


### PR DESCRIPTION
# Description

The PR introduces `ECDSAKey` which is used to encapsulate ECDSA private, public key and Ethereum address. As a consequence, transaction signing logic needed to be changed to rely on crypto.Key instead of `ethgo.Key` interface and instead of the `ethgo` abstraction for `Transaction` and `transaction signers`, the abstractions from the Blade are used.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
