### PR TITLE
Implement EIP-3607

### DIFF
--- a/chain/params.go
+++ b/chain/params.go
@@ -93,6 +93,7 @@ const (
 	EIP155         = "EIP155"
 	Governance     = "governance"
 	EIP3855        = "EIP3855"
+	EIP3607        = "EIP3607"
 )
 
 // Forks is map which contains all forks and their starting blocks from genesis
@@ -130,6 +131,7 @@ func (f *Forks) At(block uint64) ForksInTime {
 		EIP155:         f.IsActive(EIP155, block),
 		Governance:     f.IsActive(Governance, block),
 		EIP3855:        f.IsActive(EIP3855, block),
+		EIP3607:        f.IsActive(EIP3607, block),
 	}
 }
 
@@ -181,7 +183,8 @@ type ForksInTime struct {
 	EIP158,
 	EIP155,
 	Governance,
-	EIP3855 bool
+	EIP3855,
+	EIP3607 bool
 }
 
 // AllForksEnabled should contain all supported forks by current edge version
@@ -197,4 +200,5 @@ var AllForksEnabled = &Forks{
 	London:         NewFork(0),
 	Governance:     NewFork(0),
 	EIP3855:        NewFork(0),
+	EIP3607:        NewFork(0),
 }

--- a/state/executor.go
+++ b/state/executor.go
@@ -425,8 +425,28 @@ func (t *Transition) Txn() *Txn {
 	return t.state
 }
 
+// In case account checks should not be skipped, check if code hash is hash for
+// an empty object or empty code hash.
+func (t Transition) checkAccount(msg *types.Transaction) bool {
+	// If needed, skip account checks
+	if !msg.SkipAccountChecks {
+		codeHash := t.state.GetCodeHash(msg.From)
+		if codeHash != types.ZeroHash && codeHash != types.EmptyCodeHash {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Apply applies a new transaction
 func (t *Transition) Apply(msg *types.Transaction) (*runtime.ExecutionResult, error) {
+
+	if !t.checkAccount(msg) {
+		return nil, fmt.Errorf("%w: address %v, codehash: %v", ErrSenderNoEOA, msg.From.String(),
+			t.state.GetCodeHash(msg.From).String())
+	}
+
 	s := t.state.Snapshot()
 
 	result, err := t.apply(msg)
@@ -516,6 +536,7 @@ func (t *Transition) checkDynamicFees(msg *types.Transaction) error {
 
 var (
 	ErrNonceIncorrect        = errors.New("incorrect nonce")
+	ErrSenderNoEOA           = errors.New("sender not an eoa")
 	ErrNotEnoughFundsForGas  = errors.New("not enough funds to cover gas costs")
 	ErrBlockLimitReached     = errors.New("gas limit reached in the pool")
 	ErrIntrinsicGasOverflow  = errors.New("overflow in intrinsic gas calculation")

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -326,15 +326,16 @@ func (t *stTransaction) At(i indexes, baseFee *big.Int) (*types.Transaction, err
 	}
 
 	return &types.Transaction{
-		From:      t.From,
-		To:        t.To,
-		Nonce:     t.Nonce,
-		Value:     value,
-		Gas:       t.GasLimit[i.Gas],
-		GasPrice:  gasPrice,
-		GasFeeCap: t.MaxFeePerGas,
-		GasTipCap: t.MaxPriorityFeePerGas,
-		Input:     hex.MustDecodeHex(t.Data[i.Data]),
+		From:              t.From,
+		To:                t.To,
+		Nonce:             t.Nonce,
+		Value:             value,
+		Gas:               t.GasLimit[i.Gas],
+		GasPrice:          gasPrice,
+		GasFeeCap:         t.MaxFeePerGas,
+		GasTipCap:         t.MaxPriorityFeePerGas,
+		Input:             hex.MustDecodeHex(t.Data[i.Data]),
+		SkipAccountChecks: false,
 	}, nil
 }
 

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -326,16 +326,15 @@ func (t *stTransaction) At(i indexes, baseFee *big.Int) (*types.Transaction, err
 	}
 
 	return &types.Transaction{
-		From:              t.From,
-		To:                t.To,
-		Nonce:             t.Nonce,
-		Value:             value,
-		Gas:               t.GasLimit[i.Gas],
-		GasPrice:          gasPrice,
-		GasFeeCap:         t.MaxFeePerGas,
-		GasTipCap:         t.MaxPriorityFeePerGas,
-		Input:             hex.MustDecodeHex(t.Data[i.Data]),
-		SkipAccountChecks: false,
+		From:      t.From,
+		To:        t.To,
+		Nonce:     t.Nonce,
+		Value:     value,
+		Gas:       t.GasLimit[i.Gas],
+		GasPrice:  gasPrice,
+		GasFeeCap: t.MaxFeePerGas,
+		GasTipCap: t.MaxPriorityFeePerGas,
+		Input:     hex.MustDecodeHex(t.Data[i.Data]),
 	}, nil
 }
 
@@ -422,21 +421,27 @@ func (t *stTransaction) UnmarshalJSON(input []byte) error {
 
 // forks
 var Forks = map[string]*chain.Forks{
-	"Frontier": {},
+	"Frontier": {
+		chain.EIP3607: chain.NewFork(0),
+	},
 	"Homestead": {
+		chain.EIP3607:   chain.NewFork(0),
 		chain.Homestead: chain.NewFork(0),
 	},
 	"EIP150": {
+		chain.EIP3607:   chain.NewFork(0),
 		chain.Homestead: chain.NewFork(0),
 		chain.EIP150:    chain.NewFork(0),
 	},
 	"EIP158": {
+		chain.EIP3607:   chain.NewFork(0),
 		chain.Homestead: chain.NewFork(0),
 		chain.EIP150:    chain.NewFork(0),
 		chain.EIP155:    chain.NewFork(0),
 		chain.EIP158:    chain.NewFork(0),
 	},
 	"Byzantium": {
+		chain.EIP3607:   chain.NewFork(0),
 		chain.Homestead: chain.NewFork(0),
 		chain.EIP150:    chain.NewFork(0),
 		chain.EIP155:    chain.NewFork(0),
@@ -444,6 +449,7 @@ var Forks = map[string]*chain.Forks{
 		chain.Byzantium: chain.NewFork(0),
 	},
 	"Constantinople": {
+		chain.EIP3607:        chain.NewFork(0),
 		chain.Homestead:      chain.NewFork(0),
 		chain.EIP150:         chain.NewFork(0),
 		chain.EIP155:         chain.NewFork(0),
@@ -459,6 +465,7 @@ var Forks = map[string]*chain.Forks{
 		chain.Byzantium:      chain.NewFork(0),
 		chain.Constantinople: chain.NewFork(0),
 		chain.Petersburg:     chain.NewFork(0),
+		chain.EIP3607:        chain.NewFork(0),
 	},
 	"Istanbul": {
 		chain.Homestead:      chain.NewFork(0),
@@ -469,18 +476,19 @@ var Forks = map[string]*chain.Forks{
 		chain.Constantinople: chain.NewFork(0),
 		chain.Petersburg:     chain.NewFork(0),
 		chain.Istanbul:       chain.NewFork(0),
+		chain.EIP3607:        chain.NewFork(0),
 	},
 	"FrontierToHomesteadAt5": {
+		chain.EIP3607:   chain.NewFork(0),
 		chain.Homestead: chain.NewFork(5),
 	},
 	"HomesteadToEIP150At5": {
+		chain.EIP3607:   chain.NewFork(0),
 		chain.Homestead: chain.NewFork(0),
 		chain.EIP150:    chain.NewFork(5),
 	},
-	"HomesteadToDaoAt5": {
-		chain.Homestead: chain.NewFork(0),
-	},
 	"EIP158ToByzantiumAt5": {
+		chain.EIP3607:   chain.NewFork(0),
 		chain.Homestead: chain.NewFork(0),
 		chain.EIP150:    chain.NewFork(0),
 		chain.EIP155:    chain.NewFork(0),
@@ -488,6 +496,7 @@ var Forks = map[string]*chain.Forks{
 		chain.Byzantium: chain.NewFork(5),
 	},
 	"ByzantiumToConstantinopleAt5": {
+		chain.EIP3607:        chain.NewFork(0),
 		chain.Homestead:      chain.NewFork(0),
 		chain.EIP150:         chain.NewFork(0),
 		chain.EIP155:         chain.NewFork(0),
@@ -496,6 +505,7 @@ var Forks = map[string]*chain.Forks{
 		chain.Constantinople: chain.NewFork(5),
 	},
 	"ByzantiumToConstantinopleFixAt5": {
+		chain.EIP3607:        chain.NewFork(0),
 		chain.Homestead:      chain.NewFork(0),
 		chain.EIP150:         chain.NewFork(0),
 		chain.EIP155:         chain.NewFork(0),
@@ -505,6 +515,7 @@ var Forks = map[string]*chain.Forks{
 		chain.Petersburg:     chain.NewFork(5),
 	},
 	"ConstantinopleFixToIstanbulAt5": {
+		chain.EIP3607:        chain.NewFork(0),
 		chain.Homestead:      chain.NewFork(0),
 		chain.EIP150:         chain.NewFork(0),
 		chain.EIP155:         chain.NewFork(0),

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -62,6 +62,9 @@ type Transaction struct {
 	Hash      Hash
 	From      Address
 
+	// When set, the message nonce is not checked against the account nonce.
+	SkipAccountChecks bool
+
 	Type TxType
 
 	ChainID *big.Int

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -62,9 +62,6 @@ type Transaction struct {
 	Hash      Hash
 	From      Address
 
-	// When set, the message nonce is not checked against the account nonce.
-	SkipAccountChecks bool
-
 	Type TxType
 
 	ChainID *big.Int


### PR DESCRIPTION
# Description

Reject transactions whose senders are SC accounts (namely the one that do not have `ZeroHash` byte code nor `EmptyCodeHash`). https://eips.ethereum.org/EIPS/eip-3607

It is implemented as a fork, so that it is possible to configure whether we want such check in place or not.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
