### PR TITLE
bug: txrelayer-fails-with-anvil

### DIFF
--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -157,7 +157,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 
 		if txn.MaxFeePerGas == nil {
 			// retrieve the latest base fee
-			feeHist, err := t.Client().Eth().FeeHistory(1, ethgo.Latest, nil)
+			feeHist, err := t.Client().Eth().FeeHistory(1, ethgo.Latest, []float64{})
 			if err != nil {
 				return ethgo.ZeroHash, fmt.Errorf("failed to get fee history: %w", err)
 			}
@@ -182,7 +182,9 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 	if txn.Gas == 0 {
 		gasLimit, err := t.client.Eth().EstimateGas(ConvertTxnToCallMsg(txn))
 		if err != nil {
-			return ethgo.ZeroHash, fmt.Errorf("failed to estimate gas: %w", err)
+			// TODO: Add Logger and write the err return ethgo.ZeroHash, fmt.Errorf("failed to estimate gas: %w", err)
+			// return ethgo.ZeroHash, fmt.Errorf("failed to estimate gas: %w", err)
+			gasLimit = DefaultGasLimit * 2
 		}
 
 		txn.Gas = gasLimit + (gasLimit * gasLimitIncreasePercentage / 100)


### PR DESCRIPTION
# Description

Fix the txrelayer to work with anvil
* Use DefaultGasLimit if `EstimateGas` fails. There is open issue in anvil on creating smart contract
* Fix the call to `FeeHistory`, passing empty slice instead of nil

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
