### PR TITLE
Validator snapshot calculation optimization

### DIFF
--- a/consensus/polybft/validator/validator_metadata.go
+++ b/consensus/polybft/validator/validator_metadata.go
@@ -304,7 +304,7 @@ func (as AccountSet) ApplyDelta(validatorsDelta *ValidatorSetDelta) (AccountSet,
 
 	// Figure out which validators from the existing set are not marked for deletion.
 	// Those should be kept in the snapshot.
-	validators := make(AccountSet, 0)
+	validators := make(AccountSet, 0, as.Len())
 
 	for i, validator := range as {
 		// If a validator is not in the Removed set, or it is in the Removed set
@@ -319,7 +319,7 @@ func (as AccountSet) ApplyDelta(validatorsDelta *ValidatorSetDelta) (AccountSet,
 	// Append added validators
 	for _, addedValidator := range validatorsDelta.Added {
 		if validators.ContainsAddress(addedValidator.Address) {
-			return nil, fmt.Errorf("validator %v is already present in the validators snapshot", addedValidator.Address.String())
+			return nil, fmt.Errorf("validator %s is already present in the validators snapshot", addedValidator.Address)
 		}
 
 		validators = append(validators, addedValidator)

--- a/consensus/polybft/validator/validator_metadata.go
+++ b/consensus/polybft/validator/validator_metadata.go
@@ -299,7 +299,7 @@ func (as AccountSet) GetFilteredValidators(bitmap bitmap.Bitmap) (AccountSet, er
 // Function returns new AccountSet with old and new data merged. AccountSet is immutable!
 func (as AccountSet) ApplyDelta(validatorsDelta *ValidatorSetDelta) (AccountSet, error) {
 	if validatorsDelta == nil || validatorsDelta.IsEmpty() {
-		return as.Copy(), nil
+		return as, nil
 	}
 
 	// Figure out which validators from the existing set are not marked for deletion.

--- a/consensus/polybft/validator/validator_metadata.go
+++ b/consensus/polybft/validator/validator_metadata.go
@@ -296,7 +296,8 @@ func (as AccountSet) GetFilteredValidators(bitmap bitmap.Bitmap) (AccountSet, er
 
 // ApplyDelta receives ValidatorSetDelta and applies it to the values from the current AccountSet
 // (removes the ones marked for deletion and adds the one which are being added by delta)
-// Function returns new AccountSet with old and new data merged. AccountSet is immutable!
+// Function returns new AccountSet with old and new data merged.
+// Note: AccountSet is immutable in case of non-empty delta!
 func (as AccountSet) ApplyDelta(validatorsDelta *ValidatorSetDelta) (AccountSet, error) {
 	if validatorsDelta == nil || validatorsDelta.IsEmpty() {
 		return as, nil

--- a/consensus/polybft/validators_snapshot.go
+++ b/consensus/polybft/validators_snapshot.go
@@ -138,6 +138,8 @@ func (v *validatorsSnapshotCache) GetSnapshot(
 				latestValidatorSnapshot.Epoch+1, err)
 		}
 
+		v.logger.Trace("Applying delta", "epochEndBlock", nextEpochEndBlockNumber)
+
 		intermediateSnapshot, err := v.computeSnapshot(latestValidatorSnapshot, nextEpochEndBlockNumber, parents)
 		if err != nil {
 			return nil, fmt.Errorf("failed to compute snapshot for epoch %d: %w", latestValidatorSnapshot.Epoch+1, err)

--- a/consensus/polybft/validators_snapshot_test.go
+++ b/consensus/polybft/validators_snapshot_test.go
@@ -309,16 +309,13 @@ func TestValidatorsSnapshotCache_HugeBuild(t *testing.T) {
 	lastValIndex := validatorSetSize
 	epochValidators := map[uint64]epochValidatorSetIndexes{}
 
-	for i := uint64(0); i < lastBlock; i += epochSize {
+	// create headers for the first epoch separately
+	createHeaders(t, headersMap, 0, epochSize-1, 1, nil, newValidators)
+
+	for i := epochSize; i < lastBlock; i += epochSize {
 		from := i
 		to := i + epochSize - 1
 		epoch := i/epochSize + 1
-
-		if i == 0 {
-			createHeaders(t, headersMap, from, to, epoch, nil, newValidators)
-
-			continue
-		}
 
 		oldValidators = newValidators
 
@@ -349,7 +346,7 @@ func TestValidatorsSnapshotCache_HugeBuild(t *testing.T) {
 
 	snapshot, err := validatorsSnapshotCache.GetSnapshot(lastBlock-epochSize, nil, nil)
 
-	fmt.Println("Time needed to calculate snapshot:", time.Since(s))
+	t.Log("Time needed to calculate snapshot:", time.Since(s))
 
 	require.NoError(t, err)
 	require.NotNil(t, snapshot)

--- a/consensus/polybft/validators_snapshot_test.go
+++ b/consensus/polybft/validators_snapshot_test.go
@@ -303,6 +303,7 @@ func TestValidatorsSnapshotCache_HugeBuild(t *testing.T) {
 
 		if i == 0 {
 			createHeaders(t, headersMap, from, to, epoch, nil, allValidators)
+
 			continue
 		}
 

--- a/consensus/polybft/validators_snapshot_test.go
+++ b/consensus/polybft/validators_snapshot_test.go
@@ -358,30 +358,35 @@ func TestValidatorsSnapshotCache_HugeBuild(t *testing.T) {
 	// check if the validators of random epochs are as expected
 	snapshot, err = validatorsSnapshotCache.GetSnapshot(46, nil, nil) // epoch 5 where validator set did not change
 	require.NoError(t, err)
+
 	epochValIndexes, ok := epochValidators[5]
 	require.True(t, ok)
 	require.True(t, allValidators[epochValIndexes.firstValIndex:epochValIndexes.lastValIndex].Equals(snapshot))
 
 	snapshot, err = validatorsSnapshotCache.GetSnapshot(numOfEpochsToChangeValSet*epochSize, nil, nil) // epoch 50 where validator set was changed
 	require.NoError(t, err)
+
 	epochValIndexes, ok = epochValidators[numOfEpochsToChangeValSet]
 	require.True(t, ok)
 	require.True(t, allValidators[epochValIndexes.firstValIndex:epochValIndexes.lastValIndex].Equals(snapshot))
 
 	snapshot, err = validatorsSnapshotCache.GetSnapshot(2*numOfEpochsToChangeValSet*epochSize, nil, nil) // epoch 100 where validator set was changed
 	require.NoError(t, err)
+
 	epochValIndexes, ok = epochValidators[2*numOfEpochsToChangeValSet]
 	require.True(t, ok)
 	require.True(t, allValidators[epochValIndexes.firstValIndex:epochValIndexes.lastValIndex].Equals(snapshot))
 
 	snapshot, err = validatorsSnapshotCache.GetSnapshot(57903, nil, nil) // epoch 5790 where validator set did not change
 	require.NoError(t, err)
+
 	epochValIndexes, ok = epochValidators[57903/epochSize+1]
 	require.True(t, ok)
 	require.True(t, allValidators[epochValIndexes.firstValIndex:epochValIndexes.lastValIndex].Equals(snapshot))
 
 	snapshot, err = validatorsSnapshotCache.GetSnapshot(99991, nil, nil) // epoch 10000 where validator set did not change
 	require.NoError(t, err)
+
 	epochValIndexes, ok = epochValidators[99991/epochSize+1]
 	require.True(t, ok)
 	require.True(t, allValidators[epochValIndexes.firstValIndex:epochValIndexes.lastValIndex].Equals(snapshot))


### PR DESCRIPTION
# Description

When calculating validator snapshot, a lot of time was spent on copying the `accountSet`, which is not necessary.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually