### PR TITLE
[BLADE-138] Consolidate `TestTxn` to use `TxRelayer`

### DIFF
--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -856,7 +856,6 @@ func TestE2E_Bridge_ChildchainTokensTransfer(t *testing.T) {
 		initialExitEventID := getLastExitEventID(t, childchainTxRelayer)
 
 		erc721DeployTxn := cluster.Deploy(t, admin, contractsapi.RootERC721.Bytecode)
-		require.NoError(t, erc721DeployTxn.Wait())
 		require.True(t, erc721DeployTxn.Succeed())
 		rootERC721Token := types.Address(erc721DeployTxn.Receipt().ContractAddress)
 
@@ -867,7 +866,6 @@ func TestE2E_Bridge_ChildchainTokensTransfer(t *testing.T) {
 			require.NoError(t, err)
 
 			mintTxn := cluster.MethodTxn(t, admin, rootERC721Token, mintInput)
-			require.NoError(t, mintTxn.Wait())
 			require.True(t, mintTxn.Succeed())
 
 			// add all depositors to bride block list

--- a/e2e-polybft/e2e/helpers_test.go
+++ b/e2e-polybft/e2e/helpers_test.go
@@ -144,7 +144,7 @@ func setAccessListRole(t *testing.T, cluster *framework.TestCluster, precompile,
 	require.NoError(t, err)
 
 	enableSetTxn := cluster.MethodTxn(t, aclAdmin, precompile, input)
-	require.NoError(t, enableSetTxn.Wait())
+	require.True(t, enableSetTxn.Succeed())
 
 	expectRole(t, cluster, precompile, account, role)
 }

--- a/e2e-polybft/e2e/storage_test.go
+++ b/e2e-polybft/e2e/storage_test.go
@@ -123,15 +123,17 @@ func checkStorage(t *testing.T, txs []*framework.TestTxn, client *jsonrpc.EthCli
 		assert.Equal(t, tx.Txn().Nonce(), bt.Nonce())
 		assert.Equal(t, tx.Receipt().TransactionIndex, bt.TxnIndex)
 		v, r, s := bt.RawSignatureValues()
-		assert.NotEmpty(t, v)
-		assert.NotEmpty(t, r)
-		assert.NotEmpty(t, s)
+		assert.NotNil(t, v)
+		assert.NotNil(t, r)
+		assert.NotNil(t, s)
 		assert.Equal(t, tx.Txn().From().Bytes(), bt.From().Bytes())
 		assert.Equal(t, tx.Txn().To().Bytes(), bt.To().Bytes())
 
-		if i%2 == 0 { // Intentionally disable it since dynamic fee tx not working
+		if i%2 == 0 {
 			assert.Equal(t, types.DynamicFeeTxType, bt.Type())
-			assert.Equal(t, uint64(0), bt.GasPrice().Uint64())
+			assert.Nil(t, bt.GasPrice()) // dynamic txs don't have gasPrice set
+			assert.NotNil(t, bt.GasFeeCap())
+			assert.NotNil(t, bt.GasTipCap())
 			assert.NotNil(t, bt.ChainID())
 		} else {
 			// assert.Equal(t, ethgo.TransactionLegacy, bt.Type)

--- a/e2e-polybft/e2e/storage_test.go
+++ b/e2e-polybft/e2e/storage_test.go
@@ -50,7 +50,7 @@ func TestE2E_Storage(t *testing.T) {
 			// Send every second transaction as a dynamic fees one
 			var txn *types.Transaction
 
-			if i%2 == 10 { // Intentionally disable it since dynamic fee tx not working
+			if i%2 == 0 { // Intentionally disable it since dynamic fee tx not working
 				chainID, err := client.ChainID()
 				require.NoError(t, err)
 
@@ -129,7 +129,7 @@ func checkStorage(t *testing.T, txs []*framework.TestTxn, client *jsonrpc.EthCli
 		assert.Equal(t, tx.Txn().From().Bytes(), bt.From().Bytes())
 		assert.Equal(t, tx.Txn().To().Bytes(), bt.To().Bytes())
 
-		if i%2 == 10 { // Intentionally disable it since dynamic fee tx not working
+		if i%2 == 0 { // Intentionally disable it since dynamic fee tx not working
 			assert.Equal(t, ethgo.TransactionDynamicFee, bt.Type())
 			assert.Equal(t, uint64(0), bt.GasPrice().Uint64())
 			assert.NotNil(t, bt.ChainID())

--- a/e2e-polybft/e2e/storage_test.go
+++ b/e2e-polybft/e2e/storage_test.go
@@ -72,7 +72,7 @@ func TestE2E_Storage(t *testing.T) {
 			txn.SetNonce(uint64(i))
 
 			tx := cluster.SendTxn(t, sender, txn)
-			require.NoError(t, err)
+			require.True(t, tx.Succeed())
 
 			txs = append(txs, tx)
 		}(i, receivers[i])

--- a/e2e-polybft/e2e/storage_test.go
+++ b/e2e-polybft/e2e/storage_test.go
@@ -130,7 +130,7 @@ func checkStorage(t *testing.T, txs []*framework.TestTxn, client *jsonrpc.EthCli
 		assert.Equal(t, tx.Txn().To().Bytes(), bt.To().Bytes())
 
 		if i%2 == 0 { // Intentionally disable it since dynamic fee tx not working
-			assert.Equal(t, ethgo.TransactionDynamicFee, bt.Type())
+			assert.Equal(t, types.DynamicFeeTxType, bt.Type())
 			assert.Equal(t, uint64(0), bt.GasPrice().Uint64())
 			assert.NotNil(t, bt.ChainID())
 		} else {

--- a/e2e-polybft/e2e/storage_test.go
+++ b/e2e-polybft/e2e/storage_test.go
@@ -72,7 +72,6 @@ func TestE2E_Storage(t *testing.T) {
 			txn.SetNonce(uint64(i))
 
 			tx := cluster.SendTxn(t, sender, txn)
-			err = tx.Wait()
 			require.NoError(t, err)
 
 			txs = append(txs, tx)

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -51,11 +51,12 @@ type TxRelayer interface {
 var _ TxRelayer = (*TxRelayerImpl)(nil)
 
 type TxRelayerImpl struct {
-	ipAddress        string
-	client           *jsonrpc.EthClient
-	receiptsPollFreq time.Duration
-	receiptsTimeout  time.Duration
-	noWaitReceipt    bool
+	ipAddress           string
+	client              *jsonrpc.EthClient
+	receiptsPollFreq    time.Duration
+	receiptsTimeout     time.Duration
+	noWaitReceipt       bool
+	estimateGasFallback bool
 
 	lock sync.Mutex
 
@@ -209,10 +210,17 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *types.Transaction, key crypto
 	if txn.Gas() == 0 {
 		gasLimit, err := t.client.EstimateGas(ConvertTxnToCallMsg(txn))
 		if err != nil {
-			return types.ZeroHash, fmt.Errorf("failed to estimate gas: %w", err)
+			if !t.estimateGasFallback {
+				return types.ZeroHash, fmt.Errorf("failed to estimate gas: %w", err)
+			}
+
+			gasLimit = DefaultGasLimit
+		} else {
+			// increase gas limit by certain percentage
+			gasLimit = gasLimit + (gasLimit * gasLimitIncreasePercentage / 100)
 		}
 
-		txn.SetGas(gasLimit + (gasLimit * gasLimitIncreasePercentage / 100))
+		txn.SetGas(gasLimit)
 	}
 
 	signer := crypto.NewLondonSigner(
@@ -281,7 +289,11 @@ func (t *TxRelayerImpl) sendTransactionLocalLocked(txn *types.Transaction) (type
 
 	gasLimit, err := t.client.EstimateGas(ConvertTxnToCallMsg(txn))
 	if err != nil {
-		return types.ZeroHash, err
+		if !t.estimateGasFallback {
+			return types.ZeroHash, err
+		}
+
+		gasLimit = DefaultGasLimit
 	}
 
 	txn.SetGas(gasLimit)
@@ -369,5 +381,11 @@ func WithNoWaiting() TxRelayerOption {
 func WithReceiptsTimeout(receiptsTimeout time.Duration) TxRelayerOption {
 	return func(t *TxRelayerImpl) {
 		t.receiptsTimeout = receiptsTimeout
+	}
+}
+
+func WithEstimateGasFallback() TxRelayerOption {
+	return func(t *TxRelayerImpl) {
+		t.estimateGasFallback = true
 	}
 }

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -217,7 +217,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *types.Transaction, key crypto
 			gasLimit = DefaultGasLimit
 		} else {
 			// increase gas limit by certain percentage
-			gasLimit = gasLimit + (gasLimit * gasLimitIncreasePercentage / 100)
+			gasLimit += (gasLimit * gasLimitIncreasePercentage / 100)
 		}
 
 		txn.SetGas(gasLimit)


### PR DESCRIPTION
# Description

This PR, changes the `TestTxn` structure in `test-cluster` to use the existing `txRelayer` to send transaction.

It also brings back couple of tests in `e2e/jsonrpc.go` that were removed by mistake in some previous merge.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually