### PR TITLE
Consolidate EVM benchmark framework

### DIFF
--- a/tests/evm_benchmark_test.go
+++ b/tests/evm_benchmark_test.go
@@ -26,46 +26,41 @@ const (
 )
 
 func BenchmarkEVM(b *testing.B) {
-	folders, err := listFolders([]string{benchmarksDir})
+	files, err := listFiles(benchmarksDir, testsExtension)
 	require.NoError(b, err)
 
-	for _, folder := range folders {
-		files, err := listFiles(folder, testsExtension)
-		require.NoError(b, err)
+	for _, file := range files {
+		name := filepath.ToSlash(strings.TrimPrefix(strings.TrimSuffix(file, testsExtension), benchmarksDir+string(filepath.Separator)))
 
-		for _, file := range files {
-			name := filepath.ToSlash(strings.TrimPrefix(strings.TrimSuffix(file, testsExtension), folder+string(filepath.Separator)))
+		b.Run(name, func(b *testing.B) {
+			data, err := os.ReadFile(file)
+			require.NoError(b, err)
 
-			b.Run(name, func(b *testing.B) {
-				data, err := os.ReadFile(file)
-				require.NoError(b, err)
+			var testCases map[string]testCase
+			if err = json.Unmarshal(data, &testCases); err != nil {
+				b.Fatalf("failed to unmarshal %s: %v", file, err)
+			}
 
-				var testCases map[string]testCase
-				if err = json.Unmarshal(data, &testCases); err != nil {
-					b.Fatalf("failed to unmarshal %s: %v", file, err)
-				}
+			for _, tc := range testCases {
+				for fork, postState := range tc.Post {
+					forks, exists := Forks[fork]
+					if !exists {
+						b.Logf("%s fork is not supported, skipping test case.", fork)
+						continue
+					}
 
-				for _, tc := range testCases {
-					for fork, postState := range tc.Post {
-						forks, exists := Forks[fork]
-						if !exists {
-							b.Logf("%s fork is not supported, skipping test case.", fork)
-							continue
-						}
+					fc := &forkConfig{name: fork, forks: forks}
 
-						fc := &forkConfig{name: fork, forks: forks}
-
-						for idx, postStateEntry := range postState {
-							key := fmt.Sprintf("%s/%d", fork, idx)
-							b.Run(key, func(b *testing.B) {
-								err := runBenchmarkTest(b, tc, fc, postStateEntry)
-								require.NoError(b, err, fmt.Sprintf("test %s (case#%d) execution failed", name, idx))
-							})
-						}
+					for idx, postStateEntry := range postState {
+						key := fmt.Sprintf("%s/%d", fork, idx)
+						b.Run(key, func(b *testing.B) {
+							err := runBenchmarkTest(b, tc, fc, postStateEntry)
+							require.NoError(b, err, fmt.Sprintf("test %s (case#%d) execution failed", name, idx))
+						})
 					}
 				}
-			})
-		}
+			}
+		})
 	}
 }
 

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -654,18 +654,20 @@ func listFiles(folder string, extensions ...string) ([]string, error) {
 			return err
 		}
 
-		if !d.IsDir() {
-			if len(extensions) > 0 {
-				// filter files by extensions
-				for _, ext := range extensions {
-					if strings.HasSuffix(path, ext) {
-						files = append(files, path)
-					}
+		if d.IsDir() {
+			return nil
+		}
+
+		if len(extensions) > 0 {
+			// filter files by extensions
+			for _, ext := range extensions {
+				if fileExt := filepath.Ext(path); fileExt == ext {
+					files = append(files, path)
 				}
-			} else {
-				// if no extensions filter is provided, add all files
-				files = append(files, path)
 			}
+		} else {
+			// if no extensions filter is provided, add all files
+			files = append(files, path)
 		}
 
 		return nil

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -649,12 +649,12 @@ func listFolders(paths []string) ([]string, error) {
 func listFiles(folder string, extensions ...string) ([]string, error) {
 	var files []string
 
-	err := filepath.WalkDir(folder, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.Walk(folder, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if d.IsDir() {
+		if info.IsDir() {
 			return nil
 		}
 

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/fs"
 	"math/big"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -613,37 +612,6 @@ func contains(l []string, name string) bool {
 	}
 
 	return false
-}
-
-func listFolders(paths []string) ([]string, error) {
-	var folders []string
-
-	for _, rootPath := range paths {
-		err := filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-
-			if d.IsDir() {
-				files, err := os.ReadDir(path)
-				if err != nil {
-					return err
-				}
-
-				if len(files) > 0 {
-					folders = append(folders, path)
-				}
-			}
-
-			return nil
-		})
-
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return folders, nil
 }
 
 func listFiles(folder string, extensions ...string) ([]string, error) {


### PR DESCRIPTION
# Description

This PR fixes the gathering of the test files because tests were executed multiple times with the previous approach (the same fix was applied to the EVM state unit tests). 

It also consolidates the way tests are executed on the go ethereum (each subtest is run separately via the `b.Run`).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
