### PR TITLE
Add verbose logging to the transactions execution

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -569,7 +569,6 @@ func TestBlockchainWriteBody(t *testing.T) {
 	newChain := func(
 		t *testing.T,
 		txFromByTxHash map[types.Hash]types.Address,
-		path string,
 	) *Blockchain {
 		t.Helper()
 
@@ -604,7 +603,7 @@ func TestBlockchainWriteBody(t *testing.T) {
 
 		txFromByTxHash := map[types.Hash]types.Address{}
 
-		chain := newChain(t, txFromByTxHash, "t1")
+		chain := newChain(t, txFromByTxHash)
 		defer chain.db.Close()
 		batchWriter := chain.db.NewWriter()
 
@@ -633,7 +632,7 @@ func TestBlockchainWriteBody(t *testing.T) {
 
 		txFromByTxHash := map[types.Hash]types.Address{}
 
-		chain := newChain(t, txFromByTxHash, "t2")
+		chain := newChain(t, txFromByTxHash)
 		defer chain.db.Close()
 		batchWriter := chain.db.NewWriter()
 
@@ -665,7 +664,7 @@ func TestBlockchainWriteBody(t *testing.T) {
 			tx.Hash(): addr,
 		}
 
-		chain := newChain(t, txFromByTxHash, "t3")
+		chain := newChain(t, txFromByTxHash)
 		defer chain.db.Close()
 		batchWriter := chain.db.NewWriter()
 

--- a/chain/params.go
+++ b/chain/params.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 
 	"github.com/0xPolygon/polygon-edge/forkmanager"
@@ -188,6 +189,17 @@ type ForksInTime struct {
 	EIP3855,
 	Berlin,
 	EIP3607 bool
+}
+
+func (f ForksInTime) String() string {
+	return fmt.Sprintf("EIP150: %t, EIP158: %t, EIP155: %t, "+
+		"Homestead: %t, Byzantium: %t, Constantinople: %t, "+
+		"Petersburg: %t, Istanbul: %t, Berlin: %t, London: %t"+
+		"Governance: %t, EIP3855: %t, EIP3607: %t",
+		f.EIP150, f.EIP158, f.EIP155,
+		f.Homestead, f.Byzantium, f.Constantinople, f.Petersburg,
+		f.Istanbul, f.Berlin, f.London,
+		f.Governance, f.EIP3855, f.EIP3607)
 }
 
 // AllForksEnabled should contain all supported forks by current edge version

--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -1,6 +1,7 @@
 package polybft
 
 import (
+	"bytes"
 	"fmt"
 	"time"
 
@@ -157,6 +158,8 @@ func (b *BlockBuilder) WriteTx(tx *types.Transaction) error {
 
 // Fill fills the block with transactions from the txpool
 func (b *BlockBuilder) Fill() {
+	var buf bytes.Buffer
+
 	blockTimer := time.NewTimer(b.params.BlockTime)
 
 	b.params.TxPool.Prepare()
@@ -168,6 +171,10 @@ write:
 		default:
 			tx := b.params.TxPool.Peek()
 
+			if b.params.Logger.IsDebug() && tx != nil {
+				_, _ = buf.WriteString(tx.String())
+			}
+
 			// execute transactions one by one
 			finished, err := b.writeTxPoolTransaction(tx)
 			if err != nil {
@@ -178,6 +185,10 @@ write:
 				break write
 			}
 		}
+	}
+
+	if b.params.Logger.IsDebug() {
+		b.params.Logger.Debug("[BlockBuilder.Fill]", "block number", b.header.Number, "block txs", buf.String())
 	}
 
 	//	wait for the timer to expire

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -10,7 +10,7 @@ import (
 	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/go-ibft/messages/proto"
 	"github.com/armon/go-metrics"
-	hcf "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/0xPolygon/polygon-edge/bls"
 	"github.com/0xPolygon/polygon-edge/chain"
@@ -101,7 +101,7 @@ type fsm struct {
 	proposerCommitmentToRegister *CommitmentMessageSigned
 
 	// logger instance
-	logger hcf.Logger
+	logger hclog.Logger
 
 	// target is the block being computed
 	target *types.FullBlock
@@ -192,7 +192,7 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 		EventRoot:             f.exitEventRootHash,
 	}
 
-	f.logger.Debug("[Build Proposal]", "Current validators hash", currentValidatorsHash,
+	f.logger.Trace("[FSM.BuildProposal]", "Current validators hash", currentValidatorsHash,
 		"Next validators hash", nextValidatorsHash)
 
 	stateBlock, err := f.blockBuilder.Build(func(h *types.Header) {
@@ -204,17 +204,33 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 		return nil, err
 	}
 
-	if f.logger.IsDebug() {
+	if f.logger.GetLevel() <= hclog.Debug {
 		checkpointHash, err := extra.Checkpoint.Hash(f.backend.GetChainID(), f.Height(), stateBlock.Block.Hash())
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate proposal hash: %w", err)
 		}
 
-		f.logger.Debug("[FSM Build Proposal]",
-			"block", stateBlock.Block.Number(),
+		var buf bytes.Buffer
+
+		for i, tx := range stateBlock.Block.Transactions {
+			if f.logger.IsDebug() {
+				buf.WriteString(tx.Hash().String())
+			} else if f.logger.IsTrace() {
+				buf.WriteString(tx.String())
+			}
+
+			if i != len(stateBlock.Block.Transactions) {
+				buf.WriteString("\n")
+			}
+		}
+
+		f.logger.Debug("[FSM.BuildProposal]",
+			"block num", stateBlock.Block.Number(),
 			"round", currentRound,
-			"txs", len(stateBlock.Block.Transactions),
-			"proposal hash", checkpointHash.String())
+			"state root", stateBlock.Block.Header.StateRoot,
+			"proposal hash", checkpointHash.String(),
+			"txs count", len(stateBlock.Block.Transactions),
+			"txs", buf.String())
 	}
 
 	f.target = stateBlock
@@ -380,7 +396,7 @@ func (f *fsm) Validate(proposal []byte) error {
 			return fmt.Errorf("failed to retrieve validators:%w", err)
 		}
 
-		f.logger.Trace("[FSM Validate]", "Block", block.Number(), "parent validators", validators)
+		f.logger.Trace("[FSM.Validate]", "block num", block.Number(), "parent validators", validators)
 	}
 
 	stateBlock, err := f.backend.ProcessBlock(f.parent, &block)
@@ -394,10 +410,10 @@ func (f *fsm) Validate(proposal []byte) error {
 			return fmt.Errorf("failed to calculate proposal hash: %w", err)
 		}
 
-		f.logger.Debug("[FSM Validate] Finish",
+		f.logger.Debug("[FSM.Validate]",
 			"block num", block.Number(),
+			"state root", block.Header.StateRoot,
 			"proposer", types.BytesToHash(block.Header.Miner),
-			"txs", len(block.Transactions),
 			"proposal hash", checkpointHash)
 	}
 

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -219,7 +219,7 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 				buf.WriteString(tx.String())
 			}
 
-			if i != len(stateBlock.Block.Transactions) {
+			if i != len(stateBlock.Block.Transactions)-1 {
 				buf.WriteString("\n")
 			}
 		}

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -462,6 +462,7 @@ func (p *Polybft) Initialize() error {
 
 	// set blockchain backend
 	p.blockchain = &blockchainWrapper{
+		logger:     p.logger.Named("blockchain_wrapper"),
 		blockchain: p.config.Blockchain,
 		executor:   p.config.Executor,
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -147,12 +147,21 @@ func NewServer(config *Config) (*Server, error) {
 		restoreProgression: progress.NewProgressionWrapper(progress.ChainSyncRestore),
 	}
 
-	m.logger.Info("Data dir", "path", config.DataDir)
-	m.logger.Info("Version metadata",
+	m.logger.Info("data dir", "path", config.DataDir)
+	m.logger.Info("version metadata",
 		"version", versioning.Version,
 		"commit", versioning.Commit,
 		"branch", versioning.Branch,
 		"build time", versioning.BuildTime)
+
+	if m.logger.IsDebug() {
+		chainConfigJSON, err := json.MarshalIndent(config.Chain, "", "\t")
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal chain config to JSON: %w", err)
+		}
+
+		m.logger.Debug(fmt.Sprintf("chain configuration %s", string(chainConfigJSON)))
+	}
 
 	var dirPaths = []string{
 		"blockchain",

--- a/server/server.go
+++ b/server/server.go
@@ -218,7 +218,7 @@ func NewServer(config *Config) (*Server, error) {
 	st := itrie.NewState(stateStorage)
 	m.state = st
 
-	m.executor = state.NewExecutor(config.Chain.Params, st, logger)
+	m.executor = state.NewExecutor(config.Chain.Params, st, logger.Named("executor"))
 
 	// custom write genesis hook per consensus engine
 	engineName := m.config.Chain.Params.GetEngine()

--- a/types/access_list_tx.go
+++ b/types/access_list_tx.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 
@@ -163,6 +164,23 @@ func (t *TxAccessList) unmarshalJSON(v *fastjson.Value) error {
 	}
 
 	return nil
+}
+
+func (t *TxAccessList) String() string {
+	var buf bytes.Buffer
+
+	for _, accessEntry := range *t {
+		buf.WriteString(fmt.Sprintf("address=%s", accessEntry.Address))
+		for i, storageKey := range accessEntry.StorageKeys {
+			if i == 0 {
+				buf.WriteString("\n")
+			}
+
+			buf.WriteString(fmt.Sprintf("\tkey=%s", storageKey))
+		}
+	}
+
+	return buf.String()
 }
 
 type AccessListTxn struct {

--- a/types/access_list_tx.go
+++ b/types/access_list_tx.go
@@ -171,6 +171,7 @@ func (t *TxAccessList) String() string {
 
 	for _, accessEntry := range *t {
 		buf.WriteString(fmt.Sprintf("address=%s", accessEntry.Address))
+
 		for i, storageKey := range accessEntry.StorageKeys {
 			if i == 0 {
 				buf.WriteString("\n")

--- a/types/access_list_tx.go
+++ b/types/access_list_tx.go
@@ -170,14 +170,14 @@ func (t *TxAccessList) String() string {
 	var buf bytes.Buffer
 
 	for _, accessEntry := range *t {
-		buf.WriteString(fmt.Sprintf("address=%s", accessEntry.Address))
+		_, _ = buf.WriteString(fmt.Sprintf("address=%s", accessEntry.Address))
 
 		for i, storageKey := range accessEntry.StorageKeys {
 			if i == 0 {
-				buf.WriteString("\n")
+				_, _ = buf.WriteString("\n")
 			}
 
-			buf.WriteString(fmt.Sprintf("\tkey=%s", storageKey))
+			_, _ = buf.WriteString(fmt.Sprintf("\tstorage key=%s", storageKey))
 		}
 	}
 

--- a/types/header.go
+++ b/types/header.go
@@ -51,6 +51,17 @@ func (h *Header) IsGenesis() bool {
 	return h.Hash != ZeroHash && h.Number == 0
 }
 
+func (h *Header) String() string {
+	return fmt.Sprintf("[Header#%d] ParentHash: %s, Hash: %s, BaseFee: %d, "+
+		"Miner: %s, StateRoot: %s, TxRoot: %s, ReceiptsRoot: %s, "+
+		"LogsBloom: %s, Difficulty: %d, GasLimit: %d, GasUsed: %d, "+
+		"Timestamp: %d, ExtraData: %x, MixHash: %s, Nonce: %s, Sha3Uncles: %s",
+		h.Number, h.ParentHash, h.Hash, h.BaseFee,
+		BytesToAddress(h.Miner), h.StateRoot, h.TxRoot,
+		h.ReceiptsRoot, h.LogsBloom, h.Difficulty, h.GasLimit,
+		h.GasUsed, h.Timestamp, h.ExtraData, h.MixHash, h.Nonce, h.Sha3Uncles)
+}
+
 type Nonce [8]byte
 
 func (n Nonce) String() string {

--- a/types/header.go
+++ b/types/header.go
@@ -158,29 +158,6 @@ func (b *Block) String() string {
 	return str
 }
 
-type IterationResult struct {
-	ShouldContinue bool
-	ShouldBreak    bool
-	Err            error
-}
-
-// TxnIterator represents an iterator for block transactions
-func (b *Block) TxnIterator(handler func(int, *Transaction) *IterationResult) error {
-	for i, tx := range b.Transactions {
-		result := handler(i, tx)
-
-		if result == nil || result.ShouldContinue {
-			continue
-		}
-
-		if result.ShouldBreak || result.Err != nil {
-			return result.Err
-		}
-	}
-
-	return nil
-}
-
 // WithSeal returns a new block with the data from b but the header replaced with
 // the sealed one.
 func (b *Block) WithSeal(header *Header) *Block {

--- a/types/header.go
+++ b/types/header.go
@@ -165,9 +165,9 @@ type IterationResult struct {
 }
 
 // TxnIterator represents an iterator for block transactions
-func (b *Block) TxnIterator(handler func(*Transaction) *IterationResult) error {
-	for _, tx := range b.Transactions {
-		result := handler(tx)
+func (b *Block) TxnIterator(handler func(int, *Transaction) *IterationResult) error {
+	for i, tx := range b.Transactions {
+		result := handler(i, tx)
 
 		if result == nil || result.ShouldContinue {
 			continue

--- a/types/header.go
+++ b/types/header.go
@@ -158,6 +158,29 @@ func (b *Block) String() string {
 	return str
 }
 
+type IterationResult struct {
+	ShouldContinue bool
+	ShouldBreak    bool
+	Err            error
+}
+
+// TxnIterator represents an iterator for block transactions
+func (b *Block) TxnIterator(handler func(*Transaction) *IterationResult) error {
+	for _, tx := range b.Transactions {
+		result := handler(tx)
+
+		if result == nil || result.ShouldContinue {
+			continue
+		}
+
+		if result.ShouldBreak || result.Err != nil {
+			return result.Err
+		}
+	}
+
+	return nil
+}
+
 // WithSeal returns a new block with the data from b but the header replaced with
 // the sealed one.
 func (b *Block) WithSeal(header *Header) *Block {

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -123,6 +123,21 @@ type TxData interface {
 	copy() TxData
 }
 
+func (tx *Transaction) String() string {
+	recipient := ""
+	if tx.To() != nil {
+		recipient = tx.To().String()
+	}
+
+	v, r, s := tx.RawSignatureValues()
+
+	return fmt.Sprintf("[%s] Nonce: %d, GasPrice: %d, GasTipCap: %d, GasFeeCap: %d, "+
+		"Gas: %d, To: %s, Value: %d, Input: %x, V: %d, R: %d, S: %s, Hash: %s, From: %s",
+		tx.Type(), tx.Nonce(), tx.GasPrice(), tx.GasTipCap(), tx.GasFeeCap(),
+		tx.Gas(), recipient, tx.Value(), tx.Input(),
+		v, r, s, tx.Hash(), tx.From())
+}
+
 func (t *Transaction) Type() TxType {
 	return t.Inner.transactionType()
 }

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -124,18 +124,13 @@ type TxData interface {
 }
 
 func (tx *Transaction) String() string {
-	recipient := ""
-	if tx.To() != nil {
-		recipient = tx.To().String()
-	}
-
 	v, r, s := tx.RawSignatureValues()
 
 	return fmt.Sprintf("[%s] Nonce: %d, GasPrice: %d, GasTipCap: %d, GasFeeCap: %d, "+
-		"Gas: %d, To: %s, Value: %d, Input: %x, V: %d, R: %d, S: %s, Hash: %s, From: %s",
+		"Gas: %d, To: %s, Value: %d, Input: %x, V: %d, R: %d, S: %s, Hash: %s, From: %s, AccessList: %s",
 		tx.Type(), tx.Nonce(), tx.GasPrice(), tx.GasTipCap(), tx.GasFeeCap(),
-		tx.Gas(), recipient, tx.Value(), tx.Input(),
-		v, r, s, tx.Hash(), tx.From())
+		tx.Gas(), tx.To(), tx.Value(), tx.Input(),
+		v, r, s, tx.Hash(), tx.From(), tx.AccessList())
 }
 
 func (t *Transaction) Type() TxType {


### PR DESCRIPTION
# Description

The aim of this PR is to provide more verbose logging when executing block transactions and logging chain configuration on the node startup.

TODOs:
- [x] debug log configuration on server startup https://github.com/Ethernal-Tech/blade/blob/304b7dd26417de7d2633a2f0929e18fb70a4c1c7/server/config.go#L18

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
