### PR TITLE
Bump Ethereum tests version

### DIFF
--- a/crypto/txsigner_london_berlin_test.go
+++ b/crypto/txsigner_london_berlin_test.go
@@ -71,6 +71,7 @@ func TestLondonSignerSender(t *testing.T) {
 			require.NoError(t, err, "unable to generate private key")
 
 			var txn *types.Transaction
+
 			switch tc.txType {
 			case types.AccessListTx:
 				txn = types.NewTx(&types.AccessListTxn{

--- a/state/executor.go
+++ b/state/executor.go
@@ -648,6 +648,7 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 		if err := t.state.IncrNonce(msg.From()); err != nil {
 			return nil, err
 		}
+
 		result = t.Call2(msg.From(), *(msg.To()), msg.Input(), value, gasLeft, initialAccessList)
 	}
 

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -34,6 +34,7 @@ func (c *state) calculateGasForEIP2929(addr types.Address) uint64 {
 		gas = WarmStorageReadCostEIP2929
 	} else {
 		gas = ColdAccountAccessCostEIP2929
+
 		c.msg.AddToJournal(&runtime.AccessListAddAccountChange{Address: addr})
 		c.msg.AccessList.AddAddress(addr)
 	}

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -1624,8 +1624,10 @@ func Test_opSload(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
 			s, closeFn := getState(tt.config)
 			defer closeFn()
+
 			s.msg = tt.contract
 			s.gas = tt.initState.gas
 			s.sp = tt.initState.sp
@@ -1635,6 +1637,7 @@ func Test_opSload(t *testing.T) {
 			s.host = tt.mockHost
 			tt.contract.AccessList = tt.initState.accessList
 			opSload(s)
+
 			assert.Equal(t, tt.resultState.gas, s.gas, "gas in state after execution is not correct")
 			assert.Equal(t, tt.resultState.sp, s.sp, "sp in state after execution is not correct")
 			assert.Equal(t, tt.resultState.stack, s.stack, "stack in state after execution is not correct")
@@ -2383,6 +2386,7 @@ func Test_opCall(t *testing.T) {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+
 			state, closeFn := getState(&test.config)
 			defer closeFn()
 

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -1636,6 +1636,7 @@ func Test_opSload(t *testing.T) {
 			s.config = tt.config
 			s.host = tt.mockHost
 			tt.contract.AccessList = tt.initState.accessList
+
 			opSload(s)
 
 			assert.Equal(t, tt.resultState.gas, s.gas, "gas in state after execution is not correct")

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/crypto"
@@ -216,7 +217,11 @@ func TestState(t *testing.T) {
 						fc := &forkConfig{name: fork, forks: forks}
 
 						for idx, postStateEntry := range postState {
+							start := time.Now()
 							err := RunSpecificTest(t, file, tc, fc, idx, postStateEntry)
+
+							t.Logf("'%s' executed. Duration=%v\n", file, time.Since(start))
+
 							require.NoError(t, tc.checkError(fork, idx, err))
 						}
 					}

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -169,7 +169,7 @@ func TestState(t *testing.T) {
 		"CALLBlake2f_MaxRounds",
 	}
 
-	folders, err := listFolders([]string{stateTests}, ".json")
+	folders, err := listFolders([]string{stateTests})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +211,7 @@ func TestState(t *testing.T) {
 					for fork, postState := range tc.Post {
 						forks, exists := Forks[fork]
 						if !exists {
-							//t.Logf("%s fork is not supported, skipping test case.", fork)
+							t.Logf("%s fork is not supported, skipping test case.", fork)
 							continue
 						}
 

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -166,6 +166,7 @@ func TestState(t *testing.T) {
 		"RevertPrecompiledTouch",
 		"RevertPrecompiledTouch_storage",
 		"loopMul",
+		"CALLBlake2f_MaxRounds",
 	}
 
 	folders, err := listFolders([]string{stateTests}, ".json")
@@ -210,7 +211,7 @@ func TestState(t *testing.T) {
 					for fork, postState := range tc.Post {
 						forks, exists := Forks[fork]
 						if !exists {
-							t.Logf("%s fork is not supported, skipping test case.", fork)
+							//t.Logf("%s fork is not supported, skipping test case.", fork)
 							continue
 						}
 
@@ -220,7 +221,7 @@ func TestState(t *testing.T) {
 							start := time.Now()
 							err := RunSpecificTest(t, file, tc, fc, idx, postStateEntry)
 
-							t.Logf("'%s' executed. Duration=%v\n", file, time.Since(start))
+							t.Logf("'%s' executed. Fork: %s. Case: %d, Duration=%v\n", file, fork, idx, time.Since(start))
 
 							require.NoError(t, tc.checkError(fork, idx, err))
 						}

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -162,7 +162,7 @@ func TestState(t *testing.T) {
 	}
 
 	skip := []string{
-		"RevertPrecompiledTouch",
+		"loopMul",
 	}
 
 	// There are two folders in spec tests, one for the current tests for the Istanbul fork
@@ -173,18 +173,14 @@ func TestState(t *testing.T) {
 	}
 
 	for _, folder := range folders {
-		files, err := listFiles(folder)
+		files, err := listFiles(folder, ".json")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		for _, file := range files {
-			if !strings.HasSuffix(file, ".json") {
-				continue
-			}
-
 			if contains(long, file) && testing.Short() {
-				t.Skipf("Long tests are skipped in short mode")
+				t.Skip("Long tests are skipped in short mode")
 
 				continue
 			}

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -162,12 +162,12 @@ func TestState(t *testing.T) {
 	}
 
 	skip := []string{
+		"RevertPrecompiledTouch",
+		"RevertPrecompiledTouch_storage",
 		"loopMul",
 	}
 
-	// There are two folders in spec tests, one for the current tests for the Istanbul fork
-	// and one for the legacy tests for the other forks
-	folders, err := listFolders(stateTests)
+	folders, err := listFolders([]string{stateTests}, ".json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,13 +180,13 @@ func TestState(t *testing.T) {
 
 		for _, file := range files {
 			if contains(long, file) && testing.Short() {
-				t.Skip("Long tests are skipped in short mode")
+				t.Logf("Long test '%s' is skipped in short mode\n", file)
 
 				continue
 			}
 
 			if contains(skip, file) {
-				t.Skip()
+				t.Logf("Test '%s' is skipped\n", file)
 
 				continue
 			}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -621,7 +621,7 @@ func listFolders(tests ...string) ([]string, error) {
 	return folders, nil
 }
 
-func listFiles(folder string) ([]string, error) {
+func listFiles(folder string, extensions ...string) ([]string, error) {
 	var files []string
 
 	err := filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
@@ -630,7 +630,15 @@ func listFiles(folder string) ([]string, error) {
 		}
 
 		if !info.IsDir() {
-			files = append(files, path)
+			if len(extensions) > 0 {
+				for _, ext := range extensions {
+					if strings.HasSuffix(path, ext) {
+						files = append(files, path)
+					}
+				}
+			} else {
+				files = append(files, path)
+			}
 		}
 
 		return nil

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -484,6 +484,7 @@ var Forks = map[string]*chain.Forks{
 		chain.Constantinople: chain.NewFork(0),
 	},
 	"ConstantinopleFix": {
+		chain.EIP3607:        chain.NewFork(0),
 		chain.Homestead:      chain.NewFork(0),
 		chain.EIP150:         chain.NewFork(0),
 		chain.EIP155:         chain.NewFork(0),
@@ -491,9 +492,9 @@ var Forks = map[string]*chain.Forks{
 		chain.Byzantium:      chain.NewFork(0),
 		chain.Constantinople: chain.NewFork(0),
 		chain.Petersburg:     chain.NewFork(0),
-		chain.EIP3607:        chain.NewFork(0),
 	},
 	"Istanbul": {
+		chain.EIP3607:        chain.NewFork(0),
 		chain.Homestead:      chain.NewFork(0),
 		chain.EIP150:         chain.NewFork(0),
 		chain.EIP155:         chain.NewFork(0),
@@ -502,7 +503,6 @@ var Forks = map[string]*chain.Forks{
 		chain.Constantinople: chain.NewFork(0),
 		chain.Petersburg:     chain.NewFork(0),
 		chain.Istanbul:       chain.NewFork(0),
-		chain.EIP3607:        chain.NewFork(0),
 	},
 	"FrontierToHomesteadAt5": {
 		chain.EIP3607:   chain.NewFork(0),
@@ -552,6 +552,7 @@ var Forks = map[string]*chain.Forks{
 		chain.Istanbul:       chain.NewFork(5),
 	},
 	"Berlin": {
+		chain.EIP3607:        chain.NewFork(0),
 		chain.Homestead:      chain.NewFork(0),
 		chain.EIP150:         chain.NewFork(0),
 		chain.EIP155:         chain.NewFork(0),
@@ -563,6 +564,7 @@ var Forks = map[string]*chain.Forks{
 		chain.Berlin:         chain.NewFork(0),
 	},
 	"BerlinToLondonAt5": {
+		chain.EIP3607:        chain.NewFork(0),
 		chain.Homestead:      chain.NewFork(0),
 		chain.EIP150:         chain.NewFork(0),
 		chain.EIP155:         chain.NewFork(0),
@@ -613,8 +615,6 @@ func listFolders(paths []string, extensions ...string) ([]string, error) {
 				}
 
 				if len(files) > 0 {
-					fmt.Println("Folder", path)
-
 					folders = append(folders, path)
 				}
 			}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -577,6 +577,7 @@ var Forks = map[string]*chain.Forks{
 		chain.London:         chain.NewFork(5),
 	},
 	// "London": {
+	// 	chain.EIP3607:        chain.NewFork(0),
 	// 	chain.Homestead:      chain.NewFork(0),
 	// 	chain.EIP150:         chain.NewFork(0),
 	// 	chain.EIP155:         chain.NewFork(0),

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -599,7 +599,7 @@ func contains(l []string, name string) bool {
 	return false
 }
 
-func listFolders(paths []string, extensions ...string) ([]string, error) {
+func listFolders(paths []string) ([]string, error) {
 	var folders []string
 
 	for _, rootPath := range paths {


### PR DESCRIPTION
# Description

This PR uses the newest release tag from official `ethereum` EVM tests, and fixes tests folder and files loading which did not load all the tests to be executed.

It also adds logging about test execution and skips two long running tests:
- `loop_mul`
- `CREATEBlake2f_MaxRounds`.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually