### PR TITLE
Keep proposed txs until proposal is committed/failed

### DIFF
--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -102,7 +102,10 @@ func (d *Dev) run() {
 		header := d.blockchain.Header()
 		if err := d.writeNewBlock(header); err != nil {
 			d.logger.Error("failed to mine block", "err", err)
+			d.txpool.ReinjectProposed(true)
 		}
+
+		d.txpool.ReinjectProposed(false)
 	}
 }
 

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -102,10 +102,10 @@ func (d *Dev) run() {
 		header := d.blockchain.Header()
 		if err := d.writeNewBlock(header); err != nil {
 			d.logger.Error("failed to mine block", "err", err)
-			d.txpool.ReinjectProposed(true)
+			d.txpool.ReinsertProposed(true)
 		}
 
-		d.txpool.ReinjectProposed(false)
+		d.txpool.ReinsertProposed(false)
 	}
 }
 

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -1033,6 +1033,16 @@ func (c *consensusRuntime) BuildRoundChangeMessage(
 	return signedMsg
 }
 
+// StartRound notifies about new round start
+func (c *consensusRuntime) StartRound(view *proto.View) {
+	var reinsert bool
+	if view.Round > 0 {
+		reinsert = true
+	}
+
+	c.config.txPool.ReinsertProposed(reinsert)
+}
+
 // getFirstBlockOfEpoch returns the first block of epoch in which provided header resides
 func (c *consensusRuntime) getFirstBlockOfEpoch(epochNumber uint64, latestHeader *types.Header) (uint64, error) {
 	if latestHeader.Number == 0 {

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -48,6 +48,7 @@ type txPoolInterface interface {
 	Demote(*types.Transaction)
 	SetSealing(bool)
 	ResetWithBlock(*types.Block)
+	ReinjectProposed(bool)
 }
 
 // epochMetadata is the static info for epoch currently being processed

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -1034,13 +1034,15 @@ func (c *consensusRuntime) BuildRoundChangeMessage(
 }
 
 // StartRound notifies about new round start
-func (c *consensusRuntime) StartRound(view *proto.View) {
+func (c *consensusRuntime) StartRound(view *proto.View) error {
 	var reinsert bool
 	if view.Round > 0 {
 		reinsert = true
 	}
 
 	c.config.txPool.ReinsertProposed(reinsert)
+
+	return nil
 }
 
 // getFirstBlockOfEpoch returns the first block of epoch in which provided header resides

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -48,7 +48,7 @@ type txPoolInterface interface {
 	Demote(*types.Transaction)
 	SetSealing(bool)
 	ResetWithBlock(*types.Block)
-	ReinjectProposed(bool)
+	ReinsertProposed(bool)
 }
 
 // epochMetadata is the static info for epoch currently being processed

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1000,6 +1000,36 @@ func TestConsensusRuntime_BuildPrepareMessage(t *testing.T) {
 	assert.Equal(t, signedMsg, runtime.BuildPrepareMessage(proposalHash, view))
 }
 
+func TestConsensusRuntime_StartRound_RoundZero(t *testing.T) {
+	txPool := new(txPoolMock)
+	txPool.On("ReinsertProposed", false).Once()
+
+	runtime := &consensusRuntime{
+		config: &runtimeConfig{
+			txPool: txPool,
+		},
+		logger: hclog.NewNullLogger(),
+	}
+
+	view := &proto.View{}
+	runtime.StartRound(view)
+}
+
+func TestConsensusRuntime_StartRound_RoundNotZero(t *testing.T) {
+	txPool := new(txPoolMock)
+	txPool.On("ReinsertProposed", true).Once()
+
+	runtime := &consensusRuntime{
+		config: &runtimeConfig{
+			txPool: txPool,
+		},
+		logger: hclog.NewNullLogger(),
+	}
+
+	view := &proto.View{Round: 1}
+	runtime.StartRound(view)
+}
+
 func createTestBlocks(t *testing.T, numberOfBlocks, defaultEpochSize uint64,
 	validatorSet validator.AccountSet) (*types.Header, *testHeadersMap) {
 	t.Helper()

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1012,7 +1012,7 @@ func TestConsensusRuntime_StartRound_RoundZero(t *testing.T) {
 	}
 
 	view := &proto.View{}
-	runtime.StartRound(view)
+	require.NoError(t, runtime.StartRound(view))
 }
 
 func TestConsensusRuntime_StartRound_RoundNotZero(t *testing.T) {
@@ -1027,7 +1027,7 @@ func TestConsensusRuntime_StartRound_RoundNotZero(t *testing.T) {
 	}
 
 	view := &proto.View{Round: 1}
-	runtime.StartRound(view)
+	require.NoError(t, runtime.StartRound(view))
 }
 
 func createTestBlocks(t *testing.T, numberOfBlocks, defaultEpochSize uint64,

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -360,8 +360,8 @@ func (tp *txPoolMock) ResetWithBlock(fullBlock *types.Block) {
 	tp.Called(fullBlock)
 }
 
-func (tp *txPoolMock) ReinjectProposed(reinject bool) {
-	tp.Called(reinject)
+func (tp *txPoolMock) ReinsertProposed(reinsert bool) {
+	tp.Called(reinsert)
 }
 
 var _ syncer.Syncer = (*syncerMock)(nil)

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -360,6 +360,10 @@ func (tp *txPoolMock) ResetWithBlock(fullBlock *types.Block) {
 	tp.Called(fullBlock)
 }
 
+func (tp *txPoolMock) ReinjectProposed(reinject bool) {
+	tp.Called(reinject)
+}
+
 var _ syncer.Syncer = (*syncerMock)(nil)
 
 type syncerMock struct {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	cloud.google.com/go/secretmanager v1.12.0
-	github.com/0xPolygon/go-ibft v0.4.1-0.20230717081138-628065cf23b6
+	github.com/0xPolygon/go-ibft v0.4.1-0.20240424084119-1e0f56f229a2
 	github.com/Ethernal-Tech/blockchain-event-tracker v0.0.0-20231202204931-b886edca635a
 	github.com/Ethernal-Tech/merkle-tree v0.0.0-20231213143318-4db9da419e04
 	github.com/armon/go-metrics v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBr
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-github.com/0xPolygon/go-ibft v0.4.1-0.20230717081138-628065cf23b6 h1:EL/37sEjeLmQ2RTd9xMLLOuMXY6fMV/zB8a5X0BJUMM=
-github.com/0xPolygon/go-ibft v0.4.1-0.20230717081138-628065cf23b6/go.mod h1:0W1BnkhtXa2K59PzTPoQvbKOnI+G6QliXIHpQWNeiAM=
+github.com/0xPolygon/go-ibft v0.4.1-0.20240424084119-1e0f56f229a2 h1:wyIdL/UIsNJKtj6Ty8ALBAe/LIbDn1IuClStvmiY2hY=
+github.com/0xPolygon/go-ibft v0.4.1-0.20240424084119-1e0f56f229a2/go.mod h1:FPdz+s0jyQzW4pZK+HMnhz2b8ebsg5FaSVFTjvQi8ls=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -529,18 +529,18 @@ func (p *TxPool) ResetWithBlock(block *types.Block) {
 	}
 }
 
-// ReinjectProposed clears localProposed slice and returns txs to the pool
+// ReinsertProposed clears localProposed slice and reinserts txs to the pool
 // if local node was proposer for the previous failed round
-func (p *TxPool) ReinjectProposed(reinject bool) {
-	p.logger.Info("ReinjectProposed", "reinject", reinject, "localProposed length", len(p.localProposed))
+func (p *TxPool) ReinsertProposed(reinsert bool) {
+	p.logger.Info("ReinsertProposed", "reinsert", reinsert, "localProposed length", len(p.localProposed))
 
 	// if local node was previous proposer
 	if len(p.localProposed) > 0 {
-		if reinject {
+		if reinsert {
 			// return txs to the pool
 			for _, tx := range p.localProposed {
 				if err := p.addTx(local, tx); err != nil {
-					p.logger.Error("ReinjectProposed", "tx hash", tx.Hash(), "error", err)
+					p.logger.Error("ReinsertProposed", "tx hash", tx.Hash(), "error", err)
 				}
 			}
 		}


### PR DESCRIPTION
# Description

We should keep txpool transactions until consensus notifies us what shall we do with proposed txs based on proposal status.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
