### PR TITLE
e2e fixes

### DIFF
--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -837,11 +837,10 @@ func TestE2E_Bridge_ChildchainTokensTransfer(t *testing.T) {
 
 			// check that balances on the child chain are correct
 			for i, receiver := range depositors {
-				temp := big.NewInt(0)
 				balance := erc20BalanceOf(t, receiver, contracts.NativeERC20TokenContract, childchainTxRelayer)
 				t.Log("Attempt", it+1, "Balance before", balancesBefore[i], "Balance after", balance)
 
-				if balance.Cmp(temp.Add(balancesBefore[i], big.NewInt(amount))) != 0 {
+				if balance.Cmp(new(big.Int).Add(balancesBefore[i], big.NewInt(amount))) != 0 {
 					allSuccessful = false
 
 					break
@@ -1251,9 +1250,9 @@ func TestE2E_Bridge_Transfers_AccessLists(t *testing.T) {
 
 func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 	var (
-		epochSize             = 10
 		stateSyncedLogsCount  = 2
-		numberOfAttempts      = 4
+		epochSize             = uint64(10)
+		numberOfAttempts      = uint64(4)
 		numBlockConfirmations = uint64(2)
 		exitEventsCount       = uint64(2)
 		tokensToTransfer      = ethgo.Gwei(10)
@@ -1276,7 +1275,7 @@ func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 	// with london fork enabled
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithBridge(),
-		framework.WithEpochSize(epochSize),
+		framework.WithEpochSize(int(epochSize)),
 		framework.WithNumBlockConfirmations(numBlockConfirmations),
 		framework.WithNativeTokenConfig(nativeTokenNonMintableConfig),
 		// this enables London (EIP-1559) fork
@@ -1445,14 +1444,14 @@ func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 		require.NoError(t, err)
 
 		// wait for couple of epoches
-		finalBlockNum := currentBlock.Header.Number + uint64(2*epochSize)
+		finalBlockNum := currentBlock.Header.Number + 2*epochSize
 		require.NoError(t, cluster.WaitForBlock(finalBlockNum, 2*time.Minute))
 
 		// the transaction is processed and there should be a success event
 		var stateSyncedResult contractsapi.StateSyncResultEvent
 
-		for i := 0; i < numberOfAttempts; i++ {
-			logs, err := getFilteredLogs(stateSyncedResult.Sig(), 0, finalBlockNum+uint64(i*epochSize), childEthEndpoint)
+		for i := uint64(0); i < numberOfAttempts; i++ {
+			logs, err := getFilteredLogs(stateSyncedResult.Sig(), 0, finalBlockNum+i*epochSize, childEthEndpoint)
 			require.NoError(t, err)
 
 			if len(logs) == stateSyncedLogsCount || i == numberOfAttempts-1 {
@@ -1462,7 +1461,7 @@ func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 				break
 			}
 
-			require.NoError(t, cluster.WaitForBlock(finalBlockNum+uint64((i+1)*epochSize), time.Minute))
+			require.NoError(t, cluster.WaitForBlock(finalBlockNum+(i+1)*epochSize, time.Minute))
 		}
 	})
 }


### PR DESCRIPTION
# Description

Fix for TestE2E_Bridge_ChildchainTokensTransfer because it can't pass in attempts after the 1st one.
NonMintableERC20 is changed to take epochs into account instead of sprints because commitment is built at the epoch end. We need this because test fails occasionally due to slow CI instance. If we give more chances for test to pass it is expected to be greener, as it is for the same ERC721 test which is 100% green. In the worst negative scenario we will wait for 30 seconds longer than before. In the positive case an average duration time should be similar as it was before, but this gives at least 1 or 2 epoch commitments more and that increases the chance for positive outcome.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually