### PR TITLE
[BLADE-113] GitHub workflow changes

### DIFF
--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -1,11 +1,11 @@
 ---
 name: Benchmark Tests
 on: # yamllint disable-line rule:truthy
-    workflow_call:
-      outputs:
-        workflow_output:
-          description: "Benchmark Tests output"
-          value: ${{ jobs.benchmark_test.outputs.test_output_failure }}
+  workflow_call:
+    outputs:
+      workflow_output:
+        description: "Benchmark Tests output"
+        value: ${{ jobs.benchmark_test.outputs.test_output_failure }}
 
 jobs:
   benchmark_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ on: # yamllint disable-line rule:truthy
       benchmark-test:
         description: Benchmark Tests
         type: boolean
-        default: true
+        required: true
     outputs:
       build-blade:
         description: Build Blade output

--- a/.github/workflows/deploy-network.yml
+++ b/.github/workflows/deploy-network.yml
@@ -18,6 +18,16 @@ on: # yamllint disable-line rule:truthy
         type: string
         default: "2"
         required: true
+      max_slots:
+        description: Max Slots
+        type: string
+        default: "276480"
+        required: true
+      max_enqueued:
+        description: Max Enqueued
+        type: string
+        default: "276480"
+        required: true
       is_london_fork_active:
         description: EIP-1559
         type: boolean
@@ -42,6 +52,14 @@ on: # yamllint disable-line rule:truthy
         required: true
       block_time:
         description: Block Time
+        type: string
+        required: true
+      max_slots:
+        description: Max Slots
+        type: string
+        required: true
+      max_enqueued:
+        description: Max Enqueued
         type: string
         required: true
       is_london_fork_active:
@@ -80,7 +98,6 @@ jobs:
   check_network:
     name: Check if the network is already deployed
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
     outputs:
       check_output: ${{ steps.check_state_file.outputs.resources }}
       rpc_url: ${{ steps.rpc_url.outputs.url }}
@@ -163,6 +180,8 @@ jobs:
           echo "${{ secrets.VAULT_PASSWORD }}" > password.txt
           sed 's/devnet/${{ inputs.environment }}/g' inventory/aws_ec2.yml > inventory/aws_ec2.yml.tmp && mv inventory/aws_ec2.yml.tmp inventory/aws_ec2.yml
           sed 's/blade_tag: .*/blade_tag: ${{ github.sha }}/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
+          sed 's/is_bridge_active: .*/blade_tag: ${{ inputs.is_bridge_active }}/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
+          sed 's/is_london_fork_active: .*/blade_tag: ${{ inputs.is_london_fork_active }}/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
           sed 's/INFO/${{ vars.LOG_LEVEL }}/g' roles/blade/templates/blade.service > roles/blade/templates/blade.service.tmp && mv roles/blade/templates/blade.service.tmp roles/blade/templates/blade.service
       - name: Setup Ansible
         working-directory: ansible
@@ -175,11 +194,11 @@ jobs:
       - name: Run Ansible (Bootstrap blade)
         if: (steps.previous_data.outputs.previous_data_output == '' || contains(steps.previous_data.outputs.previous_data_output, 'error'))
         working-directory: ansible
-        run: ansible-playbook site.yml --extra-vars "clean_deploy_title=${{ inputs.environment }} blade_repository=${{ github.repository }} block_gas_limit=${{ inputs.block_gas_limit }} block_time=${{ inputs.block_time }} is_london_fork_active=${{ inputs.is_london_fork_active }} is_bridge_active=${{ inputs.is_bridge_active }}"
+        run: ansible-playbook site.yml --extra-vars "clean_deploy_title=${{ inputs.environment }} blade_repository=${{ github.repository }} block_gas_limit=${{ inputs.block_gas_limit }} block_time=${{ inputs.block_time }} max_slots=${{ inputs.max_slots }} max_enqueued=${{ inputs.max_enqueued }}"
       - name: Run Ansible (Restore data)
         if: contains(steps.previous_data.outputs.previous_data_output, 'download')
         working-directory: ansible
-        run: ansible-playbook site.yml --extra-vars "clean_deploy_title=${{ inputs.environment }} blade_repository=${{ github.repository }} block_gas_limit=${{ inputs.block_gas_limit }} block_time=${{ inputs.block_time }} s3_bucket=${{ secrets.AWS_S3_BLADE_BUCKET }} restore_data=true"
+        run: ansible-playbook site.yml --extra-vars "clean_deploy_title=${{ inputs.environment }} s3_bucket=${{ secrets.AWS_S3_BLADE_BUCKET }} restore_data=true"
       - name: Ansible Failed
         if: failure()
         id: ansible_failure
@@ -194,6 +213,12 @@ jobs:
     if: (always() && inputs.notification)
     with:
       environment: ${{ inputs.environment }}
+      block_gas_limit: ${{ inputs.block_gas_limit }}
+      block_time: ${{ inputs.block_time }}
+      max_slots: ${{ inputs.max_slots }}
+      max_enqueued: ${{ inputs.max_enqueued }}
+      is_london_fork_active: ${{ inputs.is_london_fork_active }}
+      is_bridge_active: ${{ inputs.is_bridge_active }}
       deploy_network_terraform_output: ${{ needs.deploy_network.outputs.terraform_output }}
       deploy_network_ansible_output: ${{ needs.deploy_network.outputs.ansible_output }}
       rpc_url: ${{ needs.check_network.outputs.rpc_url || needs.deploy_network.outputs.rpc_url }}

--- a/.github/workflows/deploy-network.yml
+++ b/.github/workflows/deploy-network.yml
@@ -180,8 +180,8 @@ jobs:
           echo "${{ secrets.VAULT_PASSWORD }}" > password.txt
           sed 's/devnet/${{ inputs.environment }}/g' inventory/aws_ec2.yml > inventory/aws_ec2.yml.tmp && mv inventory/aws_ec2.yml.tmp inventory/aws_ec2.yml
           sed 's/blade_tag: .*/blade_tag: ${{ github.sha }}/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
-          sed 's/is_bridge_active: .*/blade_tag: ${{ inputs.is_bridge_active }}/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
-          sed 's/is_london_fork_active: .*/blade_tag: ${{ inputs.is_london_fork_active }}/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
+          sed 's/is_bridge_active: .*/is_bridge_active: ${{ inputs.is_bridge_active }}/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
+          sed 's/is_london_fork_active: .*/is_london_fork_active: ${{ inputs.is_london_fork_active }}/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
           sed 's/INFO/${{ vars.LOG_LEVEL }}/g' roles/blade/templates/blade.service > roles/blade/templates/blade.service.tmp && mv roles/blade/templates/blade.service.tmp roles/blade/templates/blade.service
       - name: Setup Ansible
         working-directory: ansible

--- a/.github/workflows/deploy-network.yml
+++ b/.github/workflows/deploy-network.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Run Ansible (Restore data)
         if: contains(steps.previous_data.outputs.previous_data_output, 'download')
         working-directory: ansible
-        run: ansible-playbook site.yml --extra-vars "clean_deploy_title=${{ inputs.environment }} s3_bucket=${{ secrets.AWS_S3_BLADE_BUCKET }} restore_data=true"
+        run: ansible-playbook site.yml --extra-vars "clean_deploy_title=${{ inputs.environment }} blade_repository=${{ github.repository }} s3_bucket=${{ secrets.AWS_S3_BLADE_BUCKET }} restore_data=true"
       - name: Ansible Failed
         if: failure()
         id: ansible_failure

--- a/.github/workflows/deploy-network.yml
+++ b/.github/workflows/deploy-network.yml
@@ -210,7 +210,7 @@ jobs:
     name: Deploy Notification
     needs: [check_network, deploy_network]
     uses: ./.github/workflows/notification-deploy-network.yml
-    if: (always() && inputs.notification)
+    if: ((success() || failure()) && inputs.notification)
     with:
       environment: ${{ inputs.environment }}
       block_gas_limit: ${{ inputs.block_gas_limit }}

--- a/.github/workflows/destroy-network.yml
+++ b/.github/workflows/destroy-network.yml
@@ -11,7 +11,7 @@ on: # yamllint disable-line rule:truthy
       logs:
         description: Upload Logs
         type: boolean
-        default: false
+        default: true
       notification:
         description: Notification
         type: boolean

--- a/.github/workflows/destroy-network.yml
+++ b/.github/workflows/destroy-network.yml
@@ -152,7 +152,7 @@ jobs:
     name: Network Notifications
     uses: ./.github/workflows/notification-destroy-network.yml
     needs: [upload_logs_and_data, destroy_network]
-    if: ((success() || failure()) && inputs.notification)
+    if: (always() && inputs.notification)
     with:
       environment: ${{ inputs.environment }}
       logs: ${{ inputs.logs }}

--- a/.github/workflows/destroy-network.yml
+++ b/.github/workflows/destroy-network.yml
@@ -152,7 +152,7 @@ jobs:
     name: Network Notifications
     uses: ./.github/workflows/notification-destroy-network.yml
     needs: [upload_logs_and_data, destroy_network]
-    if: (always() && inputs.notification)
+    if: ((success() || failure()) && inputs.notification)
     with:
       environment: ${{ inputs.environment }}
       logs: ${{ inputs.logs }}

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -15,7 +15,7 @@ on: # yamllint disable-line rule:truthy
       timeout:
         description: Time Out
         type: string
-        default: "220s"
+        default: "1800s"
         required: true
       rate:
         description: Rate
@@ -136,7 +136,6 @@ jobs:
   check_network:
     name: Check if the network is already deployed
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
     outputs:
       rpc_url: ${{ steps.rpc_url.outputs.url }}
     steps:
@@ -228,6 +227,12 @@ jobs:
     with:
       environment: ${{ inputs.environment }}
       scenario: ${{ inputs.scenario }}
+      timeout: ${{ inputs.timeout }}
+      rate: ${{ inputs.rate }}
+      timeUnit: ${{ inputs.timeUnit }}
+      duration: ${{ inputs.duration }}
+      preAllocatedVUs: ${{ inputs.preAllocatedVUs }}
+      maxVUs: ${{ inputs.maxVUs }}
       tps_avg: ${{ needs.load_test_scenario.outputs.tps_avg }}
       tps_max: ${{ needs.load_test_scenario.outputs.tps_max }}
       iterations: ${{ needs.load_test_scenario.outputs.iterations }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,12 @@ on: # yamllint disable-line rule:truthy
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      force-run:
+        description: Force Run
+        type: boolean
+        default: false
 
 jobs:
   check:
@@ -21,7 +27,7 @@ jobs:
     name: CI
     uses: ./.github/workflows/ci.yml
     needs: check
-    if: needs.check.outputs.new_commit_count > 0
+    if: (needs.check.outputs.new_commit_count > 0 || inputs.force-run)
     with:
       build-blade: true
       lint: true
@@ -35,12 +41,14 @@ jobs:
     name: Deploy Network
     uses: ./.github/workflows/deploy-network.yml
     needs: check
-    if: needs.check.outputs.new_commit_count > 0
+    if: (needs.check.outputs.new_commit_count > 0 || inputs.force-run)
     with:
       environment: nightly
       block_gas_limit: "200000000"
       block_time: "2"
-      is_london_fork_active: true
+      max_slots: "276480"
+      max_enqueued: "276480"
+      is_london_fork_active: false
       is_bridge_active: true
       notification: false
     secrets:
@@ -54,7 +62,7 @@ jobs:
     with:
       environment: nightly
       scenario: EOA
-      timeout: "220s"
+      timeout: "1800s"
       rate: "3000"
       timeUnit: "1s"
       duration: "10m"
@@ -77,7 +85,7 @@ jobs:
     with:
       environment: nightly
       scenario: ERC20
-      timeout: "220s"
+      timeout: "1800s"
       rate: "1500"
       timeUnit: "1s"
       duration: "10m"
@@ -96,8 +104,8 @@ jobs:
   destroy_network:
     name: Destroy Network
     uses: ./.github/workflows/destroy-network.yml
-    needs: [deploy_network, load_test_multiple_eoa, load_test_multiple_erc20]
-    if: always()
+    needs: [check, deploy_network, load_test_multiple_eoa, load_test_multiple_erc20]
+    if: (always() && (needs.check.outputs.new_commit_count > 0 || inputs.force-run))
     with:
       environment: nightly
       logs: true
@@ -113,6 +121,12 @@ jobs:
     if: success() || failure()
     with:
       environment: nightly
+      block_gas_limit: "200000000"
+      block_time: "2"
+      max_slots: "276480"
+      max_enqueued: "276480"
+      is_london_fork_active: false
+      is_bridge_active: true
       logs: true
       build_blade_output: ${{ needs.ci.outputs.build-blade }}
       lint_output: ${{ needs.ci.outputs.lint }}
@@ -151,7 +165,7 @@ jobs:
   notification_load_test_multiple_erc20:
     name: Load Test ERC20 Notification
     uses: ./.github/workflows/notification-load-test.yml
-    needs: [load_test_multiple_erc20, notification_nightly]
+    needs: [load_test_multiple_erc20, notification_nightly, notification_load_test_multiple_eoa]
     if: (always() && needs.load_test_multiple_erc20.outputs.load_test_output == 'true')
     with:
       environment: nightly

--- a/.github/workflows/notification-deploy-network.yml
+++ b/.github/workflows/notification-deploy-network.yml
@@ -7,6 +7,30 @@ on: # yamllint disable-line rule:truthy
         description: The environment to run against
         type: string
         required: true
+      block_gas_limit:
+        description: Block Gas Limit
+        type: string
+        required: true
+      block_time:
+        description: Block Time (sec)
+        type: string
+        required: true
+      max_slots:
+        description: Max Slots
+        type: string
+        required: true
+      max_enqueued:
+        description: Max Enqueued
+        type: string
+        required: true
+      is_london_fork_active:
+        description: EIP-1559
+        type: boolean
+        required: true
+      is_bridge_active:
+        description: With Bridge
+        type: boolean
+        required: true
       deploy_network_terraform_output:
         description: Deploy Network - Terraform output
         type: string
@@ -27,6 +51,7 @@ jobs:
   notification:
     name: Notification
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     steps:
       - name: Short SHA
         id: short_sha
@@ -36,71 +61,117 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-          green_color: '#03C03C'
-          red_color: '#E60012'
           succeed_bnt: 'primary'
           failed_bnt: 'danger'
         with:
           payload: |
             {
-              "attachments": [
+              "blocks": [
                 {
-                  "color": "${{ inputs.deploy_network_terraform_output == '' && inputs.deploy_network_ansible_output == '' && env.green_color || env.red_color }}",
-                  "blocks": [
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Deploy ${{ inputs.environment }}net"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
                     {
-                      "type": "header",
+                      "type": "button",
                       "text": {
                         "type": "plain_text",
-                        "text": "Deploy ${{ inputs.environment }}net"
-                      }
+                        "text": "Workflow Run"
+                      },
+                      "style": "${{ inputs.deploy_network_terraform_output == '' && inputs.deploy_network_ansible_output == '' && env.succeed_bnt || env.failed_bnt }}",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                     },
                     {
-                      "type": "context",
-                      "elements": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "Environment: *${{ inputs.environment }}*"
-                        }
-                      ]
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "JSON-RPC"
+                      },
+                      "url": "http://${{ inputs.rpc_url }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Triggered by: *${{ github.triggering_actor }}*"
                     },
                     {
-                      "type": "context",
-                      "elements": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "Commit: *<https://github.com/${{ github.repository }}/tree/${{ github.sha }}|${{ steps.short_sha.outputs.value }}>*"
-                        }
-                      ]
+                      "type": "mrkdwn",
+                      "text": "Commit: *<https://github.com/${{ github.repository }}/tree/${{ github.sha }}|${{ steps.short_sha.outputs.value }}>*"
+                    }
+                  ]
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Environment: *${{ inputs.environment }}*"
                     },
                     {
-                      "type": "context",
-                      "elements": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "Triggered by: *${{ github.triggering_actor }}*"
-                        }
-                      ]
+                      "type": "mrkdwn",
+                      "text": "Instances Type: *${{ vars.AWS_INSTANCE_TYPE }}*"
+                    }
+                  ]
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Validators: *${{ vars.VALIDATOR_COUNT }}*"
                     },
                     {
-                      "type": "actions",
-                      "elements": [
-                        {
-                          "type": "button",
-                          "text": {
-                            "type": "plain_text",
-                            "text": "Workflow Run"
-                          },
-                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                        },
-                        {
-                          "type": "button",
-                          "text": {
-                            "type": "plain_text",
-                            "text": "JSON-RPC"
-                          },
-                          "url": "http://${{ inputs.rpc_url }}"
-                        }
-                      ]
+                      "type": "mrkdwn",
+                      "text": "Full Nodes: *${{ vars.FULLNODE_COUNT }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Rootchain servers: *${{ vars.GETH_COUNT }}*"
+                    }
+                  ]
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Block Gas Limit: *${{ inputs.block_gas_limit }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Block Time: *${{ inputs.block_time }}s*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Max Slots: *${{ inputs.max_slots }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Max Enqueued: *${{ inputs.max_enqueued }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Bridge: *${{ inputs.is_bridge_active }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "London: *${{ inputs.is_london_fork_active }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Log Level: *${{ vars.LOG_LEVEL }}*"
                     }
                   ]
                 }

--- a/.github/workflows/notification-destroy-network.yml
+++ b/.github/workflows/notification-destroy-network.yml
@@ -37,7 +37,6 @@ jobs:
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
           succeed_bnt: 'primary'
           failed_bnt: 'danger'
-          url: https://s3.console.aws.amazon.com/s3/buckets/${{ secrets.AWS_S3_BLADE_BUCKET }}?region=${{ vars.AWS_REGION }}&prefix=logs/${{ github.run_id }}/
         with:
           payload: |
             {

--- a/.github/workflows/notification-destroy-network.yml
+++ b/.github/workflows/notification-destroy-network.yml
@@ -35,64 +35,53 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-          green_color: '#03C03C'
-          red_color: '#E60012'
           succeed_bnt: 'primary'
           failed_bnt: 'danger'
           url: https://s3.console.aws.amazon.com/s3/buckets/${{ secrets.AWS_S3_BLADE_BUCKET }}?region=${{ vars.AWS_REGION }}&prefix=logs/${{ github.run_id }}/
         with:
           payload: |
             {
-              "attachments": [
+              "blocks": [
                 {
-                  "color": "${{ inputs.destroy_network_upload_logs == '' && inputs.destroy_network_terraform_logs == '' && env.green_color || env.red_color }}",
-                  "blocks": [
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Destroy ${{ inputs.environment }}net"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
                     {
-                      "type": "header",
+                      "type": "button",
                       "text": {
                         "type": "plain_text",
-                        "text": "Destroy ${{ inputs.environment }}net"
-                      }
+                        "text": "Workflow Run"
+                      },
+                      "style": "${{ inputs.destroy_network_upload_logs == '' && inputs.destroy_network_terraform_logs == '' && env.succeed_bnt || env.failed_bnt }}",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                     },
                     {
-                      "type": "context",
-                      "elements": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "Environment: *${{ inputs.environment }}*"
-                        }
-                      ]
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "${{ inputs.logs && inputs.destroy_network_upload_logs == '' && 'Logs' || 'No Logs' }}"
+                      },
+                      "style": "${{ inputs.logs && inputs.destroy_network_upload_logs == '' && env.succeed_bnt || env.failed_bnt }}",
+                      "url": "https://s3.console.aws.amazon.com/s3/buckets/${{ secrets.AWS_S3_BLADE_BUCKET }}?region=${{ vars.AWS_REGION }}&prefix=logs/${{ github.run_id }}/"
+                    }
+                  ]
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Triggered by: *user*"
                     },
                     {
-                      "type": "context",
-                      "elements": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "Triggered by: *${{ github.triggering_actor }}*"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "actions",
-                      "elements": [
-                        {
-                          "type": "button",
-                          "text": {
-                            "type": "plain_text",
-                            "text": "Workflow Run"
-                          },
-                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                        },
-                        {
-                          "type": "button",
-                          "text": {
-                            "type": "plain_text",
-                            "text": "${{ inputs.logs && inputs.destroy_network_upload_logs == '' && 'Logs' || 'No Logs' }}"
-                          },
-                          "style": "${{ inputs.logs && inputs.destroy_network_upload_logs == '' && env.succeed_bnt || env.failed_bnt }}",
-                          "url": "https://s3.console.aws.amazon.com/s3/buckets/${{ secrets.AWS_S3_BLADE_BUCKET }}?region=${{ vars.AWS_REGION }}&prefix=logs/${{ github.run_id }}/"
-                        }
-                      ]
+                      "type": "mrkdwn",
+                      "text": "Environment: *dev*"
                     }
                   ]
                 }

--- a/.github/workflows/notification-destroy-network.yml
+++ b/.github/workflows/notification-destroy-network.yml
@@ -76,11 +76,11 @@ jobs:
                   "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "Triggered by: *user*"
+                      "text": "Triggered by: *${{ github.triggering_actor }}*"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "Environment: *dev*"
+                      "text": "Environment: *${{ inputs.environment }}*"
                     }
                   ]
                 }

--- a/.github/workflows/notification-load-test.yml
+++ b/.github/workflows/notification-load-test.yml
@@ -11,6 +11,30 @@ on: # yamllint disable-line rule:truthy
         description: The scenario to run
         type: string
         required: true
+      timeout:
+        description: Time Out
+        type: string
+        required: true
+      rate:
+        description: Rate
+        type: string
+        required: true
+      timeUnit:
+        description: Time Unit
+        type: string
+        required: true
+      duration:
+        description: Duration
+        type: string
+        required: true
+      preAllocatedVUs:
+        description: Preallocated VUs
+        type: string
+        required: true
+      maxVUs:
+        description: Max VUs
+        type: string
+        required: true
       tps_avg:
         description: "Average Transactions Per Second"
         type: string
@@ -47,91 +71,133 @@ jobs:
   notification:
     name: Notification
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     steps:
+      - name: Short SHA
+        id: short_sha
+        run: echo "value=`echo ${{ github.sha }} | cut -c1-7`" >> $GITHUB_OUTPUT
       - name: Notify Slack
         uses: slackapi/slack-github-action@v1.25.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-          green_color: '#03C03C'
           succeed_bnt: 'primary'
         with:
           payload: |
             {
-              "attachments": [
+              "blocks": [
                 {
-                  "color": "${{ env.green_color }}",
-                  "blocks": [
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Load Test: ${{ inputs.scenario }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
                     {
-                      "type": "header",
+                      "type": "button",
                       "text": {
                         "type": "plain_text",
-                        "text": "Load Test: ${{ inputs.scenario }}"
-                      }
+                        "text": "Workflow Run"
+                      },
+                      "style": "${{ env.succeed_bnt }}",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}""
+                    }
+                  ]
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Triggered by: *${{ github.triggering_actor }}*"
                     },
                     {
-                      "type": "context",
-                      "elements": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "Environment: *${{ inputs.environment }}*"
-                        }
-                      ]
+                      "type": "mrkdwn",
+                      "text": "Commit: *<https://github.com/${{ github.repository }}/tree/${{ github.sha }}|${{ steps.short_sha.outputs.value }}>*"
+                    }
+                  ]
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Environment: *${{ inputs.environment }}*"
                     },
                     {
-                      "type": "context",
-                      "elements": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "Triggered by: *${{ github.triggering_actor }}*"
-                        }
-                      ]
+                      "type": "mrkdwn",
+                      "text": "Instances Type: *${{ vars.AWS_INSTANCE_TYPE }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Time Out: *${{ inputs.timeout }}*"
                     },
                     {
-                      "type": "actions",
-                      "elements": [
-                        {
-                          "type": "button",
-                          "text": {
-                            "type": "plain_text",
-                            "text": "Workflow Run"
-                          },
-                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                        }
-                      ]
+                      "type": "mrkdwn",
+                      "text": "Rate: *${{ inputs.rate }}*"
                     },
                     {
-                      "type": "section",
-                      "fields": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Average TPS*\n${{ inputs.tps_avg }}"
-                        },
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Max TPS*\n${{ inputs.tps_max }}"
-                        },
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Average Gas Used*\n${{ inputs.gas_avg }}"
-                        },
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Max Gas Used*\n${{ inputs.gas_max }}"
-                        },
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Transactions*\n${{ inputs.iterations }}"
-                        },
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Block Number*\n${{ inputs.block }}"
-                        },
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Time to Mine*\n${{ inputs.ttm }}"
-                        }
-                      ]
+                      "type": "mrkdwn",
+                      "text": "Time Unit: *${{ inputs.timeUnit }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Duration: *${{ inputs.duration }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Preallocated VUs: *${{ inputs.preAllocatedVUs }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Max VUs: *${{ inputs.maxVUs }}*"
+                    }
+                  ]
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Average TPS*\n${{ inputs.tps_avg }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Max TPS*\n${{ inputs.tps_max }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Average Gas Used*\n${{ inputs.gas_avg }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Max Gas Used*\n${{ inputs.gas_max }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Transactions*\n${{ inputs.iterations }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Block Number*\n${{ inputs.block }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Time to Mine (ms)*\n${{ inputs.ttm }}"
                     }
                   ]
                 }

--- a/.github/workflows/notification-load-test.yml
+++ b/.github/workflows/notification-load-test.yml
@@ -103,7 +103,7 @@ jobs:
                         "text": "Workflow Run"
                       },
                       "style": "${{ env.succeed_bnt }}",
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}""
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                     }
                   ]
                 },

--- a/.github/workflows/notification-load-test.yml
+++ b/.github/workflows/notification-load-test.yml
@@ -132,7 +132,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "Instances Type: *${{ vars.AWS_INSTANCE_TYPE }}"
+                      "text": "Instances Type: *${{ vars.AWS_INSTANCE_TYPE }}*"
                     }
                   ]
                 },

--- a/.github/workflows/notification-load-test.yml
+++ b/.github/workflows/notification-load-test.yml
@@ -132,7 +132,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "Instances Type: *${{ vars.AWS_INSTANCE_TYPE }}*"
+                      "text": "Instance Type: *${{ vars.AWS_INSTANCE_TYPE }}*"
                     }
                   ]
                 },

--- a/.github/workflows/notification-nightly.yml
+++ b/.github/workflows/notification-nightly.yml
@@ -7,6 +7,30 @@ on: # yamllint disable-line rule:truthy
         description: The environment to run against
         type: string
         required: true
+      block_gas_limit:
+        description: Block Gas Limit
+        type: string
+        required: true
+      block_time:
+        description: Block Time (sec)
+        type: string
+        required: true
+      max_slots:
+        description: Max Slots
+        type: string
+        required: true
+      max_enqueued:
+        description: Max Enqueued
+        type: string
+        required: true
+      is_london_fork_active:
+        description: EIP-1559
+        type: boolean
+        required: true
+      is_bridge_active:
+        description: With Bridge
+        type: boolean
+        required: true
       logs:
         description: Upload Logs
         type: string
@@ -77,6 +101,7 @@ jobs:
   notification:
     name: Notification
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     steps:
       - name: Short SHA
         id: short_sha
@@ -86,120 +111,184 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-          green_color: '#03C03C'
-          red_color: '#E60012'
           succeed_bnt: 'primary'
           failed_bnt: 'danger'
+          succeed_job: ':green:'
+          failed_job: ':red:'
         with:
           payload: |
             {
-              "attachments": [
+              "blocks": [
                 {
-                  "color": "${{ inputs.build_blade_output == '' && inputs.lint_output == '' && inputs.unit_test_output == '' && inputs.e2e_polybft_test_output == '' && inputs.e2e_legacy_test_output == '' && inputs.property_polybft_test_output == '' && inputs.fuzz_test_output == '' && inputs.benchmark_test_output == '' && inputs.deploy_network_terraform_output == '' && inputs.deploy_network_ansible_output == '' && inputs.load_test_multiple_eoa_output == 'true' && inputs.load_test_multiple_erc20_output == 'true' && inputs.destroy_network_logs_output == '' && inputs.destroy_network_terraform_output == '' && env.green_color || env.red_color }}",
-                  "blocks": [
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Nightly build"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
                     {
-                      "type": "header",
+                      "type": "button",
                       "text": {
                         "type": "plain_text",
-                        "text": "Nightly build"
-                      }
+                        "text": "Workflow Run"
+                      },
+                      "style": "${{ inputs.build_blade_output == '' && inputs.lint_output == '' && inputs.unit_test_output == '' && inputs.e2e_polybft_test_output == '' && inputs.e2e_legacy_test_output == '' && inputs.property_polybft_test_output == '' && inputs.fuzz_test_output == '' && inputs.benchmark_test_output == '' && inputs.deploy_network_terraform_output == '' && inputs.deploy_network_ansible_output == '' && inputs.load_test_multiple_eoa_output == 'true' && inputs.load_test_multiple_erc20_output == 'true' && inputs.destroy_network_logs_output == '' && inputs.destroy_network_terraform_output == '' && env.succeed_bnt || env.failed_bnt }}",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                     },
                     {
-                      "type": "context",
-                      "elements": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "Environment: *${{ inputs.environment }}*"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "context",
-                      "elements": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "Commit: *<https://github.com/${{ github.repository }}/tree/${{ github.sha }}|${{ steps.short_sha.outputs.value }}>*"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "context",
-                      "elements": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "Triggered by: *${{ github.triggering_actor }}*"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "actions",
-                      "elements": [
-                        {
-                          "type": "button",
-                          "text": {
-                            "type": "plain_text",
-                            "text": "Workflow Run"
-                          },
-                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                        },
-                        {
-                          "type": "button",
-                          "text": {
-                            "type": "plain_text",
-                            "text": "${{ inputs.logs == 'true' && inputs.destroy_network_logs_output == '' && 'Logs' || 'No Logs' }}"
-                          },
-                          "style": "${{ inputs.logs == 'true' && inputs.destroy_network_logs_output == '' && env.succeed_bnt || env.failed_bnt }}",
-                          "url": "https://s3.console.aws.amazon.com/s3/buckets/${{ secrets.AWS_S3_BLADE_BUCKET }}?region=${{ vars.AWS_REGION }}&prefix=logs/${{ github.run_id }}/"
-                        }
-                      ]
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "${{ inputs.logs == 'true' && inputs.destroy_network_logs_output == '' && 'Logs' || 'No Logs' }}"
+                      },
+                      "style": "${{ inputs.logs == 'true' && inputs.destroy_network_logs_output == '' && env.succeed_bnt || env.failed_bnt }}",
+                      "url": "https://s3.console.aws.amazon.com/s3/buckets/${{ secrets.AWS_S3_BLADE_BUCKET }}?region=${{ vars.AWS_REGION }}&prefix=logs/${{ github.run_id }}/"
                     }
                   ]
                 },
                 {
-                  "color": "${{ inputs.build_blade_output == '' && inputs.lint_output == '' && inputs.unit_test_output == '' && inputs.fuzz_test_output == '' && inputs.benchmark_test_output == '' && inputs.e2e_legacy_test_output == '' && inputs.e2e_polybft_test_output == '' && inputs.property_polybft_test_output == '' && env.green_color || env.red_color }}",
-                  "blocks": [
+                  "type": "context",
+                  "elements": [
                     {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*CI*\n${{ inputs.build_blade_output == '' && 'Build' || '~Build~' }}, ${{ inputs.lint_output == '' && 'Lint' || '~Lint~' }}, ${{ inputs.unit_test_output == '' && 'Unit Tests' || '~Unit Tests~' }},\n${{ inputs.fuzz_test_output == '' && 'Fuzz Tests' || '~Fuzz Tests~' }}, ${{ inputs.e2e_legacy_test_output == '' && 'E2E Legacy Tests' || '~E2E Legacy Tests~' }},\n${{ inputs.e2e_polybft_test_output == '' && 'E2E PolyBFT Tests' || '~E2E PolyBFT Tests~' }}, ${{ inputs.property_polybft_test_output == '' && 'Property PolyBFT Tests' || '~Property PolyBFT Tests~' }},\n${{ inputs.benchmark_test_output == '' && 'Benchmark Tests' || '~Benchmark Tests~' }}"
-                      }
+                      "type": "mrkdwn",
+                      "text": "Triggered by: *${{ github.triggering_actor }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Commit: *<https://github.com/${{ github.repository }}/tree/${{ github.sha }}|${{ steps.short_sha.outputs.value }}>*"
                     }
                   ]
                 },
                 {
-                  "color": "${{ inputs.deploy_network_terraform_output == '' && inputs.deploy_network_ansible_output == '' && env.green_color || env.red_color }}",
-                  "blocks": [
+                  "type": "divider"
+                },
+                {
+                  "type": "context",
+                  "elements": [
                     {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*Deploy Network*"
-                      }
+                      "type": "mrkdwn",
+                      "text": "Environment: *${{ inputs.environment }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Instances Type: *${{ vars.AWS_INSTANCE_TYPE }}*"
                     }
                   ]
                 },
                 {
-                  "color": "${{ inputs.load_test_multiple_eoa_output == 'true' && inputs.load_test_multiple_erc20_output == 'true' && env.green_color || env.red_color }}",
-                  "blocks": [
+                  "type": "context",
+                  "elements": [
                     {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*Load Tests*\n${{ inputs.load_test_multiple_eoa_output == 'true' && 'EOA' || '~EOA~' }},\n${{ inputs.load_test_multiple_erc20_output == 'true' && 'ERC20' || '~ERC20~' }}"
-                      }
+                      "type": "mrkdwn",
+                      "text": "Validators: *${{ vars.VALIDATOR_COUNT }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Full Nodes: *${{ vars.FULLNODE_COUNT }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Rootchain servers: *${{ vars.GETH_COUNT }}*"
                     }
                   ]
                 },
                 {
-                  "color": "${{ inputs.destroy_network_logs_output == '' && inputs.destroy_network_terraform_output == '' && env.green_color || env.red_color }}",
-                  "blocks": [
+                  "type": "context",
+                  "elements": [
                     {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*Destroy Network*"
-                      }
+                      "type": "mrkdwn",
+                      "text": "Block Gas Limit: *${{ inputs.block_gas_limit }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Block Time: *${{ inputs.block_time }}s*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Max Slots: *${{ inputs.max_slots }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Max Enqueued: *${{ inputs.max_enqueued }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Bridge: *${{ inputs.is_bridge_active }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "London: *${{ inputs.is_london_fork_active }}*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Log Level: *${{ vars.LOG_LEVEL }}*"
+                    }
+                  ]
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ inputs.build_blade_output == '' && env.succeed_job || env.failed_job }} *Build*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ inputs.lint_output == '' && env.succeed_job || env.failed_job }} *Lint*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ inputs.unit_test_output == '' && env.succeed_job || env.failed_job }} *Unit Tests*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ inputs.fuzz_test_output == '' && env.succeed_job || env.failed_job }} *Fuzz Tests*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ inputs.e2e_legacy_test_output == '' && env.succeed_job || env.failed_job }} *E2E Legacy Tests*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ inputs.e2e_polybft_test_output == '' && env.succeed_job || env.failed_job }} *E2E PolyBFT Tests*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ inputs.property_polybft_test_output == '' && env.succeed_job || env.failed_job }} *Property PolyBFT Tests*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ inputs.benchmark_test_output == '' && env.succeed_job || env.failed_job }} *Benchmark Tests*"
+                    }
+                  ]
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ inputs.deploy_network_terraform_output == '' && inputs.deploy_network_ansible_output == '' && env.succeed_job || env.failed_job }} *Deploy Network*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ inputs.benchmark_test_output == '' && env.succeed_job || env.failed_job }} *Destroy Network*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ inputs.load_test_multiple_eoa_output == 'true' && env.succeed_job || env.failed_job }} *Load Test EOA*"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ inputs.load_test_multiple_erc20_output == 'true' && env.succeed_job || env.failed_job }} *Load Test ERC20*"
                     }
                   ]
                 }


### PR DESCRIPTION
- Modified the appearance of Slack notifications.
- Included additional details in Slack notifications such as `Block Gas Limit`, `Block Time`, `Max Slots`, `Max Enqueued`, `London`, `Bridge`, `Instance Type`, `Validators`, `Full Nodes`, `Rootchain servers`, and `Log Level`.
- Fixed the activation of `London` fork.
- Extended `Time Out` duration for Load Tests.
- Returned `Nightly builds` on-demand with the option of `Force Run` to bypass checking for new changes.
- Activated Upload Logs by default on the `Destroy Network` action.