### PR TITLE
Fix the linter configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,9 +7,6 @@ run:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
   skip-dirs-use-default: true
 
-service:
-  golangci-lint-version: 1.57.2
-
 linters:
   disable-all: true
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,8 +6,6 @@ run:
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
   skip-dirs-use-default: true
-  skip-dirs:
-    - tests
 
 service:
   golangci-lint-version: 1.49.0
@@ -58,6 +56,8 @@ linters-settings:
 
 issues:
   new-from-rev: origin/develop # report only new issues with reference to develop branch
+  exclude-dirs:
+    - tests
   exclude-rules:
     - path: _test\.go
       linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ run:
   skip-dirs-use-default: true
 
 service:
-  golangci-lint-version: 1.49.0
+  golangci-lint-version: 1.57.2
 
 linters:
   disable-all: true


### PR DESCRIPTION
# Description

The PR fixes the warning that is displayed when linting analysis is run (the `run.skip-dirs` config parameter needs to be moved to `issues.exclude-dirs`) and bumps the `golangci` version to the latest (v1.57.2).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
