### PR TITLE
Adjust round 0 timeout for go-ibft

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/0xPolygon/go-ibft/core"
 	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/go-ibft/messages/proto"
 	hcf "github.com/hashicorp/go-hclog"
@@ -558,12 +557,7 @@ func (c *consensusRuntime) restartEpoch(header *types.Header, dbTx *bolt.Tx) (*e
 		return nil, err
 	}
 
-	// if block time is greater than default base round timeout,
-	// set base round timeout as twice the block time
-	blockTime := currentPolyConfig.BlockTime.Duration
-	if blockTime >= core.DefaultBaseRoundTimeout {
-		c.config.polybftBackend.SetBlockTime(blockTime)
-	}
+	c.config.polybftBackend.SetBlockTime(currentPolyConfig.BlockTime.Duration)
 
 	return &epochMetadata{
 		Number:              epochNumber,

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -206,6 +206,7 @@ func TestConsensusRuntime_OnBlockInserted_EndOfEpoch(t *testing.T) {
 
 	polybftBackendMock := new(polybftBackendMock)
 	polybftBackendMock.On("GetValidatorsWithTx", mock.Anything, mock.Anything, mock.Anything).Return(validatorSet).Times(3)
+	polybftBackendMock.On("SetBlockTime", mock.Anything).Once()
 
 	txPool := new(txPoolMock)
 	txPool.On("ResetWithBlock", mock.Anything).Once()
@@ -480,6 +481,7 @@ func Test_NewConsensusRuntime(t *testing.T) {
 
 	polybftBackendMock := new(polybftBackendMock)
 	polybftBackendMock.On("GetValidatorsWithTx", mock.Anything, mock.Anything, mock.Anything).Return(validators).Times(3)
+	polybftBackendMock.On("SetBlockTime", mock.Anything).Once()
 
 	tmpDir := t.TempDir()
 	config := &runtimeConfig{

--- a/consensus/polybft/ibft_consensus.go
+++ b/consensus/polybft/ibft_consensus.go
@@ -38,6 +38,6 @@ func (c *IBFTConsensusWrapper) runSequence(height uint64) (<-chan struct{}, func
 	return sequenceDone, func() {
 		// stopSequence terminates the running IBFT sequence gracefully and waits for it to return
 		cancelSequence()
-		<-sequenceDone // waits until c.IBFT.RunSequenc routine finishes
+		<-sequenceDone // waits until c.IBFT.RunSequence routine finishes
 	}
 }

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -167,6 +167,10 @@ func (p *polybftBackendMock) GetValidatorsWithTx(blockNumber uint64, parents []*
 	panic("polybftBackendMock.GetValidatorsWithTx doesn't support such combination of arguments") //nolint:gocritic
 }
 
+func (p *polybftBackendMock) SetBlockTime(blockTime time.Duration) {
+	p.Called(blockTime)
+}
+
 var _ blockBuilder = (*blockBuilderMock)(nil)
 
 type blockBuilderMock struct {

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	bolt "go.etcd.io/bbolt"
 
+	"github.com/0xPolygon/go-ibft/core"
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/consensus"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
@@ -773,8 +774,11 @@ func (p *Polybft) GetValidatorsWithTx(blockNumber uint64, parents []*types.Heade
 }
 
 func (p *Polybft) SetBlockTime(blockTime time.Duration) {
-	baseRoundTimeout := int64(blockTime.Seconds() * baseRoundTimeoutScaleFactor)
-	p.ibft.SetBaseRoundTimeout(time.Duration(baseRoundTimeout) * time.Second)
+	// if block time is greater than default base round timeout,
+	// set base round timeout as twice the block time
+	if blockTime >= core.DefaultBaseRoundTimeout {
+		p.ibft.SetBaseRoundTimeout(blockTime * baseRoundTimeoutScaleFactor)
+	}
 }
 
 // ProcessHeaders updates the snapshot based on the verified headers

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -508,13 +508,6 @@ func (p *Polybft) Initialize() error {
 	}
 
 	p.ibft = newIBFTConsensusWrapper(p.logger, p.runtime, p)
-	// if block time is greater than default base round timeout,
-	// set base round timeout as twice the block time
-	blockTime := time.Duration(int64(p.config.BlockTime)) * time.Second
-	if blockTime >= core.DefaultBaseRoundTimeout {
-		baseRoundTimeout := int64(blockTime.Seconds() * baseRoundTimeoutScaleFactor)
-		p.ibft.SetBaseRoundTimeout(time.Duration(baseRoundTimeout) * time.Second)
-	}
 
 	if err = p.subscribeToIbftTopic(); err != nil {
 		return fmt.Errorf("IBFT topic subscription failed: %w", err)
@@ -669,6 +662,14 @@ func (p *Polybft) startConsensusProtocol() {
 				p.logger.Error("failed to create fsm", "block number", latestHeader.Number, "error", err)
 
 				continue
+			}
+
+			// if block time is greater than default base round timeout,
+			// set base round timeout as twice the block time
+			blockTime := time.Duration(int64(p.config.BlockTime)) * time.Second
+			if blockTime >= core.DefaultBaseRoundTimeout {
+				baseRoundTimeout := int64(blockTime.Seconds() * baseRoundTimeoutScaleFactor)
+				p.ibft.SetBaseRoundTimeout(time.Duration(baseRoundTimeout) * time.Second)
 			}
 
 			sequenceCh, stopSequence = p.ibft.runSequence(latestHeader.Number + 1)

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,6 @@ dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBr
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-github.com/0xPolygon/go-ibft v0.4.1-0.20230717081138-628065cf23b6 h1:EL/37sEjeLmQ2RTd9xMLLOuMXY6fMV/zB8a5X0BJUMM=
-github.com/0xPolygon/go-ibft v0.4.1-0.20230717081138-628065cf23b6/go.mod h1:0W1BnkhtXa2K59PzTPoQvbKOnI+G6QliXIHpQWNeiAM=
 github.com/0xPolygon/go-ibft v0.4.1-0.20240424093031-00f7637226a6 h1:s8YmD/yvpC2Lu3vSrb0laBThj/YCnQ1dpnVZqf4CfHo=
 github.com/0xPolygon/go-ibft v0.4.1-0.20240424093031-00f7637226a6/go.mod h1:FPdz+s0jyQzW4pZK+HMnhz2b8ebsg5FaSVFTjvQi8ls=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -475,7 +475,7 @@ func (p *TxPool) Demote(tx *types.Transaction) {
 // ResetWithBlock processes the transactions from the newly
 // finalized block to sync the pool with the new state
 func (p *TxPool) ResetWithBlock(block *types.Block) {
-	// process the txs in the event
+	// process the txs in the block
 	// to make sure the pool is up-to-date
 	// Grab the latest state root now that the block has been inserted
 	stateRoot := p.store.Header().StateRoot


### PR DESCRIPTION
# Description

In case block time is greater than or equal to default base round timeout, that is 10s, base round timeout is determined as twice the block time.

- [x] adjust round 0 timeout if block time is changed through governance.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
