### PR TITLE
Remove extra exit with out of the gas error

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -155,7 +155,7 @@ func (e *Executor) ProcessBlock(
 
 	for i, t := range block.Transactions {
 		if t.Gas() > block.Header.GasLimit {
-			continue
+			return nil, runtime.ErrOutOfGas
 		}
 
 		if err = txn.Write(t); err != nil {

--- a/state/executor.go
+++ b/state/executor.go
@@ -746,7 +746,6 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 	coinbaseFee := new(big.Int).Mul(new(big.Int).SetUint64(result.GasUsed), effectiveTip)
 	t.state.AddBalance(t.ctx.Coinbase, coinbaseFee)
 
-	//nolint:godox
 	// Burn some amount if the london hardfork is applied and token is non mintable.
 	// Basically, burn amount is just transferred to the current burn contract.
 	if t.isL1OriginatedToken && t.config.London && msg.Type() != types.StateTxType {

--- a/state/executor.go
+++ b/state/executor.go
@@ -179,12 +179,12 @@ func (e *Executor) ProcessBlock(
 		}
 	}
 
-	var (
-		logMsg  = "[Executor.ProcessBlock] finished."
-		logArgs = []interface{}{"txs count", len(block.Transactions), "txs", buf.String()}
-	)
-
 	if logLvl <= hclog.Debug {
+		var (
+			logMsg  = "[Executor.ProcessBlock] finished."
+			logArgs = []interface{}{"txs count", len(block.Transactions), "txs", buf.String()}
+		)
+
 		e.logger.Log(logLvl, logMsg, logArgs...)
 	}
 

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -261,7 +261,6 @@ func (c *state) Run() ([]byte, error) {
 
 		// consume the gas of the instruction
 		if !c.consumeGas(inst.gas) {
-			c.exit(errOutOfGas)
 			c.captureExecution(op.String(), uint64(c.ip), gasCopy, inst.gas)
 
 			break
@@ -332,8 +331,6 @@ func (c *state) allocateMemory(offset, size *big.Int) bool {
 		c.lastGasCost = newCost
 
 		if !c.consumeGas(cost) {
-			c.exit(errOutOfGas)
-
 			return false
 		}
 


### PR DESCRIPTION
# Description

The PR removes unnecessary calls to `exit` with `out of gas` error message, since that part is already handled in the `consumeGas` function.

Also in case there is a transaction in the block that consumes more gas than the entire block gas limit, an error is returned.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
