### PR TITLE
Lower logging on dispatcher, jsonrpc and txpool

### DIFF
--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -171,7 +171,7 @@ write:
 		default:
 			tx := b.params.TxPool.Peek()
 
-			if b.params.Logger.IsDebug() && tx != nil {
+			if b.params.Logger.IsTrace() && tx != nil {
 				_, _ = buf.WriteString(tx.String())
 			}
 

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -398,7 +398,7 @@ func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
 }
 
 func (d *Dispatcher) handleReq(req Request) ([]byte, Error) {
-	d.logger.Debug("request", "method", req.Method, "id", req.ID)
+	d.logger.Trace("request", "method", req.Method, "id", req.ID)
 
 	service, fd, ferr := d.getFnHandler(req)
 	if ferr != nil {

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -356,7 +356,7 @@ func (j *JSONRPC) handleJSONRPCRequest(w http.ResponseWriter, req *http.Request)
 	}
 
 	// log request
-	j.logger.Debug("handle", "request", string(data))
+	j.logger.Trace("handle", "request", string(data))
 
 	resp, err := j.dispatcher.Handle(data)
 	if err != nil {
@@ -365,7 +365,7 @@ func (j *JSONRPC) handleJSONRPCRequest(w http.ResponseWriter, req *http.Request)
 		_, _ = w.Write(resp)
 	}
 
-	j.logger.Debug("handle", "response", string(resp))
+	j.logger.Trace("handle", "response", string(resp))
 }
 
 type GetResponse struct {

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -771,9 +771,7 @@ func (p *TxPool) pruneAccountsWithNonceHoles() {
 // successful, an account is created for this address
 // (only once) and an enqueueRequest is signaled.
 func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
-	if p.logger.IsDebug() {
-		p.logger.Debug("add tx", "origin", origin.String(), "hash", tx.Hash().String(), "type", tx.Type())
-	}
+	p.logger.Trace("add tx", "origin", origin.String(), "hash", tx.Hash().String(), "type", tx.Type())
 
 	// validate incoming tx
 	if err := p.validateTx(tx); err != nil {
@@ -887,9 +885,7 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 func (p *TxPool) invokePromotion(tx *types.Transaction, callPromote bool) {
 	p.eventManager.signalEvent(proto.EventType_ADDED, tx.Hash())
 
-	if p.logger.IsDebug() {
-		p.logger.Debug("enqueue request", "hash", tx.Hash().String())
-	}
+	p.logger.Trace("enqueue request", "hash", tx.Hash().String())
 
 	p.eventManager.signalEvent(proto.EventType_ENQUEUED, tx.Hash())
 
@@ -910,9 +906,7 @@ func (p *TxPool) handlePromoteRequest(req promoteRequest) {
 
 	// promote enqueued txs
 	promoted, pruned := account.promote()
-	if p.logger.IsDebug() {
-		p.logger.Debug("promote request", "promoted", promoted, "addr", addr.String())
-	}
+	p.logger.Trace("promote request", "promoted", promoted, "addr", addr.String())
 
 	p.index.remove(pruned...)
 	p.gauge.decrease(slotsRequired(pruned...))


### PR DESCRIPTION
# Description

Some logs on `dispatcher`, `jsonrpc` and `txpool` was wrongly left on `debug`, when they should be on `trace`.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually