### PR TITLE
`ResetWithHeaders` optimization

### DIFF
--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -213,7 +213,7 @@ func (d *Dev) writeNewBlock(parent *types.Header) error {
 
 	// after the block has been written we reset the txpool so that
 	// the old transactions are removed
-	d.txpool.ResetWithHeaders(block.Header)
+	d.txpool.ResetWithBlock(block)
 
 	return nil
 }

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -47,7 +47,7 @@ type txPoolInterface interface {
 	Drop(*types.Transaction)
 	Demote(*types.Transaction)
 	SetSealing(bool)
-	ResetWithFullBlock(*types.FullBlock)
+	ResetWithBlock(*types.Block)
 }
 
 // epochMetadata is the static info for epoch currently being processed
@@ -280,7 +280,7 @@ func (c *consensusRuntime) OnBlockInserted(fullBlock *types.FullBlock) {
 	}
 
 	// after the block has been written we reset the txpool so that the old transactions are removed
-	c.config.txPool.ResetWithFullBlock(fullBlock)
+	c.config.txPool.ResetWithBlock(fullBlock.Block)
 
 	var (
 		epoch = c.epoch

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -47,7 +47,7 @@ type txPoolInterface interface {
 	Drop(*types.Transaction)
 	Demote(*types.Transaction)
 	SetSealing(bool)
-	ResetWithHeaders(...*types.Header)
+	ResetWithFullBlock(*types.FullBlock)
 }
 
 // epochMetadata is the static info for epoch currently being processed
@@ -157,9 +157,15 @@ func newConsensusRuntime(log hcf.Logger, config *runtimeConfig) (*consensusRunti
 		eventProvider:      NewEventProvider(config.blockchain),
 	}
 
-	bridgeManager, err := newBridgeManager(runtime, config, runtime.eventProvider, log)
-	if err != nil {
-		return nil, err
+	var bridgeManager BridgeManager
+
+	if runtime.IsBridgeEnabled() {
+		bridgeManager, err = newBridgeManager(runtime, config, runtime.eventProvider, log)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		bridgeManager = &dummyBridgeManager{}
 	}
 
 	runtime.bridgeManager = bridgeManager
@@ -274,7 +280,7 @@ func (c *consensusRuntime) OnBlockInserted(fullBlock *types.FullBlock) {
 	}
 
 	// after the block has been written we reset the txpool so that the old transactions are removed
-	c.config.txPool.ResetWithHeaders(fullBlock.Block.Header)
+	c.config.txPool.ResetWithFullBlock(fullBlock)
 
 	var (
 		epoch = c.epoch

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -208,7 +208,7 @@ func TestConsensusRuntime_OnBlockInserted_EndOfEpoch(t *testing.T) {
 	polybftBackendMock.On("GetValidatorsWithTx", mock.Anything, mock.Anything, mock.Anything).Return(validatorSet).Times(3)
 
 	txPool := new(txPoolMock)
-	txPool.On("ResetWithFullBlock", mock.Anything).Once()
+	txPool.On("ResetWithBlock", mock.Anything).Once()
 
 	snapshot := NewProposerSnapshot(epochSize-1, validatorSet)
 	polybftCfg := &PolyBFTConfig{EpochSize: epochSize}

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -208,7 +208,7 @@ func TestConsensusRuntime_OnBlockInserted_EndOfEpoch(t *testing.T) {
 	polybftBackendMock.On("GetValidatorsWithTx", mock.Anything, mock.Anything, mock.Anything).Return(validatorSet).Times(3)
 
 	txPool := new(txPoolMock)
-	txPool.On("ResetWithHeaders", mock.Anything).Once()
+	txPool.On("ResetWithFullBlock", mock.Anything).Once()
 
 	snapshot := NewProposerSnapshot(epochSize-1, validatorSet)
 	polybftCfg := &PolyBFTConfig{EpochSize: epochSize}

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -230,7 +230,9 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 			"state root", stateBlock.Block.Header.StateRoot,
 			"proposal hash", checkpointHash.String(),
 			"txs count", len(stateBlock.Block.Transactions),
-			"txs", buf.String())
+			"txs", buf.String(),
+			"finsihedIn", time.Since(start),
+		)
 	}
 
 	f.target = stateBlock
@@ -321,6 +323,8 @@ func (f *fsm) ValidateCommit(signerAddr []byte, seal []byte, proposalHash []byte
 
 // Validate validates a raw proposal (used if non-proposer)
 func (f *fsm) Validate(proposal []byte) error {
+	start := time.Now().UTC()
+
 	var block types.Block
 	if err := block.UnmarshalRLP(proposal); err != nil {
 		return fmt.Errorf("failed to validate, cannot decode block data. Error: %w", err)
@@ -414,7 +418,9 @@ func (f *fsm) Validate(proposal []byte) error {
 			"block num", block.Number(),
 			"state root", block.Header.StateRoot,
 			"proposer", types.BytesToHash(block.Header.Miner),
-			"proposal hash", checkpointHash)
+			"proposal hash", checkpointHash,
+			"finishedIn", time.Since(start),
+		)
 	}
 
 	f.target = stateBlock

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -356,7 +356,7 @@ func (tp *txPoolMock) SetSealing(v bool) {
 	tp.Called(v)
 }
 
-func (tp *txPoolMock) ResetWithFullBlock(fullBlock *types.FullBlock) {
+func (tp *txPoolMock) ResetWithBlock(fullBlock *types.Block) {
 	tp.Called(fullBlock)
 }
 

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -356,8 +356,8 @@ func (tp *txPoolMock) SetSealing(v bool) {
 	tp.Called(v)
 }
 
-func (tp *txPoolMock) ResetWithHeaders(values ...*types.Header) {
-	tp.Called(values)
+func (tp *txPoolMock) ResetWithFullBlock(fullBlock *types.FullBlock) {
+	tp.Called(fullBlock)
 }
 
 var _ syncer.Syncer = (*syncerMock)(nil)

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -472,8 +472,8 @@ func (p *TxPool) Demote(tx *types.Transaction) {
 	p.eventManager.signalEvent(proto.EventType_DEMOTED, tx.Hash())
 }
 
-// ResetWithBlock processes the transactions from the new
-// full blocks to sync the pool with the new state.
+// ResetWithBlock processes the transactions from the newly
+// finalized block to sync the pool with the new state
 func (p *TxPool) ResetWithBlock(block *types.Block) {
 	// process the txs in the event
 	// to make sure the pool is up-to-date

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -519,7 +519,7 @@ func (p *TxPool) ResetWithBlock(block *types.Block) {
 
 	if !p.sealing.Load() {
 		// only non-validator cleanup inactive accounts
-		p.updateAccountSkipsCounts(stateNonces)
+		p.updateAccountSkipsCounts(stateNonces, stateRoot)
 	}
 }
 
@@ -1027,8 +1027,7 @@ func (p *TxPool) resetAccounts(stateNonces map[types.Address]uint64) {
 
 // updateAccountSkipsCounts update the accounts' skips,
 // the number of the consecutive blocks that doesn't have the account's transactions
-func (p *TxPool) updateAccountSkipsCounts(latestActiveAccounts map[types.Address]uint64) {
-	stateRoot := p.store.Header().StateRoot
+func (p *TxPool) updateAccountSkipsCounts(latestActiveAccounts map[types.Address]uint64, stateRoot types.Hash) {
 	p.accounts.Range(
 		func(key, value interface{}) bool {
 			address, _ := key.(types.Address)

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -2035,7 +2035,7 @@ func Test_updateAccountSkipsCounts(t *testing.T) {
 
 		pool.updateAccountSkipsCounts(map[types.Address]uint64{
 			// empty
-		})
+		}, types.Hash{1})
 
 		// make sure the account queue is empty and skips is reset
 		assert.Zero(t, accountMap.enqueued.length())
@@ -2070,7 +2070,7 @@ func Test_updateAccountSkipsCounts(t *testing.T) {
 
 		pool.updateAccountSkipsCounts(map[types.Address]uint64{
 			// empty
-		})
+		}, types.Hash{1})
 
 		// make sure the account queue is empty and skips is reset
 		assert.Zero(t, accountMap.enqueued.length())
@@ -2105,7 +2105,7 @@ func Test_updateAccountSkipsCounts(t *testing.T) {
 
 		pool.updateAccountSkipsCounts(map[types.Address]uint64{
 			addr1: 1,
-		})
+		}, types.Hash{1})
 
 		// make sure the account queue is empty and skips is reset
 		assert.Zero(t, accountMap.enqueued.length())
@@ -2167,7 +2167,7 @@ func Test_updateAccountSkipsCounts(t *testing.T) {
 		accountMap.setNonce(storeNonce + 3)
 		accountMap.skips = maxAccountSkips - 1
 
-		pool.updateAccountSkipsCounts(map[types.Address]uint64{})
+		pool.updateAccountSkipsCounts(map[types.Address]uint64{}, types.Hash{1})
 
 		// make sure the account queue is empty and skips is reset
 		assert.Zero(t, accountMap.enqueued.length())

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -3693,6 +3693,60 @@ func TestResetWithHeadersSetsBaseFee(t *testing.T) {
 	assert.Equal(t, blocks[len(blocks)-1].Header.BaseFee, pool.GetBaseFee())
 }
 
+func TestResetWithFullBlockSetsBaseFee(t *testing.T) {
+	t.Parallel()
+
+	blocks := []*types.FullBlock{
+		{
+			Block: &types.Block{
+				Header: &types.Header{
+					BaseFee: 100,
+					Hash:    types.Hash{1},
+				},
+			},
+		},
+		{
+			Block: &types.Block{
+				Header: &types.Header{
+					BaseFee: 1000,
+					Hash:    types.Hash{1},
+				},
+			},
+		},
+		{
+			Block: &types.Block{
+				Header: &types.Header{
+					BaseFee: 2000,
+					Hash:    types.Hash{1},
+				},
+			},
+		},
+	}
+
+	store := NewDefaultMockStore(blocks[0].Block.Header)
+	store.getBlockByHashFn = func(h types.Hash, b bool) (*types.Block, bool) {
+		for _, b := range blocks {
+			if b.Block.Header.Hash == h {
+				return b.Block, true
+			}
+		}
+
+		return nil, false
+	}
+
+	pool, err := newTestPool(store)
+	require.NoError(t, err)
+
+	pool.SetBaseFee(blocks[0].Block.Header)
+	require.Equal(t, blocks[0].Block.Header.BaseFee, pool.GetBaseFee())
+
+	pool.ResetWithFullBlock(blocks[len(blocks)-1])
+	require.Equal(t, blocks[len(blocks)-1].Block.Header.BaseFee, pool.GetBaseFee())
+
+	pool.ResetWithFullBlock(blocks[len(blocks)-2])
+	require.Equal(t, blocks[len(blocks)-2].Block.Header.BaseFee, pool.GetBaseFee())
+}
+
 func TestAddTx_TxReplacement(t *testing.T) {
 	t.Parallel()
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -3646,7 +3646,7 @@ func TestAddTxsInOrder(t *testing.T) {
 	}
 }
 
-func TestResetWithHeadersSetsBaseFee(t *testing.T) {
+func TestResetWithBlockSetsBaseFee(t *testing.T) {
 	t.Parallel()
 
 	blocks := []*types.Block{
@@ -3665,7 +3665,7 @@ func TestResetWithHeadersSetsBaseFee(t *testing.T) {
 		{
 			Header: &types.Header{
 				BaseFee: 2000,
-				Hash:    types.Hash{2},
+				Hash:    types.Hash{1},
 			},
 		},
 	}
@@ -3685,66 +3685,13 @@ func TestResetWithHeadersSetsBaseFee(t *testing.T) {
 	require.NoError(t, err)
 
 	pool.SetBaseFee(blocks[0].Header)
+	require.Equal(t, blocks[0].Header.BaseFee, pool.GetBaseFee())
 
-	pool.ResetWithHeaders()
-	assert.Equal(t, blocks[0].Header.BaseFee, pool.GetBaseFee())
+	pool.ResetWithBlock(blocks[len(blocks)-1])
+	require.Equal(t, blocks[len(blocks)-1].Header.BaseFee, pool.GetBaseFee())
 
-	pool.ResetWithHeaders(blocks[len(blocks)-2].Header, blocks[len(blocks)-1].Header)
-	assert.Equal(t, blocks[len(blocks)-1].Header.BaseFee, pool.GetBaseFee())
-}
-
-func TestResetWithFullBlockSetsBaseFee(t *testing.T) {
-	t.Parallel()
-
-	blocks := []*types.FullBlock{
-		{
-			Block: &types.Block{
-				Header: &types.Header{
-					BaseFee: 100,
-					Hash:    types.Hash{1},
-				},
-			},
-		},
-		{
-			Block: &types.Block{
-				Header: &types.Header{
-					BaseFee: 1000,
-					Hash:    types.Hash{1},
-				},
-			},
-		},
-		{
-			Block: &types.Block{
-				Header: &types.Header{
-					BaseFee: 2000,
-					Hash:    types.Hash{1},
-				},
-			},
-		},
-	}
-
-	store := NewDefaultMockStore(blocks[0].Block.Header)
-	store.getBlockByHashFn = func(h types.Hash, b bool) (*types.Block, bool) {
-		for _, b := range blocks {
-			if b.Block.Header.Hash == h {
-				return b.Block, true
-			}
-		}
-
-		return nil, false
-	}
-
-	pool, err := newTestPool(store)
-	require.NoError(t, err)
-
-	pool.SetBaseFee(blocks[0].Block.Header)
-	require.Equal(t, blocks[0].Block.Header.BaseFee, pool.GetBaseFee())
-
-	pool.ResetWithFullBlock(blocks[len(blocks)-1])
-	require.Equal(t, blocks[len(blocks)-1].Block.Header.BaseFee, pool.GetBaseFee())
-
-	pool.ResetWithFullBlock(blocks[len(blocks)-2])
-	require.Equal(t, blocks[len(blocks)-2].Block.Header.BaseFee, pool.GetBaseFee())
+	pool.ResetWithBlock(blocks[len(blocks)-2])
+	require.Equal(t, blocks[len(blocks)-2].Header.BaseFee, pool.GetBaseFee())
 }
 
 func TestAddTx_TxReplacement(t *testing.T) {


### PR DESCRIPTION
# Description

During load testing, we could see blocks where block time would drop when node is under heavy load. One of the things that took the most amount of time was `txpool.ResetWithHeaders` function which was called in `OnBlockInserted` function whenever a finalized block arrives from `syncer` or `consensus`.

In the given `ResetWithHeaders` function, there was an unnecessary call to get the new block from blockchain, since its transactions are needed to process the nonces and new state in `txpool`. Getting the block from state took a lot of time in many occasions during testing where sometimes it could take up to 3s when node is under load.

Since `OnBlockInserted` already receives a full block that was inserted (block + transactions + receipts), a new function was added to `txpool`, called `ResetWithBlock`. It basically does the same as `ResetWithHeaders`, but it doesn't ping the store to get the block and its transactions since they are already in the full block.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually