### PR TITLE
2nd leveldb database instance removal

### DIFF
--- a/blockchain/storagev2/leveldb/leveldb.go
+++ b/blockchain/storagev2/leveldb/leveldb.go
@@ -13,19 +13,16 @@ type levelDB struct {
 }
 
 var tableMapper = map[uint8][]byte{
-	// Main DB
-	storagev2.BODY:       []byte("b"), // DB key = block number + block hash + mapper, value = block body
-	storagev2.DIFFICULTY: []byte("d"), // DB key = block number + block hash + mapper, value = block total diffculty
-	storagev2.HEADER:     []byte("h"), // DB key = block number + block hash + mapper, value = block header
-	storagev2.RECEIPTS:   []byte("r"), // DB key = block number + block hash + mapper, value = block receipts
-	storagev2.CANONICAL:  {},          // DB key = block number + mapper, value = block hash
-
-	// Lookup DB
-	storagev2.FORK:         {}, // DB key = FORK_KEY + mapper, value = fork hashes
-	storagev2.HEAD_HASH:    {}, // DB key = HEAD_HASH_KEY + mapper, value = head hash
-	storagev2.HEAD_NUMBER:  {}, // DB key = HEAD_NUMBER_KEY + mapper, value = head number
-	storagev2.BLOCK_LOOKUP: {}, // DB key = block hash + mapper, value = block number
-	storagev2.TX_LOOKUP:    {}, // DB key = tx hash + mapper, value = block number
+	storagev2.BODY:         []byte("b"), // DB key = block number + block hash + mapper, value = block body
+	storagev2.DIFFICULTY:   []byte("d"), // DB key = block number + block hash + mapper, value = block total diffculty
+	storagev2.HEADER:       []byte("h"), // DB key = block number + block hash + mapper, value = block header
+	storagev2.RECEIPTS:     []byte("r"), // DB key = block number + block hash + mapper, value = block receipts
+	storagev2.CANONICAL:    {},          // DB key = block number + mapper, value = block hash
+	storagev2.FORK:         {},          // DB key = FORK_KEY + mapper, value = fork hashes
+	storagev2.HEAD_HASH:    {},          // DB key = HEAD_HASH_KEY + mapper, value = head hash
+	storagev2.HEAD_NUMBER:  {},          // DB key = HEAD_NUMBER_KEY + mapper, value = head number
+	storagev2.BLOCK_LOOKUP: {},          // DB key = block hash + mapper, value = block number
+	storagev2.TX_LOOKUP:    {},          // DB key = tx hash + mapper, value = block number
 }
 
 // NewLevelDBStorage creates the new storage reference with leveldb default options
@@ -44,21 +41,8 @@ func NewLevelDBStorage(path string, logger hclog.Logger) (*storagev2.Storage, er
 		return nil, err
 	}
 
-	// Open Lookup
-	// Set default options
-	options = &opt.Options{
-		BlockCacheCapacity: 64 * opt.MiB,
-		WriteBuffer:        opt.DefaultWriteBuffer,
-	}
-	path += "/lookup"
-
-	lookup, err := openLevelDBStorage(path, options)
-	if err != nil {
-		return nil, err
-	}
-
 	ldbs[0] = &levelDB{maindb}
-	ldbs[1] = &levelDB{lookup}
+	ldbs[1] = nil
 
 	return storagev2.Open(logger.Named("leveldb"), ldbs)
 }

--- a/blockchain/storagev2/storage.go
+++ b/blockchain/storagev2/storage.go
@@ -1,4 +1,3 @@
-//nolint:stylecheck
 package storagev2
 
 import (
@@ -39,6 +38,8 @@ const (
 )
 
 // Lookup tables
+//
+//nolint:stylecheck // needed because linter considers _ in name as an error
 const (
 	FORK         = uint8(0) | LOOKUP_INDEX
 	HEAD_HASH    = uint8(2) | LOOKUP_INDEX
@@ -47,14 +48,18 @@ const (
 	TX_LOOKUP    = uint8(8) | LOOKUP_INDEX
 )
 
+//nolint:stylecheck // needed because linter considers _ in name as an error
 const MAX_TABLES = uint8(20)
 
 // Database indexes
+//
+//nolint:stylecheck // needed because linter considers _ in name as an error
 const (
 	MAINDB_INDEX = uint8(0)
 	LOOKUP_INDEX = uint8(1)
 )
 
+//nolint:stylecheck // needed because linter considers _ in name as an error
 var (
 	FORK_KEY        = []byte("0000000f")
 	HEAD_HASH_KEY   = []byte("0000000h")


### PR DESCRIPTION
# Description

Removed 2nd leveldb instance. Now all data goes into 1 database, as it was earlier. 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
