### PR TITLE
Load test with mixed transactions

### DIFF
--- a/loadtest/runner/base_load_test_runner.go
+++ b/loadtest/runner/base_load_test_runner.go
@@ -828,7 +828,9 @@ func (r *BaseLoadTestRunner) sendTransactionsForUserInBatches(account *account, 
 			}
 
 			txn := createTxnFn(account, feeData, chainID)
-			txn.SetGas(gas)
+			if txn.Gas() == 0 {
+				txn.SetGas(gas)
+			}
 
 			signedTxn, err := signer.SignTxWithCallback(txn,
 				func(hash types.Hash) (sig []byte, err error) {

--- a/loadtest/runner/load_test_runner.go
+++ b/loadtest/runner/load_test_runner.go
@@ -14,6 +14,7 @@ const (
 	EOATestType    = "eoa"
 	ERC20TestType  = "erc20"
 	ERC721TestType = "erc721"
+	MixedTestType  = "mixed"
 )
 
 var receiverAddr = types.StringToAddress("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
@@ -21,7 +22,7 @@ var receiverAddr = types.StringToAddress("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaD
 func IsLoadTestSupported(loadTestType string) bool {
 	ltp := strings.ToLower(loadTestType)
 
-	return ltp == EOATestType || ltp == ERC20TestType || ltp == ERC721TestType
+	return ltp == EOATestType || ltp == ERC20TestType || ltp == ERC721TestType || ltp == MixedTestType
 }
 
 type account struct {
@@ -93,6 +94,13 @@ func (r *LoadTestRunner) Run(cfg LoadTestConfig) error {
 		}
 
 		return erc721Runner.Run()
+	case MixedTestType:
+		mixedTxRunner, err := NewMixedTxRunner(cfg)
+		if err != nil {
+			return err
+		}
+
+		return mixedTxRunner.Run()
 	default:
 		return fmt.Errorf("unknown load test type %s", cfg.LoadTestType)
 	}

--- a/loadtest/runner/mixed_tx_runner.go
+++ b/loadtest/runner/mixed_tx_runner.go
@@ -1,0 +1,181 @@
+package runner
+
+import (
+	"fmt"
+	"math/big"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/0xPolygon/polygon-edge/txrelayer"
+	"github.com/0xPolygon/polygon-edge/types"
+)
+
+// MixedTxRunner represents a load test runner for sending every type of transaction
+// in a single load test
+type MixedTxRunner struct {
+	*BaseLoadTestRunner
+	*ERC20Runner
+	*ERC721Runner
+	*EOARunner
+
+	rand *rand.Rand
+	lock sync.Mutex
+
+	numOfEOATxs    int
+	numOfERC20Txs  int
+	numOfERC721Txs int
+
+	erc20Gas  uint64
+	erc721Gas uint64
+}
+
+// NewMixedTxRunner creates a new MixedTxRunner
+func NewMixedTxRunner(cfg LoadTestConfig) (*MixedTxRunner, error) {
+	runner, err := NewBaseLoadTestRunner(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MixedTxRunner{
+		BaseLoadTestRunner: runner,
+		ERC20Runner:        &ERC20Runner{BaseLoadTestRunner: runner},
+		ERC721Runner:       &ERC721Runner{BaseLoadTestRunner: runner},
+		EOARunner:          &EOARunner{BaseLoadTestRunner: runner},
+		rand:               rand.New(rand.NewSource(time.Now().UnixNano())),
+	}, nil
+}
+
+// Run executes the Mixed load test.
+// It performs the following steps:
+// 1. Creates virtual users (VUs).
+// 2. Funds the VUs with native tokens.
+// 3. Deploys the ERC20 token contract.
+// 4. Mints ERC20 tokens to the VUs.
+// 5. Deploys the ERC721 token contract.
+// 6. Sends transactions using the VUs (by creating a transaction of a random type).
+// 7. Waits for the transaction pool to empty.
+// 8. Waits for transaction receipts.
+// 9. Calculates the transactions per second (TPS) based on block information and transaction statistics.
+// Returns an error if any of the steps fail.
+func (m *MixedTxRunner) Run() error {
+	fmt.Println("Running mixed load test", m.cfg.LoadTestName)
+
+	if err := m.createVUs(); err != nil {
+		return err
+	}
+
+	if err := m.fundVUs(); err != nil {
+		return err
+	}
+
+	if err := m.deployERC20Token(); err != nil {
+		return err
+	}
+
+	if err := m.mintERC20TokenToVUs(); err != nil {
+		return err
+	}
+
+	if err := m.deployERC21Token(); err != nil {
+		return err
+	}
+
+	if err := m.estimateGas(); err != nil {
+		return err
+	}
+
+	if !m.cfg.WaitForTxPoolToEmpty {
+		go m.waitForReceiptsParallel()
+		go m.calculateResultsParallel()
+
+		_, err := m.sendTransactions(m.createTransaction)
+		if err != nil {
+			return err
+		}
+
+		m.printHowManySent()
+
+		return <-m.done
+	}
+
+	txHashes, err := m.sendTransactions(m.createTransaction)
+	if err != nil {
+		return err
+	}
+
+	m.printHowManySent()
+
+	if err := m.waitForTxPoolToEmpty(); err != nil {
+		return err
+	}
+
+	return m.calculateResults(m.waitForReceipts(txHashes))
+}
+
+// createTransaction creates a transaction for the mixed load test
+func (m *MixedTxRunner) createTransaction(account *account, feeData *feeData, chainID *big.Int) *types.Transaction {
+	// Randomly choose a transaction type
+	switch m.rand.Intn(3) {
+	case 0:
+		m.lock.Lock()
+		m.numOfERC20Txs++
+		m.lock.Unlock()
+
+		tx := m.createERC20Transaction(account, feeData, chainID)
+		tx.SetGas(m.erc20Gas)
+
+		return tx
+	case 1:
+		m.lock.Lock()
+		m.numOfERC721Txs++
+		m.lock.Unlock()
+
+		tx := m.createERC721Transaction(account, feeData, chainID)
+		tx.SetGas(m.erc721Gas)
+
+		return tx
+	default:
+		m.lock.Lock()
+		m.numOfEOATxs++
+		m.lock.Unlock()
+
+		return m.createEOATransaction(account, feeData, chainID)
+	}
+}
+
+// estimateGas estimates the gas for ERC transaction types
+func (m *MixedTxRunner) estimateGas() error {
+	estimateGasFn := func(tx *types.Transaction) uint64 {
+		gasLimit, err := m.client.EstimateGas(txrelayer.ConvertTxnToCallMsg(tx))
+		if err != nil {
+			gasLimit = txrelayer.DefaultGasLimit
+		}
+
+		return gasLimit * 2 // double it just in case
+	}
+
+	chainID, err := m.client.ChainID()
+	if err != nil {
+		return err
+	}
+
+	feeData, err := getFeeData(m.client, m.cfg.DynamicTxs)
+	if err != nil {
+		return err
+	}
+
+	m.erc20Gas = estimateGasFn(m.createERC20Transaction(m.loadTestAccount, feeData, chainID))
+	m.erc721Gas = estimateGasFn(m.createERC721Transaction(m.loadTestAccount, feeData, chainID))
+
+	return nil
+}
+
+// printHowManySent prints how many transactions of each type were sent
+func (m *MixedTxRunner) printHowManySent() {
+	fmt.Println("=============================================================")
+
+	fmt.Println("EOA created", m.numOfEOATxs)
+	fmt.Println("ERC20 created", m.numOfERC20Txs)
+	fmt.Println("ERC721 created", m.numOfERC721Txs)
+}

--- a/loadtest/runner/mixed_tx_runner.go
+++ b/loadtest/runner/mixed_tx_runner.go
@@ -42,7 +42,7 @@ func NewMixedTxRunner(cfg LoadTestConfig) (*MixedTxRunner, error) {
 		ERC20Runner:        &ERC20Runner{BaseLoadTestRunner: runner},
 		ERC721Runner:       &ERC721Runner{BaseLoadTestRunner: runner},
 		EOARunner:          &EOARunner{BaseLoadTestRunner: runner},
-		rand:               rand.New(rand.NewSource(time.Now().UnixNano())),
+		rand:               rand.New(rand.NewSource(time.Now().UTC().UnixNano())),
 	}, nil
 }
 

--- a/loadtest/runner/mixed_tx_runner.go
+++ b/loadtest/runner/mixed_tx_runner.go
@@ -1,15 +1,16 @@
 package runner
 
 import (
+	"crypto/rand"
 	"fmt"
 	"math/big"
-	"math/rand"
 	"sync"
-	"time"
 
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 )
+
+var three = big.NewInt(3)
 
 // MixedTxRunner represents a load test runner for sending every type of transaction
 // in a single load test
@@ -19,7 +20,6 @@ type MixedTxRunner struct {
 	*ERC721Runner
 	*EOARunner
 
-	rand *rand.Rand
 	lock sync.Mutex
 
 	numOfEOATxs    int
@@ -42,7 +42,6 @@ func NewMixedTxRunner(cfg LoadTestConfig) (*MixedTxRunner, error) {
 		ERC20Runner:        &ERC20Runner{BaseLoadTestRunner: runner},
 		ERC721Runner:       &ERC721Runner{BaseLoadTestRunner: runner},
 		EOARunner:          &EOARunner{BaseLoadTestRunner: runner},
-		rand:               rand.New(rand.NewSource(time.Now().UTC().UnixNano())),
 	}, nil
 }
 
@@ -116,7 +115,9 @@ func (m *MixedTxRunner) Run() error {
 // createTransaction creates a transaction for the mixed load test
 func (m *MixedTxRunner) createTransaction(account *account, feeData *feeData, chainID *big.Int) *types.Transaction {
 	// Randomly choose a transaction type
-	switch m.rand.Intn(3) {
+	r, _ := rand.Int(rand.Reader, three)
+
+	switch r.Uint64() {
 	case 0:
 		m.lock.Lock()
 		m.numOfERC20Txs++

--- a/state/executor.go
+++ b/state/executor.go
@@ -375,7 +375,7 @@ func (t *Transition) Write(txn *types.Transaction) error {
 		}
 
 		txn.SetFrom(from)
-		t.logger.Debug("[Transition.Write]", "recovered sender", from)
+		t.logger.Trace("[Transition.Write]", "recovered sender", from)
 	}
 
 	// Make a local copy and apply the transaction


### PR DESCRIPTION
# Description

This PR adds a new load test type: `mixed`, which will send each type of transaction (`EOA`, `ERC20`, `EC721`) in the single load test.

The load test behaves like any other. User defines `vus` and `txs-per-user` and the tool will send a random transaction.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually