### PR TITLE
Validator Snapshot bug fix

### DIFF
--- a/consensus/polybft/state_store_epoch.go
+++ b/consensus/polybft/state_store_epoch.go
@@ -101,7 +101,7 @@ func (s *EpochStore) getNearestOrEpochSnapshot(epoch uint64, dbTx *bolt.Tx) (*va
 	)
 
 	getFn := func(tx *bolt.Tx) error {
-		for ; epoch >= 0; epoch-- {
+		for {
 			v := tx.Bucket(validatorSnapshotsBucket).Get(common.EncodeUint64ToBytes(epoch))
 			if v != nil {
 				return json.Unmarshal(v, &snapshot)
@@ -110,6 +110,8 @@ func (s *EpochStore) getNearestOrEpochSnapshot(epoch uint64, dbTx *bolt.Tx) (*va
 			if epoch == 0 { // prevent uint64 underflow
 				break
 			}
+
+			epoch--
 		}
 
 		return nil

--- a/consensus/polybft/state_store_epoch.go
+++ b/consensus/polybft/state_store_epoch.go
@@ -93,25 +93,26 @@ func (s *EpochStore) getValidatorSnapshot(epoch uint64) (*validatorSnapshot, err
 	return validatorSnapshot, err
 }
 
-// getLastSnapshot returns the last snapshot saved in db
-// since they are stored by epoch number (uint64), they are sequentially stored,
-// so the latest epoch will be the last snapshot in db
-func (s *EpochStore) getLastSnapshot(dbTx *bolt.Tx) (*validatorSnapshot, error) {
+// getNearestOrEpochSnapshot returns the nearest or the exact epoch snapshot from db
+func (s *EpochStore) getNearestOrEpochSnapshot(epoch uint64, dbTx *bolt.Tx) (*validatorSnapshot, error) {
 	var (
 		snapshot *validatorSnapshot
 		err      error
 	)
 
 	getFn := func(tx *bolt.Tx) error {
-		c := tx.Bucket(validatorSnapshotsBucket).Cursor()
-		k, v := c.Last()
+		for ; epoch >= 0; epoch-- {
+			v := tx.Bucket(validatorSnapshotsBucket).Get(common.EncodeUint64ToBytes(epoch))
+			if v != nil {
+				return json.Unmarshal(v, &snapshot)
+			}
 
-		if k == nil {
-			// we have no snapshots in db
-			return nil
+			if epoch == 0 { // prevent uint64 underflow
+				break
+			}
 		}
 
-		return json.Unmarshal(v, &snapshot)
+		return nil
 	}
 
 	if dbTx == nil {

--- a/consensus/polybft/state_store_epoch_test.go
+++ b/consensus/polybft/state_store_epoch_test.go
@@ -5,11 +5,12 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/0xPolygon/polygon-edge/bls"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestState_insertAndGetValidatorSnapshot(t *testing.T) {
@@ -191,18 +192,13 @@ func TestEpochStore_getNearestOrEpochSnapshot(t *testing.T) {
 
 	state := newTestState(t)
 	epoch := uint64(1)
-	keys, err := bls.CreateRandomBlsKeys(3)
-	require.NoError(t, err)
+	tv := validator.NewTestValidators(t, 3)
 
 	// Insert a snapshot for epoch 1
 	snapshot := &validatorSnapshot{
 		Epoch:            epoch,
 		EpochEndingBlock: 100,
-		Snapshot: validator.AccountSet{
-			&validator.ValidatorMetadata{Address: types.BytesToAddress([]byte{0x18}), BlsKey: keys[0].PublicKey()},
-			&validator.ValidatorMetadata{Address: types.BytesToAddress([]byte{0x23}), BlsKey: keys[1].PublicKey()},
-			&validator.ValidatorMetadata{Address: types.BytesToAddress([]byte{0x37}), BlsKey: keys[2].PublicKey()},
-		},
+		Snapshot:         tv.GetPublicIdentities(),
 	}
 
 	require.NoError(t, state.EpochStore.insertValidatorSnapshot(snapshot, nil))
@@ -233,6 +229,6 @@ func TestEpochStore_getNearestOrEpochSnapshot(t *testing.T) {
 
 		result, err := state.EpochStore.getNearestOrEpochSnapshot(2, nil)
 		assert.NoError(t, err)
-		assert.Equal(t, result, snapshot)
+		assert.Equal(t, snapshot, result)
 	})
 }

--- a/consensus/polybft/validators_snapshot.go
+++ b/consensus/polybft/validators_snapshot.go
@@ -297,7 +297,7 @@ func (v *validatorsSnapshotCache) getLastCachedSnapshot(currentEpoch uint64,
 	}
 
 	// if we do not have a snapshot in memory for given epoch, we will get the latest one we have
-	for ; currentEpoch >= 0; currentEpoch-- {
+	for {
 		cachedSnapshot = v.snapshots[currentEpoch]
 		if cachedSnapshot != nil {
 			v.logger.Trace("Found snapshot in memory cache", "Epoch", currentEpoch)
@@ -308,6 +308,8 @@ func (v *validatorsSnapshotCache) getLastCachedSnapshot(currentEpoch uint64,
 		if currentEpoch == 0 { // prevent uint64 underflow
 			break
 		}
+
+		currentEpoch--
 	}
 
 	dbSnapshot, err := v.state.EpochStore.getNearestOrEpochSnapshot(epochToQuery, dbTx)

--- a/consensus/polybft/validators_snapshot.go
+++ b/consensus/polybft/validators_snapshot.go
@@ -327,12 +327,6 @@ func (v *validatorsSnapshotCache) getLastCachedSnapshot(currentEpoch uint64,
 		}
 	}
 
-	if cachedSnapshot != nil && cachedSnapshot.Epoch > epochToQuery {
-		// if we have a snapshot in memory or db, but it's newer than the one we need
-		// then return nil, and just recalculate it from scratch
-		return nil, nil
-	}
-
 	return cachedSnapshot, nil
 }
 


### PR DESCRIPTION
# Description

This PR fixes the issue on validator snapshot, where an incorrect snapshot can be returned for some earlier epochs.

Basically the issue was discovered by running a network with 5 validators, which produced a number of epochs. In the newest epoch, two more validators were added, and the network finalized the ending block on that newest epoch, and a new snapshot was saved that contained those new validators (5 old + 2 new), meaning that will be the new active validator set from the next block.
After that epoch ending block was finalized (which carried validator set update), network experienced communication issues, and all validators were down, which cleared the memory cache in the `validator_set_snapshot.go`. Validators were started again, but, while validating a proposal for the new block (first block of the new epoch that contains 5 + 2 validators), parent signatures from the previous block, to be more precise, `validator_snapshot` returned the newest snapshot from `db`, which was the one updated with 2 new validators, instead of returning a snapshot from the previous epoch, since we are validating signatures from the previous block, which was in previous epoch.
This caused a constant round change on building a new block, because it returned a doesn't have quorum error, since the parent block had 4 signatures, and the returned snapshot had 7 validators, which was not enough.

The solution is, if we are querying a validator snapshot from an eariler epoch, and if we don't find it in memory, we should try to iterate in the `db` as well, and not just returned the last one we have in `db`, which might not be correct.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually