### PR TITLE
`EIP1559` token burning fix

### DIFF
--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -439,6 +439,16 @@ func ForkManagerFactory(forks *chain.Forks) error {
 	return nil
 }
 
+// IsL1OriginatedTokenCheck checks if the token is originated from L1
+func IsL1OriginatedTokenCheck(config *chain.Params) (bool, error) {
+	polyBFTConfig, err := GetPolyBFTConfig(config)
+	if err != nil {
+		return false, err
+	}
+
+	return polyBFTConfig.IsBridgeEnabled() && !polyBFTConfig.NativeTokenConfig.IsMintable, nil
+}
+
 // Initialize initializes the consensus (e.g. setup data)
 func (p *Polybft) Initialize() error {
 	p.logger.Info("initializing polybft...")

--- a/server/builtin.go
+++ b/server/builtin.go
@@ -23,6 +23,8 @@ type ForkManagerFactory func(forks *chain.Forks) error
 
 type ForkManagerInitialParamsFactory func(config *chain.Chain) (*forkmanager.ForkParams, error)
 
+type IsL1OriginatedTokenCheck func(config *chain.Params) (bool, error)
+
 const (
 	DevConsensus     ConsensusType = "dev"
 	PolyBFTConsensus ConsensusType = consensusPolyBFT.ConsensusName
@@ -54,6 +56,10 @@ var forkManagerFactory = map[ConsensusType]ForkManagerFactory{
 
 var forkManagerInitialParamsFactory = map[ConsensusType]ForkManagerInitialParamsFactory{
 	PolyBFTConsensus: consensusPolyBFT.ForkManagerInitialParamsFactory,
+}
+
+var isL1OriginatedTokenCheckFactory = map[ConsensusType]IsL1OriginatedTokenCheck{
+	PolyBFTConsensus: consensusPolyBFT.IsL1OriginatedTokenCheck,
 }
 
 func ConsensusSupported(value string) bool {

--- a/server/server.go
+++ b/server/server.go
@@ -226,6 +226,15 @@ func NewServer(config *Config) (*Server, error) {
 		m.executor.GenesisPostHook = factory(m.config.Chain, engineName)
 	}
 
+	if factory, exists := isL1OriginatedTokenCheckFactory[ConsensusType(engineName)]; exists {
+		isL1OriginatedToken, err := factory(m.config.Chain.Params)
+		if err != nil {
+			return nil, err
+		}
+
+		m.executor.IsL1OriginatedToken = isL1OriginatedToken
+	}
+
 	// apply allow list contracts deployer genesis data
 	if m.config.Chain.Params.ContractDeployerAllowList != nil {
 		addresslist.ApplyGenesisAllocs(m.config.Chain.Genesis, contracts.AllowListContractsAddr,

--- a/state/executor.go
+++ b/state/executor.go
@@ -46,6 +46,8 @@ type Executor struct {
 
 	PostHook        func(txn *Transition)
 	GenesisPostHook func(*Transition) error
+
+	IsL1OriginatedToken bool
 }
 
 // NewExecutor creates a new executor
@@ -243,6 +245,8 @@ func (e *Executor) BeginTxn(
 	t.ctx = txCtx
 	t.gasPool = uint64(txCtx.GasLimit)
 
+	t.isL1OriginatedToken = e.IsL1OriginatedToken
+
 	// enable contract deployment allow list (if any)
 	if e.config.ContractDeployerAllowList != nil {
 		t.deploymentAllowList = addresslist.NewAddressList(t, contracts.AllowListContractsAddr)
@@ -308,6 +312,8 @@ type Transition struct {
 	journalRevisions []runtime.JournalRevision
 
 	accessList *runtime.AccessList
+
+	isL1OriginatedToken bool
 }
 
 func NewTransition(logger hclog.Logger, config chain.ForksInTime, snap Snapshot, radix *Txn) *Transition {
@@ -741,13 +747,13 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 	t.state.AddBalance(t.ctx.Coinbase, coinbaseFee)
 
 	//nolint:godox
-	// TODO - burning of base fee should not be done in the EVM
-	// Burn some amount if the london hardfork is applied.
+	// Burn some amount if the london hardfork is applied and token is non mintable.
 	// Basically, burn amount is just transferred to the current burn contract.
-	// if t.config.London && msg.Type() != types.StateTxType {
-	// 	burnAmount := new(big.Int).Mul(new(big.Int).SetUint64(result.GasUsed), t.ctx.BaseFee)
-	// 	t.state.AddBalance(t.ctx.BurnContract, burnAmount)
-	// }
+	if t.isL1OriginatedToken && t.config.London && msg.Type() != types.StateTxType {
+		burnAmount := new(big.Int).Mul(new(big.Int).SetUint64(result.GasUsed), t.ctx.BaseFee)
+		t.state.AddBalance(t.ctx.BurnContract, burnAmount)
+		t.logger.Debug("[Transition.apply] Burned some amount", "amount", burnAmount)
+	}
 
 	// return gas to the pool
 	t.addGasPool(result.GasLeft)

--- a/state/executor.go
+++ b/state/executor.go
@@ -752,7 +752,6 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 	if t.isL1OriginatedToken && t.config.London && msg.Type() != types.StateTxType {
 		burnAmount := new(big.Int).Mul(new(big.Int).SetUint64(result.GasUsed), t.ctx.BaseFee)
 		t.state.AddBalance(t.ctx.BurnContract, burnAmount)
-		t.logger.Debug("[Transition.apply] Burned some amount", "amount", burnAmount)
 	}
 
 	// return gas to the pool


### PR DESCRIPTION
# Description

Tokens on `blade` should be transferred to the burn contract only when `London` (`EIP1559`) fork is active and `blade` is acting as an `L2`, where native token is originated from a `L1` chain. In that case, burned tokens need to be transferred to some contract (burn contract), from which they can be transferred back to the `L1`.

In cases where `blade` is acting as `L1` or if it is acting as `L2`, but its native token is mintable, then, burning happens in the evm as is. Meaning, tokens that will be burned, won't be transferred to any contract or address, making them "dissappear" from circulation forever.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually