### PR TITLE
Fix for txpool loosing txs

### DIFF
--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -101,8 +101,11 @@ func (d *Dev) run() {
 		// There are new transactions in the pool, try to seal them
 		header := d.blockchain.Header()
 		if err := d.writeNewBlock(header); err != nil {
+			d.txpool.ReinsertProposed()
 			d.logger.Error("failed to mine block", "err", err)
 		}
+
+		d.txpool.ClearProposed()
 	}
 }
 

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -1007,7 +1007,7 @@ func (c *consensusRuntime) BuildCommitMessage(proposalHash []byte, view *proto.V
 	return message
 }
 
-// StartRound starts a new round with the specified view
+// StartRound represents round start callback
 func (c *consensusRuntime) StartRound(view *proto.View) error {
 	if view.Round > 0 {
 		c.config.txPool.ReinsertProposed()

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -48,6 +48,8 @@ type txPoolInterface interface {
 	Demote(*types.Transaction)
 	SetSealing(bool)
 	ResetWithBlock(*types.Block)
+	ReinsertProposed()
+	ClearProposed()
 }
 
 // epochMetadata is the static info for epoch currently being processed
@@ -1007,6 +1009,12 @@ func (c *consensusRuntime) BuildCommitMessage(proposalHash []byte, view *proto.V
 
 // StartRound starts a new round with the specified view
 func (c *consensusRuntime) StartRound(view *proto.View) error {
+	if view.Round > 0 {
+		c.config.txPool.ReinsertProposed()
+	} else {
+		c.config.txPool.ClearProposed()
+	}
+
 	return nil
 }
 

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1002,24 +1002,24 @@ func TestConsensusRuntime_BuildPrepareMessage(t *testing.T) {
 
 func TestConsensusRuntime_StartRound(t *testing.T) {
 	cases := []struct {
-		name  string
-		round uint64
+		funcName string
+		round    uint64
 	}{
 		{
-			name:  "ClearProposed",
-			round: 0,
+			funcName: "ClearProposed",
+			round:    0,
 		},
 		{
-			name:  "ReinsertProposed",
-			round: 1,
+			funcName: "ReinsertProposed",
+			round:    1,
 		},
 	}
 
 	for _, c := range cases {
 		c := c
-		t.Run(c.name, func(t *testing.T) {
+		t.Run(c.funcName, func(t *testing.T) {
 			txPool := new(txPoolMock)
-			txPool.On(c.name).Once()
+			txPool.On(c.funcName).Once()
 
 			runtime := &consensusRuntime{
 				config: &runtimeConfig{

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1030,6 +1030,7 @@ func TestConsensusRuntime_StartRound(t *testing.T) {
 
 			view := &proto.View{Round: c.round}
 			require.NoError(t, runtime.StartRound(view))
+			txPool.AssertExpectations(t)
 		})
 	}
 }

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1000,6 +1000,40 @@ func TestConsensusRuntime_BuildPrepareMessage(t *testing.T) {
 	assert.Equal(t, signedMsg, runtime.BuildPrepareMessage(proposalHash, view))
 }
 
+func TestConsensusRuntime_StartRound(t *testing.T) {
+	cases := []struct {
+		name  string
+		round uint64
+	}{
+		{
+			name:  "ClearProposed",
+			round: 0,
+		},
+		{
+			name:  "ReinsertProposed",
+			round: 1,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			txPool := new(txPoolMock)
+			txPool.On(c.name).Once()
+
+			runtime := &consensusRuntime{
+				config: &runtimeConfig{
+					txPool: txPool,
+				},
+				logger: hclog.NewNullLogger(),
+			}
+
+			view := &proto.View{Round: c.round}
+			require.NoError(t, runtime.StartRound(view))
+		})
+	}
+}
+
 func createTestBlocks(t *testing.T, numberOfBlocks, defaultEpochSize uint64,
 	validatorSet validator.AccountSet) (*types.Header, *testHeadersMap) {
 	t.Helper()

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -360,6 +360,14 @@ func (tp *txPoolMock) ResetWithBlock(fullBlock *types.Block) {
 	tp.Called(fullBlock)
 }
 
+func (tp *txPoolMock) ReinsertProposed() {
+	tp.Called()
+}
+
+func (tp *txPoolMock) ClearProposed() {
+	tp.Called()
+}
+
 var _ syncer.Syncer = (*syncerMock)(nil)
 
 type syncerMock struct {

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -1,6 +1,7 @@
 package txpool
 
 import (
+	"maps"
 	"sync"
 	"sync/atomic"
 
@@ -19,11 +20,13 @@ type accountsMap struct {
 // Initializes an account for the given address.
 func (m *accountsMap) initOnce(addr types.Address, nonce uint64) *account {
 	a, loaded := m.LoadOrStore(addr, &account{
-		enqueued:    newAccountQueue(),
-		promoted:    newAccountQueue(),
-		nonceToTx:   newNonceToTxLookup(),
-		maxEnqueued: m.maxEnqueuedLimit,
-		nextNonce:   nonce,
+		enqueued:      newAccountQueue(),
+		promoted:      newAccountQueue(),
+		proposed:      newAccountQueue(),
+		nonceToTx:     newNonceToTxLookup(),
+		nonceProposed: newNonceToTxLookup(),
+		maxEnqueued:   m.maxEnqueuedLimit,
+		nextNonce:     nonce,
 	})
 	newAccount := a.(*account) //nolint:forcetypeassert
 
@@ -129,6 +132,73 @@ func (m *accountsMap) allTxs(includeEnqueued bool) (
 	return
 }
 
+func (m *accountsMap) reinsertProposed() {
+	m.Range(func(key, value interface{}) bool {
+		accountKey, ok := key.(types.Address)
+		if !ok {
+			return false
+		}
+
+		account := m.get(accountKey)
+
+		account.promoted.lock(true)
+		account.proposed.lock(true)
+		account.nonceToTx.lock()
+		account.nonceProposed.lock()
+
+		defer func() {
+			account.nonceProposed.unlock()
+			account.nonceToTx.unlock()
+			account.proposed.unlock()
+			account.promoted.unlock()
+		}()
+
+		if account.proposed.length() > 0 {
+			for {
+				tx := account.proposed.peek()
+				if tx == nil {
+					break
+				}
+
+				account.promoted.push(tx)
+				account.proposed.pop()
+			}
+			account.proposed.clear()
+
+			maps.Copy(account.nonceToTx.mapping, account.nonceProposed.mapping)
+			account.nonceProposed.reset()
+		}
+
+		return true
+	})
+}
+
+func (m *accountsMap) clearProposed() {
+	m.Range(func(key, value interface{}) bool {
+		accountKey, ok := key.(types.Address)
+		if !ok {
+			return false
+		}
+
+		account := m.get(accountKey)
+
+		account.proposed.lock(true)
+		account.nonceProposed.lock()
+
+		defer func() {
+			account.nonceProposed.unlock()
+			account.proposed.unlock()
+		}()
+
+		if account.proposed.length() > 0 {
+			account.proposed.clear()
+			account.nonceProposed.reset()
+		}
+
+		return true
+	})
+}
+
 type nonceToTxLookup struct {
 	mapping map[uint64]*types.Transaction
 	mutex   sync.Mutex
@@ -179,8 +249,8 @@ func (m *nonceToTxLookup) remove(txs ...*types.Transaction) {
 // are ready to be moved to the promoted queue.
 // lock order is important! promoted.lock(true), enqueued.lock(true), nonceToTx.lock()
 type account struct {
-	enqueued, promoted *accountQueue
-	nonceToTx          *nonceToTxLookup
+	enqueued, promoted, proposed *accountQueue
+	nonceToTx, nonceProposed     *nonceToTxLookup
 
 	nextNonce uint64
 	demotions uint64
@@ -224,15 +294,23 @@ func (a *account) reset(nonce uint64, promoteCh chan<- promoteRequest) (
 	prunedPromoted,
 	prunedEnqueued []*types.Transaction,
 ) {
+	a.proposed.lock(true)
 	a.promoted.lock(true)
 	a.enqueued.lock(true)
 	a.nonceToTx.lock()
+	a.nonceProposed.lock()
 
 	defer func() {
+		a.nonceProposed.unlock()
 		a.nonceToTx.unlock()
 		a.enqueued.unlock()
 		a.promoted.unlock()
+		a.proposed.unlock()
 	}()
+
+	// prune the proposed txs
+	prunedProposed := a.proposed.prune(nonce)
+	a.nonceProposed.remove(prunedProposed...)
 
 	// prune the promoted txs
 	prunedPromoted = a.promoted.prune(nonce)

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -132,7 +132,9 @@ func (m *accountsMap) allTxs(includeEnqueued bool) (
 	return
 }
 
-func (m *accountsMap) reinsertProposed() {
+func (m *accountsMap) reinsertProposed() uint64 {
+	var count uint64
+
 	m.Range(func(key, value interface{}) bool {
 		accountKey, ok := key.(types.Address)
 		if !ok {
@@ -162,6 +164,8 @@ func (m *accountsMap) reinsertProposed() {
 
 				account.promoted.push(tx)
 				account.proposed.pop()
+
+				count++
 			}
 			account.proposed.clear()
 
@@ -171,6 +175,8 @@ func (m *accountsMap) reinsertProposed() {
 
 		return true
 	})
+
+	return count
 }
 
 func (m *accountsMap) clearProposed() {

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -300,18 +300,18 @@ func (a *account) reset(nonce uint64, promoteCh chan<- promoteRequest) (
 	prunedPromoted,
 	prunedEnqueued []*types.Transaction,
 ) {
-	a.proposed.lock(true)
 	a.promoted.lock(true)
 	a.enqueued.lock(true)
+	a.proposed.lock(true)
 	a.nonceToTx.lock()
 	a.nonceProposed.lock()
 
 	defer func() {
 		a.nonceProposed.unlock()
 		a.nonceToTx.unlock()
+		a.proposed.unlock()
 		a.enqueued.unlock()
 		a.promoted.unlock()
-		a.proposed.unlock()
 	}()
 
 	// prune the proposed txs

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -167,7 +167,6 @@ func (m *accountsMap) reinsertProposed() uint64 {
 
 				count++
 			}
-			account.proposed.clear()
 
 			maps.Copy(account.nonceToTx.mapping, account.nonceProposed.mapping)
 			account.nonceProposed.reset()

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -406,18 +406,18 @@ func (p *TxPool) Drop(tx *types.Transaction) {
 // signals EventType_DROPPED for provided hash, clears all the slots and metrics
 // and sets nonce to provided nonce
 func (p *TxPool) dropAccount(account *account, nextNonce uint64, tx *types.Transaction) {
-	account.proposed.lock(true)
 	account.promoted.lock(true)
 	account.enqueued.lock(true)
+	account.proposed.lock(true)
 	account.nonceToTx.lock()
 	account.nonceProposed.lock()
 
 	defer func() {
 		account.nonceProposed.unlock()
 		account.nonceToTx.unlock()
+		account.proposed.unlock()
 		account.enqueued.unlock()
 		account.promoted.unlock()
-		account.proposed.unlock()
 	}()
 
 	// num of all txs dropped

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -442,10 +442,11 @@ func (p *TxPool) dropAccount(account *account, nextNonce uint64, tx *types.Trans
 	account.nonceProposed.reset()
 
 	// drop proposed
-	account.proposed.clear()
+	dropped := account.proposed.clear()
+	p.index.remove(dropped...)
 
 	// drop promoted
-	dropped := account.promoted.clear()
+	dropped = account.promoted.clear()
 	clearAccountQueue(dropped)
 
 	// update metrics

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -544,12 +544,16 @@ func (p *TxPool) ResetWithBlock(block *types.Block) {
 	}
 }
 
+// ReinsertProposed returns all txs from the accounts proposed queue to the promoted queue
+// it is called from consensus_runtime when new round > 0 starts or when current sequence is cancelled
 func (p *TxPool) ReinsertProposed() {
 	count := p.accounts.reinsertProposed()
 	p.gauge.increase(count)
 	p.Prepare()
 }
 
+// ClearProposed clears accounts proposed queue when round 0 starts
+// it is called from consensus_runtime
 func (p *TxPool) ClearProposed() {
 	p.accounts.clearProposed()
 }

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -442,11 +442,10 @@ func (p *TxPool) dropAccount(account *account, nextNonce uint64, tx *types.Trans
 	account.nonceProposed.reset()
 
 	// drop proposed
-	dropped := account.proposed.clear()
-	clearAccountQueue(dropped)
+	account.proposed.clear()
 
 	// drop promoted
-	dropped = account.promoted.clear()
+	dropped := account.promoted.clear()
 	clearAccountQueue(dropped)
 
 	// update metrics

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -545,7 +545,8 @@ func (p *TxPool) ResetWithBlock(block *types.Block) {
 }
 
 func (p *TxPool) ReinsertProposed() {
-	p.accounts.reinsertProposed()
+	count := p.accounts.reinsertProposed()
+	p.gauge.increase(count)
 	p.Prepare()
 }
 


### PR DESCRIPTION
# Description

During proposal build a proposer removes txs from the accounts.promoted with accounts.promoted.pop. That leads to possible problem because those txs are permanently removed and in the case if that round fails the proposer can't take part in the consensus and further more there is a high possibility of nonce too high error for future proposals on that particular validator.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Run EOA load test in local.

