### PR TITLE
Configure receipts timeout in tx relayer

### DIFF
--- a/command/bridge/common/params.go
+++ b/command/bridge/common/params.go
@@ -35,6 +35,8 @@ const (
 	ChildTokenFlag         = "child-token"
 	JSONRPCFlag            = "json-rpc"
 	ChildChainMintableFlag = "child-chain-mintable"
+	txTimeoutFlag          = "tx-timeout"
+	txPollFreqFlag         = "tx-poll-freq"
 
 	MinterKeyFlag     = "minter-key"
 	MinterKeyFlagDesc = "minter key is the account which is able to mint tokens to sender account " +
@@ -53,6 +55,8 @@ type BridgeParams struct {
 	PredicateAddr      string
 	JSONRPCAddr        string
 	ChildChainMintable bool
+	TxTimeout          uint64
+	TxPollFreq         uint64
 }
 
 // RegisterCommonFlags registers common bridge flags to a given command
@@ -83,6 +87,20 @@ func (p *BridgeParams) RegisterCommonFlags(cmd *cobra.Command) {
 		ChildChainMintableFlag,
 		false,
 		"flag indicating whether tokens originate from child chain",
+	)
+
+	cmd.Flags().Uint64Var(
+		&p.TxTimeout,
+		txTimeoutFlag,
+		5000,
+		"timeout for receipts in milliseconds",
+	)
+
+	cmd.Flags().Uint64Var(
+		&p.TxPollFreq,
+		txPollFreqFlag,
+		50,
+		"frequency in milliseconds for poll transactions",
 	)
 }
 

--- a/command/bridge/common/params.go
+++ b/command/bridge/common/params.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/umbracle/ethgo"
@@ -55,8 +56,8 @@ type BridgeParams struct {
 	PredicateAddr      string
 	JSONRPCAddr        string
 	ChildChainMintable bool
-	TxTimeout          uint64
-	TxPollFreq         uint64
+	TxTimeout          time.Duration
+	TxPollFreq         time.Duration
 }
 
 // RegisterCommonFlags registers common bridge flags to a given command
@@ -89,17 +90,17 @@ func (p *BridgeParams) RegisterCommonFlags(cmd *cobra.Command) {
 		"flag indicating whether tokens originate from child chain",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&p.TxTimeout,
 		txTimeoutFlag,
-		5000,
+		5*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&p.TxPollFreq,
 		txPollFreqFlag,
-		50,
+		50*time.Millisecond,
 		"frequency in milliseconds for poll transactions",
 	)
 }

--- a/command/bridge/common/params.go
+++ b/command/bridge/common/params.go
@@ -93,7 +93,7 @@ func (p *BridgeParams) RegisterCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&p.TxTimeout,
 		txTimeoutFlag,
-		5*time.Second,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/bridge/common/params.go
+++ b/command/bridge/common/params.go
@@ -36,7 +36,6 @@ const (
 	ChildTokenFlag         = "child-token"
 	JSONRPCFlag            = "json-rpc"
 	ChildChainMintableFlag = "child-chain-mintable"
-	txTimeoutFlag          = "tx-timeout"
 
 	MinterKeyFlag     = "minter-key"
 	MinterKeyFlagDesc = "minter key is the account which is able to mint tokens to sender account " +
@@ -90,7 +89,7 @@ func (p *BridgeParams) RegisterCommonFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(
 		&p.TxTimeout,
-		txTimeoutFlag,
+		cmdHelper.TxTimeoutFlag,
 		txrelayer.DefaultTimeoutTransactions,
 		cmdHelper.TxTimeoutDesc,
 	)

--- a/command/bridge/common/params.go
+++ b/command/bridge/common/params.go
@@ -37,7 +37,6 @@ const (
 	JSONRPCFlag            = "json-rpc"
 	ChildChainMintableFlag = "child-chain-mintable"
 	txTimeoutFlag          = "tx-timeout"
-	txPollFreqFlag         = "tx-poll-freq"
 
 	MinterKeyFlag     = "minter-key"
 	MinterKeyFlagDesc = "minter key is the account which is able to mint tokens to sender account " +
@@ -57,7 +56,6 @@ type BridgeParams struct {
 	JSONRPCAddr        string
 	ChildChainMintable bool
 	TxTimeout          time.Duration
-	TxPollFreq         time.Duration
 }
 
 // RegisterCommonFlags registers common bridge flags to a given command
@@ -93,16 +91,10 @@ func (p *BridgeParams) RegisterCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&p.TxTimeout,
 		txTimeoutFlag,
-		50*time.Second,
-		"timeout for receipts in milliseconds",
+		txrelayer.DefaultTimeoutTransactions,
+		cmdHelper.TxTimeoutDesc,
 	)
 
-	cmd.Flags().DurationVar(
-		&p.TxPollFreq,
-		txPollFreqFlag,
-		50*time.Millisecond,
-		"frequency in milliseconds for poll transactions",
-	)
 }
 
 func (p *BridgeParams) Validate() error {

--- a/command/bridge/deploy/deploy.go
+++ b/command/bridge/deploy/deploy.go
@@ -339,7 +339,7 @@ func GetCommand() *cobra.Command {
 
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
-		txTimeoutFlag,
+		cmdHelper.TxTimeoutFlag,
 		txrelayer.DefaultTimeoutTransactions,
 		cmdHelper.TxTimeoutDesc,
 	)

--- a/command/bridge/deploy/deploy.go
+++ b/command/bridge/deploy/deploy.go
@@ -445,8 +445,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client, chainID int64,
 	initialValidators []*validator.GenesisValidator, cmdCtx context.Context) (deploymentResultInfo, error) {
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithClient(client), txrelayer.WithWriter(outputter),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
+		txrelayer.WithReceiptsTimeout(params.txTimeout),
+		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
 
 	if err != nil {
 		return deploymentResultInfo{RootchainCfg: nil, CommandResults: nil},

--- a/command/bridge/deploy/deploy.go
+++ b/command/bridge/deploy/deploy.go
@@ -341,7 +341,7 @@ func GetCommand() *cobra.Command {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		txTimeoutFlag,
-		5*time.Second,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/bridge/deploy/deploy.go
+++ b/command/bridge/deploy/deploy.go
@@ -338,17 +338,17 @@ func GetCommand() *cobra.Command {
 		helper.ProxyContractsAdminDesc,
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		txTimeoutFlag,
-		5000,
+		5*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txPollFreq,
 		txPollFreqFlag,
-		50,
+		50*time.Millisecond,
 		"frequency in milliseconds for poll transactions",
 	)
 
@@ -445,8 +445,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client, chainID int64,
 	initialValidators []*validator.GenesisValidator, cmdCtx context.Context) (deploymentResultInfo, error) {
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithClient(client), txrelayer.WithWriter(outputter),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
 
 	if err != nil {
 		return deploymentResultInfo{RootchainCfg: nil, CommandResults: nil},

--- a/command/bridge/deploy/deploy.go
+++ b/command/bridge/deploy/deploy.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/umbracle/ethgo"
@@ -341,15 +340,8 @@ func GetCommand() *cobra.Command {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		txTimeoutFlag,
-		50*time.Second,
-		"timeout for receipts in milliseconds",
-	)
-
-	cmd.Flags().DurationVar(
-		&params.txPollFreq,
-		txPollFreqFlag,
-		50*time.Millisecond,
-		"frequency in milliseconds for poll transactions",
+		txrelayer.DefaultTimeoutTransactions,
+		cmdHelper.TxTimeoutDesc,
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(helper.TestModeFlag, deployerKeyFlag)
@@ -445,8 +437,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client, chainID int64,
 	initialValidators []*validator.GenesisValidator, cmdCtx context.Context) (deploymentResultInfo, error) {
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithClient(client), txrelayer.WithWriter(outputter),
-		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
+		txrelayer.WithReceiptsTimeout(params.txTimeout))
 
 	if err != nil {
 		return deploymentResultInfo{RootchainCfg: nil, CommandResults: nil},

--- a/command/bridge/deploy/params.go
+++ b/command/bridge/deploy/params.go
@@ -13,6 +13,8 @@ const (
 	deployerKeyFlag = "deployer-key"
 	jsonRPCFlag     = "json-rpc"
 	erc20AddrFlag   = "erc20-token"
+	txTimeoutFlag   = "tx-timeout"
+	txPollFreqFlag  = "tx-poll-freq"
 )
 
 type deployParams struct {
@@ -21,6 +23,8 @@ type deployParams struct {
 	jsonRPCAddress      string
 	rootERC20TokenAddr  string
 	proxyContractsAdmin string
+	txTimeout           uint64
+	txPollFreq          uint64
 	isTestMode          bool
 }
 

--- a/command/bridge/deploy/params.go
+++ b/command/bridge/deploy/params.go
@@ -15,7 +15,6 @@ const (
 	jsonRPCFlag     = "json-rpc"
 	erc20AddrFlag   = "erc20-token"
 	txTimeoutFlag   = "tx-timeout"
-	txPollFreqFlag  = "tx-poll-freq"
 )
 
 type deployParams struct {
@@ -25,7 +24,6 @@ type deployParams struct {
 	rootERC20TokenAddr  string
 	proxyContractsAdmin string
 	txTimeout           time.Duration
-	txPollFreq          time.Duration
 	isTestMode          bool
 }
 

--- a/command/bridge/deploy/params.go
+++ b/command/bridge/deploy/params.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
@@ -23,8 +24,8 @@ type deployParams struct {
 	jsonRPCAddress      string
 	rootERC20TokenAddr  string
 	proxyContractsAdmin string
-	txTimeout           uint64
-	txPollFreq          uint64
+	txTimeout           time.Duration
+	txPollFreq          time.Duration
 	isTestMode          bool
 }
 

--- a/command/bridge/deploy/params.go
+++ b/command/bridge/deploy/params.go
@@ -14,7 +14,6 @@ const (
 	deployerKeyFlag = "deployer-key"
 	jsonRPCFlag     = "json-rpc"
 	erc20AddrFlag   = "erc20-token"
-	txTimeoutFlag   = "tx-timeout"
 )
 
 type deployParams struct {

--- a/command/bridge/deposit/erc1155/deposit_erc1155.go
+++ b/command/bridge/deposit/erc1155/deposit_erc1155.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -98,8 +97,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	depositorAddr := depositorKey.Address()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(dp.TxTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(dp.TxPollFreq)))
+		txrelayer.WithReceiptsTimeout(dp.TxTimeout),
+		txrelayer.WithReceiptsPollFreq(dp.TxPollFreq))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/deposit/erc1155/deposit_erc1155.go
+++ b/command/bridge/deposit/erc1155/deposit_erc1155.go
@@ -98,8 +98,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	depositorAddr := depositorKey.Address()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(dp.TxTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(dp.TxPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(dp.TxTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(dp.TxPollFreq)))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/deposit/erc1155/deposit_erc1155.go
+++ b/command/bridge/deposit/erc1155/deposit_erc1155.go
@@ -97,8 +97,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	depositorAddr := depositorKey.Address()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(dp.TxTimeout),
-		txrelayer.WithReceiptsPollFreq(dp.TxPollFreq))
+		txrelayer.WithReceiptsTimeout(dp.TxTimeout))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/deposit/erc1155/deposit_erc1155.go
+++ b/command/bridge/deposit/erc1155/deposit_erc1155.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -96,7 +97,9 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 	depositorAddr := depositorKey.Address()
 
-	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr))
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr),
+		txrelayer.WithReceiptsTimeout(time.Duration(dp.TxTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(dp.TxPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/deposit/erc20/deposit_erc20.go
+++ b/command/bridge/deposit/erc20/deposit_erc20.go
@@ -90,8 +90,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	depositorAddr := depositorKey.Address()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(dp.TxTimeout),
-		txrelayer.WithReceiptsPollFreq(dp.TxPollFreq))
+		txrelayer.WithReceiptsTimeout(dp.TxTimeout))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/deposit/erc20/deposit_erc20.go
+++ b/command/bridge/deposit/erc20/deposit_erc20.go
@@ -3,6 +3,7 @@ package erc20
 import (
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/umbracle/ethgo"
@@ -89,7 +90,9 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 	depositorAddr := depositorKey.Address()
 
-	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr))
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr),
+		txrelayer.WithReceiptsTimeout(time.Duration(dp.TxTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(dp.TxPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/deposit/erc20/deposit_erc20.go
+++ b/command/bridge/deposit/erc20/deposit_erc20.go
@@ -3,7 +3,6 @@ package erc20
 import (
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/umbracle/ethgo"
@@ -91,8 +90,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	depositorAddr := depositorKey.Address()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(dp.TxTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(dp.TxPollFreq)))
+		txrelayer.WithReceiptsTimeout(dp.TxTimeout),
+		txrelayer.WithReceiptsPollFreq(dp.TxPollFreq))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/deposit/erc20/deposit_erc20.go
+++ b/command/bridge/deposit/erc20/deposit_erc20.go
@@ -91,8 +91,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	depositorAddr := depositorKey.Address()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(dp.TxTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(dp.TxPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(dp.TxTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(dp.TxPollFreq)))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/deposit/erc721/deposit_erc721.go
+++ b/command/bridge/deposit/erc721/deposit_erc721.go
@@ -88,8 +88,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	depositorAddr := depositorKey.Address()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(dp.TxTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(dp.TxPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(dp.TxTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(dp.TxPollFreq)))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/deposit/erc721/deposit_erc721.go
+++ b/command/bridge/deposit/erc721/deposit_erc721.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -86,7 +87,9 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 	depositorAddr := depositorKey.Address()
 
-	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr))
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr),
+		txrelayer.WithReceiptsTimeout(time.Duration(dp.TxTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(dp.TxPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/deposit/erc721/deposit_erc721.go
+++ b/command/bridge/deposit/erc721/deposit_erc721.go
@@ -87,8 +87,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	depositorAddr := depositorKey.Address()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(dp.TxTimeout),
-		txrelayer.WithReceiptsPollFreq(dp.TxPollFreq))
+		txrelayer.WithReceiptsTimeout(dp.TxTimeout))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/deposit/erc721/deposit_erc721.go
+++ b/command/bridge/deposit/erc721/deposit_erc721.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -88,8 +87,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	depositorAddr := depositorKey.Address()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(dp.TxTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(dp.TxPollFreq)))
+		txrelayer.WithReceiptsTimeout(dp.TxTimeout),
+		txrelayer.WithReceiptsPollFreq(dp.TxPollFreq))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -25,7 +25,6 @@ const (
 	exitEventIDFlag  = "exit-id"
 	rootJSONRPCFlag  = "root-json-rpc"
 	childJSONRPCFlag = "child-json-rpc"
-	txTimeoutFlag    = "tx-timeout"
 
 	// generateExitProofFn is JSON RPC endpoint which creates exit proof
 	generateExitProofFn = "bridge_generateExitProof"
@@ -90,7 +89,7 @@ func GetCommand() *cobra.Command {
 
 	exitCmd.Flags().DurationVar(
 		&ep.txTimeout,
-		txTimeoutFlag,
+		cmdHelper.TxTimeoutFlag,
 		txrelayer.DefaultTimeoutTransactions,
 		cmdHelper.TxTimeoutDesc,
 	)

--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -120,8 +120,8 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	rootTxRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(ep.rootJSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(ep.txTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(ep.txPollFreq)))
+		txrelayer.WithReceiptsTimeout(ep.txTimeout),
+		txrelayer.WithReceiptsPollFreq(ep.txPollFreq))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create root chain tx relayer: %w", err))
 

--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -38,8 +38,8 @@ type exitParams struct {
 	exitID            uint64
 	rootJSONRPCAddr   string
 	childJSONRPCAddr  string
-	txTimeout         uint64
-	txPollFreq        uint64
+	txTimeout         time.Duration
+	txPollFreq        time.Duration
 }
 
 var (
@@ -90,16 +90,16 @@ func GetCommand() *cobra.Command {
 		"the JSON RPC child chain endpoint",
 	)
 
-	exitCmd.Flags().Uint64Var(
+	exitCmd.Flags().DurationVar(
 		&ep.txTimeout,
 		txTimeoutFlag,
-		5000,
+		5*time.Second,
 		"timeout for receipts in milliseconds",
 	)
-	exitCmd.Flags().Uint64Var(
+	exitCmd.Flags().DurationVar(
 		&ep.txPollFreq,
 		txPollFreqFlag,
-		50,
+		50*time.Millisecond,
 		"frequency in milliseconds for poll transactions",
 	)
 
@@ -120,8 +120,8 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	rootTxRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(ep.rootJSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(ep.txTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(ep.txPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(ep.txTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(ep.txPollFreq)))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create root chain tx relayer: %w", err))
 

--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -93,7 +93,7 @@ func GetCommand() *cobra.Command {
 	exitCmd.Flags().DurationVar(
 		&ep.txTimeout,
 		txTimeoutFlag,
-		5*time.Second,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 	exitCmd.Flags().DurationVar(

--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -26,7 +26,6 @@ const (
 	rootJSONRPCFlag  = "root-json-rpc"
 	childJSONRPCFlag = "child-json-rpc"
 	txTimeoutFlag    = "tx-timeout"
-	txPollFreqFlag   = "tx-poll-freq"
 
 	// generateExitProofFn is JSON RPC endpoint which creates exit proof
 	generateExitProofFn = "bridge_generateExitProof"
@@ -39,7 +38,6 @@ type exitParams struct {
 	rootJSONRPCAddr   string
 	childJSONRPCAddr  string
 	txTimeout         time.Duration
-	txPollFreq        time.Duration
 }
 
 var (
@@ -93,14 +91,8 @@ func GetCommand() *cobra.Command {
 	exitCmd.Flags().DurationVar(
 		&ep.txTimeout,
 		txTimeoutFlag,
-		50*time.Second,
-		"timeout for receipts in milliseconds",
-	)
-	exitCmd.Flags().DurationVar(
-		&ep.txPollFreq,
-		txPollFreqFlag,
-		50*time.Millisecond,
-		"frequency in milliseconds for poll transactions",
+		txrelayer.DefaultTimeoutTransactions,
+		cmdHelper.TxTimeoutDesc,
 	)
 
 	_ = exitCmd.MarkFlagRequired(exitHelperFlag)
@@ -120,8 +112,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	rootTxRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(ep.rootJSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(ep.txTimeout),
-		txrelayer.WithReceiptsPollFreq(ep.txPollFreq))
+		txrelayer.WithReceiptsTimeout(ep.txTimeout))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create root chain tx relayer: %w", err))
 

--- a/command/bridge/finalize/finalize.go
+++ b/command/bridge/finalize/finalize.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-	"time"
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/command"
@@ -88,15 +87,8 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		50*time.Second,
-		"timeout for receipts in milliseconds",
-	)
-
-	cmd.Flags().DurationVar(
-		&params.txPollFreq,
-		bridgeHelper.TxPollFreqFlag,
-		50,
-		"frequency in milliseconds for poll transactions",
+		txrelayer.DefaultTimeoutTransactions,
+		helper.TxTimeoutDesc,
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
@@ -117,8 +109,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
+		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return fmt.Errorf("enlist validator failed: %w", err)
 	}

--- a/command/bridge/finalize/finalize.go
+++ b/command/bridge/finalize/finalize.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/command"
@@ -84,6 +85,20 @@ func setFlags(cmd *cobra.Command) {
 		bridgeHelper.BladeManagerFlagDesc,
 	)
 
+	cmd.Flags().Uint64Var(
+		&params.txTimeout,
+		bridgeHelper.TxTimeoutFlag,
+		5000,
+		"timeout for receipts in milliseconds",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.txPollFreq,
+		bridgeHelper.TxPollFreqFlag,
+		50,
+		"frequency in milliseconds for poll transactions",
+	)
+
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.PrivateKeyFlag, polybftsecrets.AccountConfigFlag)
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.PrivateKeyFlag, polybftsecrets.AccountDirFlag)
@@ -101,7 +116,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC))
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		return fmt.Errorf("enlist validator failed: %w", err)
 	}

--- a/command/bridge/finalize/finalize.go
+++ b/command/bridge/finalize/finalize.go
@@ -86,7 +86,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
-		bridgeHelper.TxTimeoutFlag,
+		helper.TxTimeoutFlag,
 		txrelayer.DefaultTimeoutTransactions,
 		helper.TxTimeoutDesc,
 	)

--- a/command/bridge/finalize/finalize.go
+++ b/command/bridge/finalize/finalize.go
@@ -117,8 +117,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
+		txrelayer.WithReceiptsTimeout(params.txTimeout),
+		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
 	if err != nil {
 		return fmt.Errorf("enlist validator failed: %w", err)
 	}

--- a/command/bridge/finalize/finalize.go
+++ b/command/bridge/finalize/finalize.go
@@ -88,7 +88,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5*time.Second,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/bridge/finalize/finalize.go
+++ b/command/bridge/finalize/finalize.go
@@ -85,14 +85,14 @@ func setFlags(cmd *cobra.Command) {
 		bridgeHelper.BladeManagerFlagDesc,
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5000,
+		5*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txPollFreq,
 		bridgeHelper.TxPollFreqFlag,
 		50,
@@ -117,8 +117,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
 	if err != nil {
 		return fmt.Errorf("enlist validator failed: %w", err)
 	}

--- a/command/bridge/finalize/params.go
+++ b/command/bridge/finalize/params.go
@@ -16,6 +16,8 @@ type finalizeParams struct {
 	jsonRPC       string
 	bladeManager  string
 	genesisPath   string
+	txTimeout     uint64
+	txPollFreq    uint64
 
 	bladeManagerAddr types.Address
 }

--- a/command/bridge/finalize/params.go
+++ b/command/bridge/finalize/params.go
@@ -3,6 +3,7 @@ package finalize
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	validatorHelper "github.com/0xPolygon/polygon-edge/command/validator/helper"
@@ -16,8 +17,8 @@ type finalizeParams struct {
 	jsonRPC       string
 	bladeManager  string
 	genesisPath   string
-	txTimeout     uint64
-	txPollFreq    uint64
+	txTimeout     time.Duration
+	txPollFreq    time.Duration
 
 	bladeManagerAddr types.Address
 }

--- a/command/bridge/finalize/params.go
+++ b/command/bridge/finalize/params.go
@@ -18,7 +18,6 @@ type finalizeParams struct {
 	bladeManager  string
 	genesisPath   string
 	txTimeout     time.Duration
-	txPollFreq    time.Duration
 
 	bladeManagerAddr types.Address
 }

--- a/command/bridge/fund/fund.go
+++ b/command/bridge/fund/fund.go
@@ -2,6 +2,7 @@ package fund
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/umbracle/ethgo"
@@ -60,6 +61,20 @@ func setFlags(cmd *cobra.Command) {
 		"",
 		polybftsecrets.PrivateKeyFlagDesc,
 	)
+
+	cmd.Flags().Uint64Var(
+		&params.txTimeout,
+		txTimeoutFlag,
+		5000,
+		"timeout for receipts in milliseconds",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.txPollFreq,
+		txPollFreqFlag,
+		50,
+		"frequency in milliseconds for poll transactions",
+	)
 }
 
 func preRunCommand(_ *cobra.Command, _ []string) error {
@@ -70,7 +85,9 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPCAddress))
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPCAddress),
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/fund/fund.go
+++ b/command/bridge/fund/fund.go
@@ -86,8 +86,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	defer outputter.WriteOutput()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPCAddress),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
+		txrelayer.WithReceiptsTimeout(params.txTimeout),
+		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/fund/fund.go
+++ b/command/bridge/fund/fund.go
@@ -64,7 +64,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
-		txTimeoutFlag,
+		cmdHelper.TxTimeoutFlag,
 		txrelayer.DefaultTimeoutTransactions,
 		cmdHelper.TxTimeoutDesc,
 	)

--- a/command/bridge/fund/fund.go
+++ b/command/bridge/fund/fund.go
@@ -2,7 +2,6 @@ package fund
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/umbracle/ethgo"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/bridge/helper"
+	cmdHelper "github.com/0xPolygon/polygon-edge/command/helper"
 	polybftsecrets "github.com/0xPolygon/polygon-edge/command/secrets/init"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -65,15 +65,8 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		txTimeoutFlag,
-		50*time.Second,
-		"timeout for receipts in milliseconds",
-	)
-
-	cmd.Flags().DurationVar(
-		&params.txPollFreq,
-		txPollFreqFlag,
-		50*time.Millisecond,
-		"frequency in milliseconds for poll transactions",
+		txrelayer.DefaultTimeoutTransactions,
+		cmdHelper.TxTimeoutDesc,
 	)
 }
 
@@ -86,8 +79,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	defer outputter.WriteOutput()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPCAddress),
-		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
+		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/fund/fund.go
+++ b/command/bridge/fund/fund.go
@@ -62,17 +62,17 @@ func setFlags(cmd *cobra.Command) {
 		polybftsecrets.PrivateKeyFlagDesc,
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		txTimeoutFlag,
-		5000,
+		5*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txPollFreq,
 		txPollFreqFlag,
-		50,
+		50*time.Millisecond,
 		"frequency in milliseconds for poll transactions",
 	)
 }
@@ -86,8 +86,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	defer outputter.WriteOutput()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPCAddress),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/bridge/fund/fund.go
+++ b/command/bridge/fund/fund.go
@@ -65,7 +65,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		txTimeoutFlag,
-		5*time.Second,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/bridge/fund/params.go
+++ b/command/bridge/fund/params.go
@@ -3,6 +3,7 @@ package fund
 import (
 	"errors"
 	"math/big"
+	"time"
 
 	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
 	cmdhelper "github.com/0xPolygon/polygon-edge/command/helper"
@@ -26,8 +27,8 @@ type fundParams struct {
 	amounts            []string
 	deployerPrivateKey string
 	jsonRPCAddress     string
-	txTimeout          uint64
-	txPollFreq         uint64
+	txTimeout          time.Duration
+	txPollFreq         time.Duration
 
 	amountValues []*big.Int
 	addresses    []types.Address

--- a/command/bridge/fund/params.go
+++ b/command/bridge/fund/params.go
@@ -14,7 +14,6 @@ const (
 	jsonRPCFlag        = "json-rpc"
 	mintStakeTokenFlag = "mint"
 	txTimeoutFlag      = "tx-timeout"
-	txPollFreqFlag     = "tx-poll-freq"
 )
 
 var (
@@ -28,10 +27,8 @@ type fundParams struct {
 	deployerPrivateKey string
 	jsonRPCAddress     string
 	txTimeout          time.Duration
-	txPollFreq         time.Duration
-
-	amountValues []*big.Int
-	addresses    []types.Address
+	amountValues       []*big.Int
+	addresses          []types.Address
 }
 
 func (fp *fundParams) validateFlags() error {

--- a/command/bridge/fund/params.go
+++ b/command/bridge/fund/params.go
@@ -12,6 +12,8 @@ import (
 const (
 	jsonRPCFlag        = "json-rpc"
 	mintStakeTokenFlag = "mint"
+	txTimeoutFlag      = "tx-timeout"
+	txPollFreqFlag     = "tx-poll-freq"
 )
 
 var (
@@ -24,6 +26,8 @@ type fundParams struct {
 	amounts            []string
 	deployerPrivateKey string
 	jsonRPCAddress     string
+	txTimeout          uint64
+	txPollFreq         uint64
 
 	amountValues []*big.Int
 	addresses    []types.Address

--- a/command/bridge/fund/params.go
+++ b/command/bridge/fund/params.go
@@ -13,7 +13,6 @@ import (
 const (
 	jsonRPCFlag        = "json-rpc"
 	mintStakeTokenFlag = "mint"
-	txTimeoutFlag      = "tx-timeout"
 )
 
 var (

--- a/command/bridge/helper/utils.go
+++ b/command/bridge/helper/utils.go
@@ -40,7 +40,6 @@ const (
 	BladeManagerFlag        = "blade-manager"
 	BladeManagerFlagDesc    = "address of blade manager contract on a rootchain"
 	TxTimeoutFlag           = "tx-timeout"
-	TxPollFreqFlag          = "tx-poll-freq"
 )
 
 var (

--- a/command/bridge/helper/utils.go
+++ b/command/bridge/helper/utils.go
@@ -39,6 +39,8 @@ const (
 	Erc20TokenFlag          = "erc20-token" //nolint:gosec
 	BladeManagerFlag        = "blade-manager"
 	BladeManagerFlagDesc    = "address of blade manager contract on a rootchain"
+	TxTimeoutFlag           = "tx-timeout"
+	TxPollFreqFlag          = "tx-poll-freq"
 )
 
 var (

--- a/command/bridge/helper/utils.go
+++ b/command/bridge/helper/utils.go
@@ -39,7 +39,6 @@ const (
 	Erc20TokenFlag          = "erc20-token" //nolint:gosec
 	BladeManagerFlag        = "blade-manager"
 	BladeManagerFlagDesc    = "address of blade manager contract on a rootchain"
-	TxTimeoutFlag           = "tx-timeout"
 )
 
 var (

--- a/command/bridge/premine/params.go
+++ b/command/bridge/premine/params.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	validatorHelper "github.com/0xPolygon/polygon-edge/command/validator/helper"
@@ -25,8 +26,8 @@ type premineParams struct {
 	jsonRPC         string
 	stakedAmount    string
 	premineAmount   string
-	txTimeout       uint64
-	txPollFreq      uint64
+	txTimeout       time.Duration
+	txPollFreq      time.Duration
 
 	premineAmountValue  *big.Int
 	stakedValue         *big.Int

--- a/command/bridge/premine/params.go
+++ b/command/bridge/premine/params.go
@@ -27,7 +27,6 @@ type premineParams struct {
 	stakedAmount    string
 	premineAmount   string
 	txTimeout       time.Duration
-	txPollFreq      time.Duration
 
 	premineAmountValue  *big.Int
 	stakedValue         *big.Int

--- a/command/bridge/premine/params.go
+++ b/command/bridge/premine/params.go
@@ -25,6 +25,8 @@ type premineParams struct {
 	jsonRPC         string
 	stakedAmount    string
 	premineAmount   string
+	txTimeout       uint64
+	txPollFreq      uint64
 
 	premineAmountValue  *big.Int
 	stakedValue         *big.Int

--- a/command/bridge/premine/premine.go
+++ b/command/bridge/premine/premine.go
@@ -121,8 +121,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)))
+		txrelayer.WithReceiptsPollFreq(params.txPollFreq),
+		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return err
 	}

--- a/command/bridge/premine/premine.go
+++ b/command/bridge/premine/premine.go
@@ -87,7 +87,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5*time.Second,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/bridge/premine/premine.go
+++ b/command/bridge/premine/premine.go
@@ -87,7 +87,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		50*time.Second,
+		150*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/bridge/premine/premine.go
+++ b/command/bridge/premine/premine.go
@@ -88,14 +88,7 @@ func setFlags(cmd *cobra.Command) {
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
 		150*time.Second,
-		"timeout for receipts in milliseconds",
-	)
-
-	cmd.Flags().DurationVar(
-		&params.txPollFreq,
-		bridgeHelper.TxPollFreqFlag,
-		150*time.Millisecond,
-		"frequency in milliseconds for poll transactions",
+		helper.TxTimeoutDesc,
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
@@ -121,7 +114,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsPollFreq(params.txPollFreq),
+		txrelayer.WithReceiptsPollFreq(150*time.Second),
 		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return err

--- a/command/bridge/premine/premine.go
+++ b/command/bridge/premine/premine.go
@@ -84,6 +84,20 @@ func setFlags(cmd *cobra.Command) {
 		"amount to premine as a staked balance",
 	)
 
+	cmd.Flags().Uint64Var(
+		&params.txTimeout,
+		bridgeHelper.TxTimeoutFlag,
+		5000,
+		"timeout for receipts in milliseconds",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.txPollFreq,
+		bridgeHelper.TxPollFreqFlag,
+		150,
+		"frequency in milliseconds for poll transactions",
+	)
+
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.PrivateKeyFlag, polybftsecrets.AccountConfigFlag)
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.PrivateKeyFlag, polybftsecrets.AccountDirFlag)
@@ -107,7 +121,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptTimeout(150*time.Millisecond))
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))))
 	if err != nil {
 		return err
 	}

--- a/command/bridge/premine/premine.go
+++ b/command/bridge/premine/premine.go
@@ -84,17 +84,17 @@ func setFlags(cmd *cobra.Command) {
 		"amount to premine as a staked balance",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5000,
+		5*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txPollFreq,
 		bridgeHelper.TxPollFreqFlag,
-		150,
+		150*time.Millisecond,
 		"frequency in milliseconds for poll transactions",
 	)
 
@@ -121,8 +121,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)),
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)))
 	if err != nil {
 		return err
 	}

--- a/command/bridge/premine/premine.go
+++ b/command/bridge/premine/premine.go
@@ -86,7 +86,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
-		bridgeHelper.TxTimeoutFlag,
+		helper.TxTimeoutFlag,
 		150*time.Second,
 		helper.TxTimeoutDesc,
 	)

--- a/command/bridge/premine/premine.go
+++ b/command/bridge/premine/premine.go
@@ -114,7 +114,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsPollFreq(150*time.Second),
+		txrelayer.WithReceiptsPollFreq(150*time.Millisecond),
 		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return err

--- a/command/bridge/premine/premine.go
+++ b/command/bridge/premine/premine.go
@@ -114,7 +114,6 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsPollFreq(150*time.Millisecond),
 		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return err

--- a/command/bridge/withdraw/erc1155/withdraw_erc1155.go
+++ b/command/bridge/withdraw/erc1155/withdraw_erc1155.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -93,8 +92,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(wp.TxTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(wp.TxPollFreq)))
+		txrelayer.WithReceiptsTimeout(wp.TxTimeout),
+		txrelayer.WithReceiptsPollFreq(wp.TxPollFreq))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create child chain tx relayer: %w", err))
 

--- a/command/bridge/withdraw/erc1155/withdraw_erc1155.go
+++ b/command/bridge/withdraw/erc1155/withdraw_erc1155.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -91,7 +92,9 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr))
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr),
+		txrelayer.WithReceiptsTimeout(time.Duration(wp.TxTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(wp.TxPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create child chain tx relayer: %w", err))
 

--- a/command/bridge/withdraw/erc1155/withdraw_erc1155.go
+++ b/command/bridge/withdraw/erc1155/withdraw_erc1155.go
@@ -92,8 +92,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(wp.TxTimeout),
-		txrelayer.WithReceiptsPollFreq(wp.TxPollFreq))
+		txrelayer.WithReceiptsTimeout(wp.TxTimeout))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create child chain tx relayer: %w", err))
 

--- a/command/bridge/withdraw/erc1155/withdraw_erc1155.go
+++ b/command/bridge/withdraw/erc1155/withdraw_erc1155.go
@@ -93,8 +93,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(wp.TxTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(wp.TxPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(wp.TxTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(wp.TxPollFreq)))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create child chain tx relayer: %w", err))
 

--- a/command/bridge/withdraw/erc20/withdraw_erc20.go
+++ b/command/bridge/withdraw/erc20/withdraw_erc20.go
@@ -83,8 +83,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(wp.TxTimeout),
-		txrelayer.WithReceiptsPollFreq(wp.TxPollFreq))
+		txrelayer.WithReceiptsTimeout(wp.TxTimeout))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create destination chain tx relayer: %w", err))
 

--- a/command/bridge/withdraw/erc20/withdraw_erc20.go
+++ b/command/bridge/withdraw/erc20/withdraw_erc20.go
@@ -84,8 +84,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(wp.TxTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(wp.TxPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(wp.TxTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(wp.TxPollFreq)))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create destination chain tx relayer: %w", err))
 

--- a/command/bridge/withdraw/erc20/withdraw_erc20.go
+++ b/command/bridge/withdraw/erc20/withdraw_erc20.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -82,7 +83,9 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr))
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr),
+		txrelayer.WithReceiptsTimeout(time.Duration(wp.TxTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(wp.TxPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create destination chain tx relayer: %w", err))
 

--- a/command/bridge/withdraw/erc20/withdraw_erc20.go
+++ b/command/bridge/withdraw/erc20/withdraw_erc20.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -84,8 +83,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(wp.TxTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(wp.TxPollFreq)))
+		txrelayer.WithReceiptsTimeout(wp.TxTimeout),
+		txrelayer.WithReceiptsPollFreq(wp.TxPollFreq))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create destination chain tx relayer: %w", err))
 

--- a/command/bridge/withdraw/erc721/withdraw_erc721.go
+++ b/command/bridge/withdraw/erc721/withdraw_erc721.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-	"time"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
@@ -84,8 +83,8 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(wp.TxTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(wp.TxPollFreq)))
+		txrelayer.WithReceiptsTimeout(wp.TxTimeout),
+		txrelayer.WithReceiptsPollFreq(wp.TxPollFreq))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create child chain tx relayer: %w", err))
 

--- a/command/bridge/withdraw/erc721/withdraw_erc721.go
+++ b/command/bridge/withdraw/erc721/withdraw_erc721.go
@@ -83,8 +83,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(wp.TxTimeout),
-		txrelayer.WithReceiptsPollFreq(wp.TxPollFreq))
+		txrelayer.WithReceiptsTimeout(wp.TxTimeout))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create child chain tx relayer: %w", err))
 

--- a/command/bridge/withdraw/erc721/withdraw_erc721.go
+++ b/command/bridge/withdraw/erc721/withdraw_erc721.go
@@ -84,8 +84,8 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr),
-		txrelayer.WithReceiptsTimeout(time.Duration(wp.TxTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(wp.TxPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(wp.TxTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(wp.TxPollFreq)))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create child chain tx relayer: %w", err))
 

--- a/command/bridge/withdraw/erc721/withdraw_erc721.go
+++ b/command/bridge/withdraw/erc721/withdraw_erc721.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
@@ -82,7 +83,9 @@ func run(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr))
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(wp.JSONRPCAddr),
+		txrelayer.WithReceiptsTimeout(time.Duration(wp.TxTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(wp.TxPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("could not create child chain tx relayer: %w", err))
 

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -23,6 +23,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+const TxTimeoutDesc = "timeout for waiting for transactions to be minted"
+
 var ErrBlockTrackerPollInterval = errors.New("block tracker poll interval must be greater than 0")
 
 type ClientCloseResult struct {

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	TxTimeoutDesc = "timeout for waiting for transactions to be minted"
+	TxTimeoutDesc = "timeout for transaction processing wait"
 	TxTimeoutFlag = "tx-timeout"
 )
 

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -23,7 +23,10 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-const TxTimeoutDesc = "timeout for waiting for transactions to be minted"
+const (
+	TxTimeoutDesc = "timeout for waiting for transactions to be minted"
+	TxTimeoutFlag = "tx-timeout"
+)
 
 var ErrBlockTrackerPollInterval = errors.New("block tracker poll interval must be greater than 0")
 

--- a/command/mint/mint_erc20.go
+++ b/command/mint/mint_erc20.go
@@ -70,7 +70,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
-		bridgeHelper.TxTimeoutFlag,
+		helper.TxTimeoutFlag,
 		txrelayer.DefaultTimeoutTransactions,
 		helper.TxTimeoutDesc,
 	)

--- a/command/mint/mint_erc20.go
+++ b/command/mint/mint_erc20.go
@@ -72,7 +72,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5*time.Second,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/mint/mint_erc20.go
+++ b/command/mint/mint_erc20.go
@@ -91,8 +91,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	defer outputter.WriteOutput()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPCAddress),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
+		txrelayer.WithReceiptsTimeout(params.txTimeout),
+		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/mint/mint_erc20.go
+++ b/command/mint/mint_erc20.go
@@ -2,7 +2,6 @@ package mint
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
@@ -72,15 +71,8 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		50*time.Second,
-		"timeout for receipts in milliseconds",
-	)
-
-	cmd.Flags().DurationVar(
-		&params.txPollFreq,
-		bridgeHelper.TxPollFreqFlag,
-		50*time.Millisecond,
-		"frequency in milliseconds for poll transactions",
+		txrelayer.DefaultTimeoutTransactions,
+		helper.TxTimeoutDesc,
 	)
 
 	_ = cmd.MarkFlagRequired(bridgeHelper.Erc20TokenFlag)
@@ -91,8 +83,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	defer outputter.WriteOutput()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPCAddress),
-		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
+		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/mint/mint_erc20.go
+++ b/command/mint/mint_erc20.go
@@ -69,17 +69,17 @@ func setFlags(cmd *cobra.Command) {
 		"erc20 token address",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5000,
+		5*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txPollFreq,
 		bridgeHelper.TxPollFreqFlag,
-		50,
+		50*time.Millisecond,
 		"frequency in milliseconds for poll transactions",
 	)
 
@@ -91,8 +91,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	defer outputter.WriteOutput()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPCAddress),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/mint/mint_erc20.go
+++ b/command/mint/mint_erc20.go
@@ -2,6 +2,7 @@ package mint
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
@@ -68,6 +69,20 @@ func setFlags(cmd *cobra.Command) {
 		"erc20 token address",
 	)
 
+	cmd.Flags().Uint64Var(
+		&params.txTimeout,
+		bridgeHelper.TxTimeoutFlag,
+		5000,
+		"timeout for receipts in milliseconds",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.txPollFreq,
+		bridgeHelper.TxPollFreqFlag,
+		50,
+		"frequency in milliseconds for poll transactions",
+	)
+
 	_ = cmd.MarkFlagRequired(bridgeHelper.Erc20TokenFlag)
 }
 
@@ -75,7 +90,9 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPCAddress))
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPCAddress),
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize tx relayer: %w", err))
 

--- a/command/mint/params.go
+++ b/command/mint/params.go
@@ -16,6 +16,8 @@ type mintParams struct {
 	tokenAddr        string
 	minterPrivateKey string
 	jsonRPCAddress   string
+	txTimeout        uint64
+	txPollFreq       uint64
 
 	amountValues []*big.Int
 }

--- a/command/mint/params.go
+++ b/command/mint/params.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+	"time"
 
 	rootHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
 	"github.com/0xPolygon/polygon-edge/command/helper"
@@ -16,8 +17,8 @@ type mintParams struct {
 	tokenAddr        string
 	minterPrivateKey string
 	jsonRPCAddress   string
-	txTimeout        uint64
-	txPollFreq       uint64
+	txTimeout        time.Duration
+	txPollFreq       time.Duration
 
 	amountValues []*big.Int
 }

--- a/command/mint/params.go
+++ b/command/mint/params.go
@@ -18,7 +18,6 @@ type mintParams struct {
 	minterPrivateKey string
 	jsonRPCAddress   string
 	txTimeout        time.Duration
-	txPollFreq       time.Duration
 
 	amountValues []*big.Int
 }

--- a/command/validator/registration/params.go
+++ b/command/validator/registration/params.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/validator/helper"
@@ -18,8 +19,8 @@ type registerParams struct {
 	jsonRPC       string
 	amount        string
 	stakeToken    string
-	txTimeout     uint64
-	txPollFreq    uint64
+	txTimeout     time.Duration
+	txPollFreq    time.Duration
 
 	amountValue    *big.Int
 	stakeTokenAddr types.Address

--- a/command/validator/registration/params.go
+++ b/command/validator/registration/params.go
@@ -20,7 +20,6 @@ type registerParams struct {
 	amount        string
 	stakeToken    string
 	txTimeout     time.Duration
-	txPollFreq    time.Duration
 
 	amountValue    *big.Int
 	stakeTokenAddr types.Address

--- a/command/validator/registration/params.go
+++ b/command/validator/registration/params.go
@@ -18,6 +18,8 @@ type registerParams struct {
 	jsonRPC       string
 	amount        string
 	stakeToken    string
+	txTimeout     uint64
+	txPollFreq    uint64
 
 	amountValue    *big.Int
 	stakeTokenAddr types.Address

--- a/command/validator/registration/register_validator.go
+++ b/command/validator/registration/register_validator.go
@@ -68,7 +68,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
-		bridgeHelper.TxTimeoutFlag,
+		helper.TxTimeoutFlag,
 		txrelayer.DefaultTimeoutTransactions,
 		helper.TxTimeoutDesc,
 	)

--- a/command/validator/registration/register_validator.go
+++ b/command/validator/registration/register_validator.go
@@ -70,7 +70,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5*time.Second,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/validator/registration/register_validator.go
+++ b/command/validator/registration/register_validator.go
@@ -101,8 +101,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
+		txrelayer.WithReceiptsTimeout(params.txTimeout),
+		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
 	if err != nil {
 		return err
 	}

--- a/command/validator/registration/register_validator.go
+++ b/command/validator/registration/register_validator.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/0xPolygon/polygon-edge/bls"
 	"github.com/0xPolygon/polygon-edge/command"
@@ -70,15 +69,8 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		50*time.Second,
-		"timeout for receipts in milliseconds",
-	)
-
-	cmd.Flags().DurationVar(
-		&params.txPollFreq,
-		bridgeHelper.TxPollFreqFlag,
-		50*time.Millisecond,
-		"frequency in milliseconds for poll transactions",
+		txrelayer.DefaultTimeoutTransactions,
+		helper.TxTimeoutDesc,
 	)
 
 	helper.RegisterJSONRPCFlag(cmd)
@@ -101,8 +93,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
+		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return err
 	}

--- a/command/validator/registration/register_validator.go
+++ b/command/validator/registration/register_validator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/bls"
 	"github.com/0xPolygon/polygon-edge/command"
@@ -66,6 +67,20 @@ func setFlags(cmd *cobra.Command) {
 		polybftsecrets.StakeTokenFlagDesc,
 	)
 
+	cmd.Flags().Uint64Var(
+		&params.txTimeout,
+		bridgeHelper.TxTimeoutFlag,
+		5000,
+		"timeout for receipts in milliseconds",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.txPollFreq,
+		bridgeHelper.TxPollFreqFlag,
+		50,
+		"frequency in milliseconds for poll transactions",
+	)
+
 	helper.RegisterJSONRPCFlag(cmd)
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountConfigFlag, polybftsecrets.AccountDirFlag)
 }
@@ -85,7 +100,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC))
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		return err
 	}

--- a/command/validator/registration/register_validator.go
+++ b/command/validator/registration/register_validator.go
@@ -67,17 +67,17 @@ func setFlags(cmd *cobra.Command) {
 		polybftsecrets.StakeTokenFlagDesc,
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5000,
+		5*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txPollFreq,
 		bridgeHelper.TxPollFreqFlag,
-		50,
+		50*time.Millisecond,
 		"frequency in milliseconds for poll transactions",
 	)
 
@@ -101,8 +101,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
 	if err != nil {
 		return err
 	}

--- a/command/validator/stake/params.go
+++ b/command/validator/stake/params.go
@@ -21,7 +21,6 @@ type stakeParams struct {
 	amount        string
 	stakeToken    string
 	txTimeout     time.Duration
-	txPollFreq    time.Duration
 
 	amountValue    *big.Int
 	stakeTokenAddr types.Address

--- a/command/validator/stake/params.go
+++ b/command/validator/stake/params.go
@@ -19,6 +19,8 @@ type stakeParams struct {
 	jsonRPC       string
 	amount        string
 	stakeToken    string
+	txTimeout     uint64
+	txPollFreq    uint64
 
 	amountValue    *big.Int
 	stakeTokenAddr types.Address

--- a/command/validator/stake/params.go
+++ b/command/validator/stake/params.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	validatorHelper "github.com/0xPolygon/polygon-edge/command/validator/helper"
@@ -19,8 +20,8 @@ type stakeParams struct {
 	jsonRPC       string
 	amount        string
 	stakeToken    string
-	txTimeout     uint64
-	txPollFreq    uint64
+	txTimeout     time.Duration
+	txPollFreq    time.Duration
 
 	amountValue    *big.Int
 	stakeTokenAddr types.Address

--- a/command/validator/stake/stake.go
+++ b/command/validator/stake/stake.go
@@ -90,8 +90,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(150*time.Millisecond))
+		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return err
 	}

--- a/command/validator/stake/stake.go
+++ b/command/validator/stake/stake.go
@@ -97,8 +97,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
+		txrelayer.WithReceiptsTimeout(params.txTimeout),
+		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
 	if err != nil {
 		return err
 	}

--- a/command/validator/stake/stake.go
+++ b/command/validator/stake/stake.go
@@ -67,7 +67,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		50*time.Second,
+		150*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/validator/stake/stake.go
+++ b/command/validator/stake/stake.go
@@ -64,6 +64,20 @@ func setFlags(cmd *cobra.Command) {
 		polybftsecrets.StakeTokenFlagDesc,
 	)
 
+	cmd.Flags().Uint64Var(
+		&params.txTimeout,
+		bridgeHelper.TxTimeoutFlag,
+		5000,
+		"timeout for receipts in milliseconds",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.txPollFreq,
+		bridgeHelper.TxPollFreqFlag,
+		150,
+		"frequency in milliseconds for poll transactions",
+	)
+
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 }
 
@@ -83,7 +97,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptTimeout(150*time.Millisecond))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		return err
 	}

--- a/command/validator/stake/stake.go
+++ b/command/validator/stake/stake.go
@@ -68,14 +68,7 @@ func setFlags(cmd *cobra.Command) {
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
 		150*time.Second,
-		"timeout for receipts in milliseconds",
-	)
-
-	cmd.Flags().DurationVar(
-		&params.txPollFreq,
-		bridgeHelper.TxPollFreqFlag,
-		150*time.Millisecond,
-		"frequency in milliseconds for poll transactions",
+		helper.TxTimeoutDesc,
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
@@ -98,7 +91,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
 		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
+		txrelayer.WithReceiptsPollFreq(150*time.Millisecond))
 	if err != nil {
 		return err
 	}

--- a/command/validator/stake/stake.go
+++ b/command/validator/stake/stake.go
@@ -66,7 +66,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
-		bridgeHelper.TxTimeoutFlag,
+		helper.TxTimeoutFlag,
 		150*time.Second,
 		helper.TxTimeoutDesc,
 	)

--- a/command/validator/stake/stake.go
+++ b/command/validator/stake/stake.go
@@ -67,7 +67,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5*time.Second,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/validator/stake/stake.go
+++ b/command/validator/stake/stake.go
@@ -64,17 +64,17 @@ func setFlags(cmd *cobra.Command) {
 		polybftsecrets.StakeTokenFlagDesc,
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5000,
+		5*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txPollFreq,
 		bridgeHelper.TxPollFreqFlag,
-		150,
+		150*time.Millisecond,
 		"frequency in milliseconds for poll transactions",
 	)
 
@@ -97,8 +97,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
 	if err != nil {
 		return err
 	}

--- a/command/validator/unstake/params.go
+++ b/command/validator/unstake/params.go
@@ -20,7 +20,6 @@ type unstakeParams struct {
 	jsonRPC       string
 	amount        string
 	txTimeout     time.Duration
-	txPollFreq    time.Duration
 
 	amountValue *big.Int
 }

--- a/command/validator/unstake/params.go
+++ b/command/validator/unstake/params.go
@@ -18,6 +18,8 @@ type unstakeParams struct {
 	accountConfig string
 	jsonRPC       string
 	amount        string
+	txTimeout     uint64
+	txPollFreq    uint64
 
 	amountValue *big.Int
 }

--- a/command/validator/unstake/params.go
+++ b/command/validator/unstake/params.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	validatorHelper "github.com/0xPolygon/polygon-edge/command/validator/helper"
@@ -18,8 +19,8 @@ type unstakeParams struct {
 	accountConfig string
 	jsonRPC       string
 	amount        string
-	txTimeout     uint64
-	txPollFreq    uint64
+	txTimeout     time.Duration
+	txPollFreq    time.Duration
 
 	amountValue *big.Int
 }

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -88,7 +88,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
 		txrelayer.WithReceiptsPollFreq(params.txPollFreq),
-		txrelayer.WithReceiptsPollFreq(params.txTimeout))
+		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return err
 	}

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -54,17 +54,17 @@ func setFlags(cmd *cobra.Command) {
 		"amount to unstake from validator",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5000,
+		5*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txPollFreq,
 		bridgeHelper.TxPollFreqFlag,
-		150,
+		150*time.Millisecond,
 		"frequency in milliseconds for poll transactions",
 	)
 
@@ -87,8 +87,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txTimeout*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txTimeout)))
 	if err != nil {
 		return err
 	}

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -80,7 +80,6 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsPollFreq(150*time.Millisecond),
 		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return err

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -57,7 +57,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5*time.Second,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/command"
+	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	polybftsecrets "github.com/0xPolygon/polygon-edge/command/secrets/init"
 	validatorHelper "github.com/0xPolygon/polygon-edge/command/validator/helper"
@@ -53,6 +54,20 @@ func setFlags(cmd *cobra.Command) {
 		"amount to unstake from validator",
 	)
 
+	cmd.Flags().Uint64Var(
+		&params.txTimeout,
+		bridgeHelper.TxTimeoutFlag,
+		5000,
+		"timeout for receipts in milliseconds",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.txPollFreq,
+		bridgeHelper.TxPollFreqFlag,
+		150,
+		"frequency in milliseconds for poll transactions",
+	)
+
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 }
 
@@ -72,7 +87,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptTimeout(150*time.Millisecond))
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txTimeout*uint64(time.Millisecond))))
 	if err != nil {
 		return err
 	}

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/command"
-	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	polybftsecrets "github.com/0xPolygon/polygon-edge/command/secrets/init"
 	validatorHelper "github.com/0xPolygon/polygon-edge/command/validator/helper"
@@ -56,7 +55,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
-		bridgeHelper.TxTimeoutFlag,
+		helper.TxTimeoutFlag,
 		150*time.Second,
 		helper.TxTimeoutDesc,
 	)

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -58,14 +58,7 @@ func setFlags(cmd *cobra.Command) {
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
 		150*time.Second,
-		"timeout for receipts in milliseconds",
-	)
-
-	cmd.Flags().DurationVar(
-		&params.txPollFreq,
-		bridgeHelper.TxPollFreqFlag,
-		150*time.Millisecond,
-		"frequency in milliseconds for poll transactions",
+		helper.TxTimeoutDesc,
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
@@ -87,7 +80,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsPollFreq(params.txPollFreq),
+		txrelayer.WithReceiptsPollFreq(150*time.Millisecond),
 		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return err

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -57,7 +57,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		50*time.Second,
+		150*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/validator/unstake/unstake.go
+++ b/command/validator/unstake/unstake.go
@@ -87,8 +87,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txTimeout)))
+		txrelayer.WithReceiptsPollFreq(params.txPollFreq),
+		txrelayer.WithReceiptsPollFreq(params.txTimeout))
 	if err != nil {
 		return err
 	}

--- a/command/validator/validators/params.go
+++ b/command/validator/validators/params.go
@@ -17,7 +17,6 @@ type validatorInfoParams struct {
 	stakeManagerAddress    string
 	chainID                int64
 	txTimeout              time.Duration
-	txPollFreq             time.Duration
 }
 
 func (v *validatorInfoParams) validateFlags() error {

--- a/command/validator/validators/params.go
+++ b/command/validator/validators/params.go
@@ -3,6 +3,7 @@ package validators
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	validatorHelper "github.com/0xPolygon/polygon-edge/command/validator/helper"
@@ -15,8 +16,8 @@ type validatorInfoParams struct {
 	supernetManagerAddress string
 	stakeManagerAddress    string
 	chainID                int64
-	txTimeout              uint64
-	txPollFreq             uint64
+	txTimeout              time.Duration
+	txPollFreq             time.Duration
 }
 
 func (v *validatorInfoParams) validateFlags() error {

--- a/command/validator/validators/params.go
+++ b/command/validator/validators/params.go
@@ -15,6 +15,8 @@ type validatorInfoParams struct {
 	supernetManagerAddress string
 	stakeManagerAddress    string
 	chainID                int64
+	txTimeout              uint64
+	txPollFreq             uint64
 }
 
 func (v *validatorInfoParams) validateFlags() error {

--- a/command/validator/validators/validator_info.go
+++ b/command/validator/validators/validator_info.go
@@ -55,7 +55,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
-		bridgeHelper.TxTimeoutFlag,
+		helper.TxTimeoutFlag,
 		txrelayer.DefaultTimeoutTransactions,
 		helper.TxTimeoutDesc,
 	)

--- a/command/validator/validators/validator_info.go
+++ b/command/validator/validators/validator_info.go
@@ -57,7 +57,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5*time.Second,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/validator/validators/validator_info.go
+++ b/command/validator/validators/validator_info.go
@@ -87,8 +87,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
+		txrelayer.WithReceiptsTimeout(params.txTimeout),
+		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
 	if err != nil {
 		return err
 	}

--- a/command/validator/validators/validator_info.go
+++ b/command/validator/validators/validator_info.go
@@ -54,17 +54,17 @@ func setFlags(cmd *cobra.Command) {
 		polybftsecrets.ChainIDFlagDesc,
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5000,
+		5*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txPollFreq,
 		bridgeHelper.TxPollFreqFlag,
-		50,
+		50*time.Millisecond,
 		"frequency in milliseconds for poll transactions",
 	)
 
@@ -87,8 +87,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
 	if err != nil {
 		return err
 	}

--- a/command/validator/validators/validator_info.go
+++ b/command/validator/validators/validator_info.go
@@ -2,7 +2,6 @@ package validators
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
@@ -57,15 +56,8 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		50*time.Second,
-		"timeout for receipts in milliseconds",
-	)
-
-	cmd.Flags().DurationVar(
-		&params.txPollFreq,
-		bridgeHelper.TxPollFreqFlag,
-		50*time.Millisecond,
-		"frequency in milliseconds for poll transactions",
+		txrelayer.DefaultTimeoutTransactions,
+		helper.TxTimeoutDesc,
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
@@ -87,8 +79,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
+		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return err
 	}

--- a/command/validator/validators/validator_info.go
+++ b/command/validator/validators/validator_info.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
@@ -53,6 +54,20 @@ func setFlags(cmd *cobra.Command) {
 		polybftsecrets.ChainIDFlagDesc,
 	)
 
+	cmd.Flags().Uint64Var(
+		&params.txTimeout,
+		bridgeHelper.TxTimeoutFlag,
+		5000,
+		"timeout for receipts in milliseconds",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.txPollFreq,
+		bridgeHelper.TxPollFreqFlag,
+		50,
+		"frequency in milliseconds for poll transactions",
+	)
+
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 }
 
@@ -71,7 +86,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC))
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		return err
 	}

--- a/command/validator/whitelist/params.go
+++ b/command/validator/whitelist/params.go
@@ -23,6 +23,8 @@ type whitelistParams struct {
 	privateKey            string
 	jsonRPC               string
 	newValidatorAddresses []string
+	txTimeout             uint64
+	txPollFreq            uint64
 }
 
 func (ep *whitelistParams) validateFlags() error {

--- a/command/validator/whitelist/params.go
+++ b/command/validator/whitelist/params.go
@@ -25,7 +25,6 @@ type whitelistParams struct {
 	jsonRPC               string
 	newValidatorAddresses []string
 	txTimeout             time.Duration
-	txPollFreq            time.Duration
 }
 
 func (ep *whitelistParams) validateFlags() error {

--- a/command/validator/whitelist/params.go
+++ b/command/validator/whitelist/params.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	validatorHelper "github.com/0xPolygon/polygon-edge/command/validator/helper"
@@ -23,8 +24,8 @@ type whitelistParams struct {
 	privateKey            string
 	jsonRPC               string
 	newValidatorAddresses []string
-	txTimeout             uint64
-	txPollFreq            uint64
+	txTimeout             time.Duration
+	txPollFreq            time.Duration
 }
 
 func (ep *whitelistParams) validateFlags() error {

--- a/command/validator/whitelist/whitelist_validators.go
+++ b/command/validator/whitelist/whitelist_validators.go
@@ -61,7 +61,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
-		bridgeHelper.TxTimeoutFlag,
+		helper.TxTimeoutFlag,
 		150*time.Second,
 		helper.TxTimeoutDesc,
 	)

--- a/command/validator/whitelist/whitelist_validators.go
+++ b/command/validator/whitelist/whitelist_validators.go
@@ -62,7 +62,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		50*time.Second,
+		150*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/validator/whitelist/whitelist_validators.go
+++ b/command/validator/whitelist/whitelist_validators.go
@@ -2,7 +2,6 @@ package whitelist
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
@@ -96,8 +95,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
+		txrelayer.WithReceiptsTimeout(params.txTimeout),
+		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
 	if err != nil {
 		return fmt.Errorf("whitelist validator failed. Could not create tx relayer: %w", err)
 	}

--- a/command/validator/whitelist/whitelist_validators.go
+++ b/command/validator/whitelist/whitelist_validators.go
@@ -2,6 +2,7 @@ package whitelist
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
@@ -61,7 +62,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5000,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/validator/whitelist/whitelist_validators.go
+++ b/command/validator/whitelist/whitelist_validators.go
@@ -59,6 +59,20 @@ func setFlags(cmd *cobra.Command) {
 		"account addresses of a possible validators",
 	)
 
+	cmd.Flags().Uint64Var(
+		&params.txTimeout,
+		bridgeHelper.TxTimeoutFlag,
+		5000,
+		"timeout for receipts in milliseconds",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.txPollFreq,
+		bridgeHelper.TxPollFreqFlag,
+		150,
+		"frequency in milliseconds for poll transactions",
+	)
+
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.PrivateKeyFlag, polybftsecrets.AccountConfigFlag)
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.PrivateKeyFlag, polybftsecrets.AccountDirFlag)
@@ -82,7 +96,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptTimeout(150*time.Millisecond))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		return fmt.Errorf("whitelist validator failed. Could not create tx relayer: %w", err)
 	}

--- a/command/validator/whitelist/whitelist_validators.go
+++ b/command/validator/whitelist/whitelist_validators.go
@@ -59,14 +59,14 @@ func setFlags(cmd *cobra.Command) {
 		"account addresses of a possible validators",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
 		5000,
 		"timeout for receipts in milliseconds",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txPollFreq,
 		bridgeHelper.TxPollFreqFlag,
 		150,
@@ -96,8 +96,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
 	if err != nil {
 		return fmt.Errorf("whitelist validator failed. Could not create tx relayer: %w", err)
 	}

--- a/command/validator/whitelist/whitelist_validators.go
+++ b/command/validator/whitelist/whitelist_validators.go
@@ -63,14 +63,7 @@ func setFlags(cmd *cobra.Command) {
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
 		150*time.Second,
-		"timeout for receipts in milliseconds",
-	)
-
-	cmd.Flags().DurationVar(
-		&params.txPollFreq,
-		bridgeHelper.TxPollFreqFlag,
-		150,
-		"frequency in milliseconds for poll transactions",
+		helper.TxTimeoutDesc,
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
@@ -97,7 +90,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
 		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
+		txrelayer.WithReceiptsPollFreq(150*time.Millisecond))
 	if err != nil {
 		return fmt.Errorf("whitelist validator failed. Could not create tx relayer: %w", err)
 	}

--- a/command/validator/whitelist/whitelist_validators.go
+++ b/command/validator/whitelist/whitelist_validators.go
@@ -89,8 +89,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(150*time.Millisecond))
+		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return fmt.Errorf("whitelist validator failed. Could not create tx relayer: %w", err)
 	}

--- a/command/validator/withdraw-rewards/params.go
+++ b/command/validator/withdraw-rewards/params.go
@@ -12,6 +12,8 @@ type withdrawRewardsParams struct {
 	accountDir    string
 	accountConfig string
 	jsonRPC       string
+	txTimeout     uint64
+	txPollFreq    uint64
 }
 
 type withdrawRewardResult struct {

--- a/command/validator/withdraw-rewards/params.go
+++ b/command/validator/withdraw-rewards/params.go
@@ -14,7 +14,6 @@ type withdrawRewardsParams struct {
 	accountConfig string
 	jsonRPC       string
 	txTimeout     time.Duration
-	txPollFreq    time.Duration
 }
 
 type withdrawRewardResult struct {

--- a/command/validator/withdraw-rewards/params.go
+++ b/command/validator/withdraw-rewards/params.go
@@ -3,6 +3,7 @@ package rewards
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	validatorHelper "github.com/0xPolygon/polygon-edge/command/validator/helper"
@@ -12,8 +13,8 @@ type withdrawRewardsParams struct {
 	accountDir    string
 	accountConfig string
 	jsonRPC       string
-	txTimeout     uint64
-	txPollFreq    uint64
+	txTimeout     time.Duration
+	txPollFreq    time.Duration
 }
 
 type withdrawRewardResult struct {

--- a/command/validator/withdraw-rewards/rewards.go
+++ b/command/validator/withdraw-rewards/rewards.go
@@ -52,7 +52,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		50*time.Second,
+		150*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/validator/withdraw-rewards/rewards.go
+++ b/command/validator/withdraw-rewards/rewards.go
@@ -84,8 +84,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	validatorAddr := validatorAccount.Ecdsa.Address()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
+		txrelayer.WithReceiptsTimeout(params.txTimeout),
+		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
 	if err != nil {
 		return err
 	}

--- a/command/validator/withdraw-rewards/rewards.go
+++ b/command/validator/withdraw-rewards/rewards.go
@@ -49,6 +49,20 @@ func setFlags(cmd *cobra.Command) {
 		polybftsecrets.AccountConfigFlagDesc,
 	)
 
+	cmd.Flags().Uint64Var(
+		&params.txTimeout,
+		bridgeHelper.TxTimeoutFlag,
+		5000,
+		"timeout for receipts in milliseconds",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.txPollFreq,
+		bridgeHelper.TxPollFreqFlag,
+		150,
+		"frequency in milliseconds for poll transactions",
+	)
+
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 }
 
@@ -70,7 +84,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	validatorAddr := validatorAccount.Ecdsa.Address()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptTimeout(150*time.Millisecond))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		return err
 	}

--- a/command/validator/withdraw-rewards/rewards.go
+++ b/command/validator/withdraw-rewards/rewards.go
@@ -52,7 +52,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5*time.Second,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/validator/withdraw-rewards/rewards.go
+++ b/command/validator/withdraw-rewards/rewards.go
@@ -49,17 +49,17 @@ func setFlags(cmd *cobra.Command) {
 		polybftsecrets.AccountConfigFlagDesc,
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5000,
+		5*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txPollFreq,
 		bridgeHelper.TxPollFreqFlag,
-		150,
+		150*time.Millisecond,
 		"frequency in milliseconds for poll transactions",
 	)
 
@@ -84,8 +84,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	validatorAddr := validatorAccount.Ecdsa.Address()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
 	if err != nil {
 		return err
 	}

--- a/command/validator/withdraw-rewards/rewards.go
+++ b/command/validator/withdraw-rewards/rewards.go
@@ -77,8 +77,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	validatorAddr := validatorAccount.Ecdsa.Address()
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(150*time.Millisecond))
+		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return err
 	}

--- a/command/validator/withdraw-rewards/rewards.go
+++ b/command/validator/withdraw-rewards/rewards.go
@@ -51,7 +51,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
-		bridgeHelper.TxTimeoutFlag,
+		helper.TxTimeoutFlag,
 		150*time.Second,
 		helper.TxTimeoutDesc,
 	)

--- a/command/validator/withdraw-rewards/rewards.go
+++ b/command/validator/withdraw-rewards/rewards.go
@@ -53,14 +53,7 @@ func setFlags(cmd *cobra.Command) {
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
 		150*time.Second,
-		"timeout for receipts in milliseconds",
-	)
-
-	cmd.Flags().DurationVar(
-		&params.txPollFreq,
-		bridgeHelper.TxPollFreqFlag,
-		150*time.Millisecond,
-		"frequency in milliseconds for poll transactions",
+		helper.TxTimeoutDesc,
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
@@ -85,7 +78,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
 		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
+		txrelayer.WithReceiptsPollFreq(150*time.Millisecond))
 	if err != nil {
 		return err
 	}

--- a/command/validator/withdraw/params.go
+++ b/command/validator/withdraw/params.go
@@ -3,6 +3,7 @@ package withdraw
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	validatorHelper "github.com/0xPolygon/polygon-edge/command/validator/helper"
@@ -16,8 +17,8 @@ type withdrawParams struct {
 	accountDir    string
 	accountConfig string
 	jsonRPC       string
-	txTimeout     uint64
-	txPollFreq    uint64
+	txTimeout     time.Duration
+	txPollFreq    time.Duration
 }
 
 func (v *withdrawParams) validateFlags() (err error) {

--- a/command/validator/withdraw/params.go
+++ b/command/validator/withdraw/params.go
@@ -16,6 +16,8 @@ type withdrawParams struct {
 	accountDir    string
 	accountConfig string
 	jsonRPC       string
+	txTimeout     uint64
+	txPollFreq    uint64
 }
 
 func (v *withdrawParams) validateFlags() (err error) {

--- a/command/validator/withdraw/params.go
+++ b/command/validator/withdraw/params.go
@@ -18,7 +18,6 @@ type withdrawParams struct {
 	accountConfig string
 	jsonRPC       string
 	txTimeout     time.Duration
-	txPollFreq    time.Duration
 }
 
 func (v *withdrawParams) validateFlags() (err error) {

--- a/command/validator/withdraw/withdraw.go
+++ b/command/validator/withdraw/withdraw.go
@@ -73,8 +73,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(150*time.Millisecond))
+		txrelayer.WithReceiptsTimeout(params.txTimeout))
 	if err != nil {
 		return err
 	}

--- a/command/validator/withdraw/withdraw.go
+++ b/command/validator/withdraw/withdraw.go
@@ -49,7 +49,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		50*time.Second,
+		150*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/validator/withdraw/withdraw.go
+++ b/command/validator/withdraw/withdraw.go
@@ -46,6 +46,20 @@ func setFlags(cmd *cobra.Command) {
 		polybftsecrets.AccountConfigFlagDesc,
 	)
 
+	cmd.Flags().Uint64Var(
+		&params.txTimeout,
+		bridgeHelper.TxTimeoutFlag,
+		5000,
+		"timeout for receipts in milliseconds",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.txPollFreq,
+		bridgeHelper.TxPollFreqFlag,
+		150,
+		"frequency in milliseconds for poll transactions",
+	)
+
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 	helper.RegisterJSONRPCFlag(cmd)
 }
@@ -66,7 +80,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptTimeout(150*time.Millisecond))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
 	if err != nil {
 		return err
 	}

--- a/command/validator/withdraw/withdraw.go
+++ b/command/validator/withdraw/withdraw.go
@@ -2,6 +2,7 @@ package withdraw
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
@@ -48,7 +49,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
-		5000,
+		50*time.Second,
 		"timeout for receipts in milliseconds",
 	)
 

--- a/command/validator/withdraw/withdraw.go
+++ b/command/validator/withdraw/withdraw.go
@@ -48,7 +48,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(
 		&params.txTimeout,
-		bridgeHelper.TxTimeoutFlag,
+		helper.TxTimeoutFlag,
 		150*time.Second,
 		helper.TxTimeoutDesc,
 	)

--- a/command/validator/withdraw/withdraw.go
+++ b/command/validator/withdraw/withdraw.go
@@ -50,14 +50,7 @@ func setFlags(cmd *cobra.Command) {
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
 		150*time.Second,
-		"timeout for receipts in milliseconds",
-	)
-
-	cmd.Flags().DurationVar(
-		&params.txPollFreq,
-		bridgeHelper.TxPollFreqFlag,
-		150,
-		"frequency in milliseconds for poll transactions",
+		helper.TxTimeoutDesc,
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
@@ -81,7 +74,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
 		txrelayer.WithReceiptsTimeout(params.txTimeout),
-		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
+		txrelayer.WithReceiptsPollFreq(150*time.Millisecond))
 	if err != nil {
 		return err
 	}

--- a/command/validator/withdraw/withdraw.go
+++ b/command/validator/withdraw/withdraw.go
@@ -2,7 +2,6 @@ package withdraw
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
@@ -80,8 +79,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
+		txrelayer.WithReceiptsTimeout(params.txTimeout),
+		txrelayer.WithReceiptsPollFreq(params.txPollFreq))
 	if err != nil {
 		return err
 	}

--- a/command/validator/withdraw/withdraw.go
+++ b/command/validator/withdraw/withdraw.go
@@ -46,14 +46,14 @@ func setFlags(cmd *cobra.Command) {
 		polybftsecrets.AccountConfigFlagDesc,
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txTimeout,
 		bridgeHelper.TxTimeoutFlag,
 		5000,
 		"timeout for receipts in milliseconds",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().DurationVar(
 		&params.txPollFreq,
 		bridgeHelper.TxPollFreqFlag,
 		150,
@@ -80,8 +80,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
-		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout*uint64(time.Millisecond))),
-		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq*uint64(time.Millisecond))))
+		txrelayer.WithReceiptsTimeout(time.Duration(params.txTimeout)),
+		txrelayer.WithReceiptsPollFreq(time.Duration(params.txPollFreq)))
 	if err != nil {
 		return err
 	}

--- a/consensus/polybft/state_sync_relayer.go
+++ b/consensus/polybft/state_sync_relayer.go
@@ -253,6 +253,6 @@ func getBridgeTxRelayer(rpcEndpoint string, logger hclog.Logger) (txrelayer.TxRe
 	}
 
 	return txrelayer.NewTxRelayer(
-		txrelayer.WithIPAddress(rpcEndpoint), txrelayer.WithNumRetries(-1),
+		txrelayer.WithIPAddress(rpcEndpoint), txrelayer.WithNoWaiting(),
 		txrelayer.WithWriter(logger.StandardWriter(&hclog.StandardLoggerOptions{})))
 }

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -23,8 +23,8 @@ const (
 	defaultNumRetries          = 1000
 	gasLimitIncreasePercentage = 100
 	feeIncreasePercentage      = 100
-	DefaultTimeoutTransactions = time.Duration(50 * time.Second)
-	DefaultPollFreq            = time.Duration(50 * time.Millisecond)
+	DefaultTimeoutTransactions = 50 * time.Second
+	DefaultPollFreq            = 50 * time.Millisecond
 )
 
 var (

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -64,7 +64,7 @@ func NewTxRelayer(opts ...TxRelayerOption) (TxRelayer, error) {
 	t := &TxRelayerImpl{
 		ipAddress:        DefaultRPCAddress,
 		receiptsPollFreq: 50 * time.Millisecond,
-		receiptsTimeout:  5 * time.Second,
+		receiptsTimeout:  50 * time.Second,
 	}
 	for _, opt := range opts {
 		opt(t)

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -65,8 +65,8 @@ type TxRelayerImpl struct {
 func NewTxRelayer(opts ...TxRelayerOption) (TxRelayer, error) {
 	t := &TxRelayerImpl{
 		ipAddress:        DefaultRPCAddress,
-		receiptsPollFreq: DefaultTimeoutTransactions,
-		receiptsTimeout:  DefaultPollFreq,
+		receiptsPollFreq: DefaultPollFreq,
+		receiptsTimeout:  DefaultTimeoutTransactions,
 	}
 	for _, opt := range opts {
 		opt(t)

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -23,6 +23,8 @@ const (
 	defaultNumRetries          = 1000
 	gasLimitIncreasePercentage = 100
 	feeIncreasePercentage      = 100
+	DefaultTimeoutTransactions = time.Duration(50 * time.Second)
+	DefaultPollFreq            = time.Duration(50 * time.Millisecond)
 )
 
 var (
@@ -63,8 +65,8 @@ type TxRelayerImpl struct {
 func NewTxRelayer(opts ...TxRelayerOption) (TxRelayer, error) {
 	t := &TxRelayerImpl{
 		ipAddress:        DefaultRPCAddress,
-		receiptsPollFreq: 50 * time.Millisecond,
-		receiptsTimeout:  50 * time.Second,
+		receiptsPollFreq: DefaultTimeoutTransactions,
+		receiptsTimeout:  DefaultPollFreq,
 	}
 	for _, opt := range opts {
 		opt(t)

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -73,7 +73,6 @@ func NewTxRelayer(opts ...TxRelayerOption) (TxRelayer, error) {
 	}
 
 	// Calculate receiptsPollFreq based on receiptsTimeout
-
 	if t.receiptsTimeout >= time.Minute {
 		t.receiptsPollFreq = 2 * time.Second
 	}


### PR DESCRIPTION
# Description

Rename the `receiptsTimeout` to `receiptsPollFreq`, because it denotes how often we are querying for tx receipts (and expose it programmatically as well) and introduce `receiptsTimeout` that would denote global timeout. 



# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
