### PR TITLE
Commitment deadlock fix

### DIFF
--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -173,9 +173,6 @@ func (s *stateSyncManager) saveVote(msg *TransportMessage) error {
 		Signature: msg.Signature,
 	}
 
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	numSignatures, err := s.state.StateSyncStore.insertMessageVote(msg.EpochNumber, msg.Hash, msgVote, nil)
 	if err != nil {
 		return fmt.Errorf("error inserting message vote: %w", err)

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -173,6 +173,9 @@ func (s *stateSyncManager) saveVote(msg *TransportMessage) error {
 		Signature: msg.Signature,
 	}
 
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	numSignatures, err := s.state.StateSyncStore.insertMessageVote(msg.EpochNumber, msg.Hash, msgVote, nil)
 	if err != nil {
 		return fmt.Errorf("error inserting message vote: %w", err)

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -1250,11 +1250,11 @@ func TestE2E_Bridge_Transfers_AccessLists(t *testing.T) {
 
 func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 	var (
+		epochSize             = 5
+		stateSyncedLogsCount  = 2
 		numBlockConfirmations = uint64(2)
-		epochSize             = 10
 		sprintSize            = uint64(5)
 		numberOfAttempts      = uint64(4)
-		stateSyncedLogsCount  = 2
 		exitEventsCount       = uint64(2)
 		tokensToTransfer      = ethgo.Gwei(10)
 		bigZero               = big.NewInt(0)

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -1250,7 +1250,7 @@ func TestE2E_Bridge_Transfers_AccessLists(t *testing.T) {
 
 func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 	var (
-		epochSize             = 5
+		epochSize             = 10
 		stateSyncedLogsCount  = 2
 		numBlockConfirmations = uint64(2)
 		sprintSize            = uint64(5)


### PR DESCRIPTION
# Description

Fix for commitment deadlock. Conensus runtime OnBlockInserted deadlocks with bridge manager AddLogs. s.state.StateSyncStore.insertMessageVote is called from bridge manager AddLogs while OnBlockInserted has pending write transaction and the call will wait until OnBlockInserted executes tx commit. However OnBlockInserted will never execute commit since at the end of epoch it will call restartEpoch and that will eventually finish with deadlock on the lock grabbed by AddLogs while calling insertMessageVote.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

