### PR TITLE
Performance improvements

### DIFF
--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -375,3 +375,48 @@ func EncodeUint64ToBytes(value uint64) []byte {
 func EncodeBytesToUint64(b []byte) uint64 {
 	return binary.BigEndian.Uint64(b)
 }
+
+// Generic object pool implementation intended to be used in single-threaded
+// manner and avoid synchronization overhead. It could be probably additionally
+// be improved by using circular buffer as oposed to stack.
+type UnsafePool[T any] struct {
+	stack []T
+}
+
+// Creates new instance of UnsafePool. Depending on observed usage, pool size
+// should be set on creation to avoid pool resizing
+func NewUnsafePool[T any]() *UnsafePool[T] {
+	return &UnsafePool[T]{}
+}
+
+// Get retrieves an object from the unsafepool, or allocates a new one if the pool
+// is empty. The allocation logic (i.e., creating a new object of type T) needs to
+// be provided externally, as Go's type system does not allow calling constructors
+// or functions specific to T without an interface.
+func (f *UnsafePool[T]) Get(newFunc func() T) T {
+	n := len(f.stack)
+	if n == 0 {
+		// Allocate a new T instance using the provided newFunc if the stack is empty.
+		return newFunc()
+	}
+
+	obj := f.stack[n-1]
+	f.stack = f.stack[:n-1]
+
+	return obj
+}
+
+// Put returns an object to the pool and executes reset function if provided. Reset
+// function is used to return the T instance to initial state.
+func (f *UnsafePool[T]) Put(resetFunc func(T) T, obj T) {
+	if resetFunc != nil {
+		obj = resetFunc(obj)
+	}
+
+	f.stack = append(f.stack, obj)
+}
+
+// Clear the content of the pool
+func (f *UnsafePool[T]) Clear() {
+	f.stack = f.stack[:0]
+}

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -1,6 +1,7 @@
 package evm
 
 import (
+	"errors"
 	"math/big"
 	"reflect"
 	"testing"
@@ -858,7 +859,7 @@ func TestCallValue(t *testing.T) {
 		s.msg.Value = value
 
 		opCallValue(s)
-		assert.Equal(t, value, s.pop())
+		assert.Equal(t, value.Uint64(), s.pop().Uint64())
 	})
 
 	t.Run("Msg Value nil", func(t *testing.T) {
@@ -866,7 +867,7 @@ func TestCallValue(t *testing.T) {
 		defer cancelFn()
 
 		opCallValue(s)
-		assert.Equal(t, zero, s.pop())
+		assert.Equal(t, zero.Uint64(), s.pop().Uint64())
 	})
 }
 
@@ -2298,9 +2299,8 @@ func Test_opReturnDataCopy(t *testing.T) {
 // function that checks significant fields. This function should be updated
 // to suite future needs.
 func CompareStates(a *state, b *state) bool {
-
 	// Compare simple fields
-	if a.ip != b.ip || a.lastGasCost != b.lastGasCost || a.sp != b.sp || a.err != b.err || a.stop != b.stop || a.gas != b.gas {
+	if a.ip != b.ip || a.lastGasCost != b.lastGasCost || a.sp != b.sp || !errors.Is(a.err, b.err) || a.stop != b.stop || a.gas != b.gas {
 		return false
 	}
 
@@ -2313,6 +2313,7 @@ func CompareStates(a *state, b *state) bool {
 	if len(a.stack) != len(b.stack) {
 		return false
 	}
+
 	for i := range a.stack {
 		if a.stack[i].Cmp(b.stack[i]) != 0 {
 			return false


### PR DESCRIPTION
# Description

Multiple performance improvements:
    - Pooling of big.Int instances on the stack to avoid frequent allocations/cleanup
    - Removing unnecessary big.Int allocation in pop() method and fixing tests
    - Avoiding unnecessary op.String() calls when tracer is not initialized.


# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Since there is not yet official performance framework, I have tested this fix with custom code.
