### PR TITLE
Sanity check tests

### DIFF
--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -162,6 +162,10 @@ func (p *genesisParams) validateFlags() error {
 	}
 
 	if p.isPolyBFTConsensus() {
+		if p.epochSize == 0 {
+			return errInvalidEpochSize
+		}
+
 		if err := p.extractNativeTokenMetadata(); err != nil {
 			return err
 		}

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -31,7 +31,7 @@ const (
 	blockTimeDriftFlag = "block-time-drift"
 
 	defaultSprintSize               = uint64(5) // in blocks
-	defaultEpochReward              = 1         // in blocks
+	defaultEpochReward              = 1         // in wei
 	defaultBlockTime                = 2 * time.Second
 	defaultBlockTimeDrift           = uint64(10) // in seconds
 	defaultBlockTrackerPollInterval = time.Second
@@ -67,10 +67,8 @@ const (
 var (
 	errNoGenesisValidators      = errors.New("genesis validators aren't provided")
 	errProxyAdminNotProvided    = errors.New("proxy contracts admin address must be set")
-	errProxyAdminIsZeroAddress  = errors.New("proxy contracts admin address must not be zero address")
 	errProxyAdminIsSystemCaller = errors.New("proxy contracts admin address must not be system caller address")
 	errBladeAdminNotProvided    = errors.New("blade admin address must be set")
-	errBladeAdminIsZeroAddress  = errors.New("blade admin address must not be zero address")
 	errBladeAdminIsSystemCaller = errors.New("blade admin address must not be system caller address")
 	errNoPremineAllowed         = errors.New("native token is not mintable" +
 		"so no premine is allowed except for zero address")

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -65,33 +65,6 @@ func verifyGenesisExistence(genesisPath string) *GenesisGenError {
 	return nil
 }
 
-// parseTrackerStartBlocks parses provided event tracker start blocks configuration.
-// It is set in a following format: <contractAddress>:<startBlock>.
-// In case smart contract address isn't provided in the string, it is assumed its starting block is 0 implicitly.
-func parseTrackerStartBlocks(trackerStartBlocksRaw []string) (map[types.Address]uint64, error) {
-	trackerStartBlocksConfig := make(map[types.Address]uint64, len(trackerStartBlocksRaw))
-
-	for _, startBlockRaw := range trackerStartBlocksRaw {
-		delimiterIdx := strings.Index(startBlockRaw, ":")
-		if delimiterIdx == -1 {
-			return nil, fmt.Errorf("invalid event tracker start block configuration provided: %s", trackerStartBlocksRaw)
-		}
-
-		// <contractAddress>:<startBlock>
-		address := types.StringToAddress(startBlockRaw[:delimiterIdx])
-		startBlockRaw := startBlockRaw[delimiterIdx+1:]
-
-		startBlock, err := strconv.ParseUint(startBlockRaw, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse provided start block %s: %w", startBlockRaw, err)
-		}
-
-		trackerStartBlocksConfig[address] = startBlock
-	}
-
-	return trackerStartBlocksConfig, nil
-}
-
 // parseBurnContractInfo parses provided burn contract information and returns burn contract block and address
 func parseBurnContractInfo(burnContractInfoRaw string) (*polybft.BurnContractInfo, error) {
 	// <block>:<address>[:<burn destination address>]

--- a/command/loadtest/load_test_run.go
+++ b/command/loadtest/load_test_run.go
@@ -37,7 +37,7 @@ func preRunCommand(cmd *cobra.Command, _ []string) error {
 func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&params.mnemonic,
-		mnemonicFlag,
+		MnemonicFlag,
 		"",
 		"the mnemonic used to generate and fund virtual users",
 	)
@@ -79,7 +79,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(
 		&params.receiptsTimeout,
-		receiptsTimeoutFlag,
+		ReceiptsTimeoutFlag,
 		30*time.Second,
 		"the timeout for waiting for transaction receipts",
 	)
@@ -93,7 +93,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(
 		&params.toJSON,
-		saveToJSONFlag,
+		SaveToJSONFlag,
 		false,
 		"saves results to JSON file",
 	)
@@ -112,7 +112,7 @@ func setFlags(cmd *cobra.Command) {
 		"size of a batch of transactions to send to rpc node",
 	)
 
-	_ = cmd.MarkFlagRequired(mnemonicFlag)
+	_ = cmd.MarkFlagRequired(MnemonicFlag)
 	_ = cmd.MarkFlagRequired(loadTestTypeFlag)
 }
 

--- a/command/loadtest/params.go
+++ b/command/loadtest/params.go
@@ -8,24 +8,25 @@ import (
 )
 
 const (
-	mnemonicFlag     = "mnemonic"
+	MnemonicFlag        = "mnemonic"
+	SaveToJSONFlag      = "to-json"
+	ReceiptsTimeoutFlag = "receipts-timeout"
+
 	loadTestTypeFlag = "type"
 	loadTestNameFlag = "name"
 
-	receiptsTimeoutFlag = "receipts-timeout"
-	txPoolTimeoutFlag   = "txpool-timeout"
+	txPoolTimeoutFlag = "txpool-timeout"
 
 	vusFlag        = "vus"
 	txsPerUserFlag = "txs-per-user"
 	dynamicTxsFlag = "dynamic"
 	batchSizeFlag  = "batch-size"
 
-	saveToJSONFlag           = "to-json"
 	waitForTxPoolToEmptyFlag = "wait-txpool"
 )
 
 var (
-	errNoMnemonicProvided      = errors.New("no mnemonic provided")
+	ErrNoMnemonicProvided      = errors.New("no mnemonic provided")
 	errNoLoadTestTypeProvided  = errors.New("no load test type provided")
 	errUnsupportedLoadTestType = errors.New("unsupported load test type")
 	errInvalidVUs              = errors.New("vus must be greater than 0")
@@ -53,7 +54,7 @@ type loadTestParams struct {
 
 func (ltp *loadTestParams) validateFlags() error {
 	if ltp.mnemonic == "" {
-		return errNoMnemonicProvided
+		return ErrNoMnemonicProvided
 	}
 
 	if ltp.loadTestType == "" {

--- a/command/root/root.go
+++ b/command/root/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/monitor"
 	"github.com/0xPolygon/polygon-edge/command/peers"
 	"github.com/0xPolygon/polygon-edge/command/regenesis"
+	"github.com/0xPolygon/polygon-edge/command/sanitycheck"
 	"github.com/0xPolygon/polygon-edge/command/secrets"
 	polybftsecrets "github.com/0xPolygon/polygon-edge/command/secrets/init"
 	"github.com/0xPolygon/polygon-edge/command/server"
@@ -59,6 +60,7 @@ func (rc *RootCommand) registerSubCommands() {
 		mint.GetCommand(),
 		validator.GetCommand(),
 		loadtest.GetCommand(),
+		sanitycheck.GetCommand(),
 	)
 }
 

--- a/command/sanitycheck/params.go
+++ b/command/sanitycheck/params.go
@@ -1,0 +1,43 @@
+package sanitycheck
+
+import (
+	"errors"
+	"time"
+
+	"github.com/0xPolygon/polygon-edge/command/loadtest"
+)
+
+const (
+	epochSizeFlag     = "epoch-size"
+	validatorKeysFlag = "validator-keys"
+)
+
+var (
+	errInvalidEpochSize = errors.New("epoch size must be greater than 0")
+)
+
+// sanityCheckParams holds the parameters for the sanity check command
+type sanityCheckParams struct {
+	mnemonic       string
+	jsonRPCAddress string
+
+	receiptsTimeout time.Duration
+
+	epochSize uint64
+	toJSON    bool
+
+	validatorKeys []string
+}
+
+// validateFlags checks if the provided flags are valid
+func (scp *sanityCheckParams) validateFlags() error {
+	if scp.mnemonic == "" {
+		return loadtest.ErrNoMnemonicProvided
+	}
+
+	if scp.epochSize == 0 {
+		return errInvalidEpochSize
+	}
+
+	return nil
+}

--- a/command/sanitycheck/sanity_check.go
+++ b/command/sanitycheck/sanity_check.go
@@ -1,0 +1,99 @@
+package sanitycheck
+
+import (
+	"time"
+
+	"github.com/0xPolygon/polygon-edge/command"
+	"github.com/0xPolygon/polygon-edge/command/helper"
+	"github.com/0xPolygon/polygon-edge/command/loadtest"
+	"github.com/0xPolygon/polygon-edge/loadtest/sanitycheck"
+	"github.com/spf13/cobra"
+)
+
+var (
+	params sanityCheckParams
+)
+
+func GetCommand() *cobra.Command {
+	loadTestCmd := &cobra.Command{
+		Use:     "sanity-check",
+		Short:   "Runs sanity check tests on a specified network",
+		PreRunE: preRunCommand,
+		Run:     runCommand,
+	}
+
+	helper.RegisterJSONRPCFlag(loadTestCmd)
+
+	setFlags(loadTestCmd)
+
+	return loadTestCmd
+}
+
+func preRunCommand(cmd *cobra.Command, _ []string) error {
+	params.jsonRPCAddress = helper.GetJSONRPCAddress(cmd)
+
+	return params.validateFlags()
+}
+
+func setFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&params.mnemonic,
+		loadtest.MnemonicFlag,
+		"",
+		"the mnemonic used to fund accounts if needed for the sanity check",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.epochSize,
+		epochSizeFlag,
+		10,
+		"epoch size on the network for which the sanity check is run",
+	)
+
+	cmd.Flags().DurationVar(
+		&params.receiptsTimeout,
+		loadtest.ReceiptsTimeoutFlag,
+		30*time.Second,
+		"the timeout for waiting for transaction receipts",
+	)
+
+	cmd.Flags().BoolVar(
+		&params.toJSON,
+		loadtest.SaveToJSONFlag,
+		false,
+		"saves results to JSON file",
+	)
+
+	cmd.Flags().StringSliceVar(
+		&params.validatorKeys,
+		validatorKeysFlag,
+		nil,
+		"private keys of validators on the network for which the sanity check is run",
+	)
+
+	_ = cmd.MarkFlagRequired(loadtest.MnemonicFlag)
+}
+
+func runCommand(cmd *cobra.Command, _ []string) {
+	outputter := command.InitializeOutputter(cmd)
+	defer outputter.WriteOutput()
+
+	sanityCheckRunner, err := sanitycheck.NewSanityCheckTestRunner(
+		&sanitycheck.SanityCheckTestConfig{
+			Mnemonic:        params.mnemonic,
+			JSONRPCUrl:      params.jsonRPCAddress,
+			ReceiptsTimeout: params.receiptsTimeout,
+			EpochSize:       params.epochSize,
+			ValidatorKeys:   params.validatorKeys,
+			ResultsToJSON:   params.toJSON,
+		},
+	)
+
+	if err != nil {
+		outputter.SetError(err)
+
+		return
+	}
+
+	sanityCheckRunner.Run()
+}

--- a/command/sanitycheck/sanity_check.go
+++ b/command/sanitycheck/sanity_check.go
@@ -95,5 +95,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	sanityCheckRunner.Run()
+	if err = sanityCheckRunner.Run(); err != nil {
+		outputter.SetError(err)
+	}
 }

--- a/loadtest/sanitycheck/base_sanity_check.go
+++ b/loadtest/sanitycheck/base_sanity_check.go
@@ -134,10 +134,15 @@ func (t *BaseSanityCheckTest) approveNativeERC20(sender *crypto.ECDSAKey,
 }
 
 // waitForEndOfEpoch waits for the end of the current epoch.
-func (t *BaseSanityCheckTest) waitForEpochEnding() (*types.Header, error) {
+func (t *BaseSanityCheckTest) waitForEpochEnding(fromBlock *uint64) (*types.Header, error) {
 	fmt.Println("Waiting for end of epoch")
 
-	currentBlock, err := t.client.GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
+	rpcBlock := jsonrpc.LatestBlockNumber
+	if fromBlock != nil {
+		rpcBlock = jsonrpc.BlockNumber(*fromBlock)
+	}
+
+	currentBlock, err := t.client.GetBlockByNumber(rpcBlock, false)
 	if err != nil {
 		return nil, err
 	}

--- a/loadtest/sanitycheck/base_sanity_check.go
+++ b/loadtest/sanitycheck/base_sanity_check.go
@@ -1,0 +1,168 @@
+package sanitycheck
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/jsonrpc"
+	"github.com/0xPolygon/polygon-edge/txrelayer"
+	"github.com/0xPolygon/polygon-edge/types"
+)
+
+// SanityCheckTest represents a sanity check test.
+type SanityCheckTest interface {
+	Name() string
+	Run() error
+}
+
+// BaseSanityCheckTest represents a base sanity check test
+type BaseSanityCheckTest struct {
+	config *SanityCheckTestConfig
+
+	testAccountKey *crypto.ECDSAKey
+	client         *jsonrpc.EthClient
+
+	txrelayer txrelayer.TxRelayer
+}
+
+// NewBaseSanityCheckTest creates a new BaseSanityCheckTest
+func NewBaseSanityCheckTest(cfg *SanityCheckTestConfig,
+	testAccountKey *crypto.ECDSAKey, client *jsonrpc.EthClient) (*BaseSanityCheckTest, error) {
+	txRelayer, err := txrelayer.NewTxRelayer(
+		txrelayer.WithClient(client),
+		txrelayer.WithReceiptsTimeout(cfg.ReceiptsTimeout),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BaseSanityCheckTest{
+		config:         cfg,
+		client:         client,
+		txrelayer:      txRelayer,
+		testAccountKey: testAccountKey,
+	}, nil
+}
+
+// decodePrivateKey decodes the given private key string.
+func (t *BaseSanityCheckTest) decodePrivateKey(privateKeyRaw string) (*crypto.ECDSAKey, error) {
+	raw, err := hex.DecodeString(privateKeyRaw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode private key string '%s': %w", privateKeyRaw, err)
+	}
+
+	return crypto.NewECDSAKeyFromRawPrivECDSA(raw)
+}
+
+// fundAddress funds native tokens to the given address.
+func (t *BaseSanityCheckTest) fundAddress(address types.Address, amount *big.Int) error {
+	fmt.Println("Funding address", address.String(), "Amount", amount.String())
+
+	s := time.Now().UTC()
+	defer func() {
+		fmt.Println("Funding address", address.String(), "took", time.Since(s))
+	}()
+
+	txRelayer, err := txrelayer.NewTxRelayer(
+		txrelayer.WithClient(t.client),
+		txrelayer.WithReceiptsTimeout(t.config.ReceiptsTimeout),
+	)
+	if err != nil {
+		return err
+	}
+
+	tx := types.NewTx(types.NewLegacyTx(
+		types.WithTo(&address),
+		types.WithFrom(t.testAccountKey.Address()),
+		types.WithValue(amount),
+		types.WithGas(21000),
+	))
+
+	receipt, err := txRelayer.SendTransaction(tx, t.testAccountKey)
+	if err != nil {
+		return err
+	}
+
+	if receipt == nil || receipt.Status != uint64(types.ReceiptSuccess) {
+		return fmt.Errorf("failed to fund native tokens to %s", address)
+	}
+
+	return nil
+}
+
+// CreateApproveERC20Txn sends approve transaction
+// to ERC20 token for spender so that it is able to spend given tokens
+func (t *BaseSanityCheckTest) approveNativeERC20(sender *crypto.ECDSAKey, amount *big.Int, spender types.Address) error {
+	fmt.Println("Approving", amount.String(), "tokens for", spender.String())
+
+	s := time.Now().UTC()
+	defer func() {
+		fmt.Println("Approving", amount.String(), "tokens for", spender.String(), "took", time.Since(s))
+	}()
+
+	approveFnParams := &contractsapi.ApproveRootERC20Fn{
+		Spender: spender,
+		Amount:  amount,
+	}
+
+	input, err := approveFnParams.EncodeAbi()
+	if err != nil {
+		return fmt.Errorf("failed to encode parameters for approve erc20 transaction. error: %w", err)
+	}
+
+	tx := types.NewTx(types.NewDynamicFeeTx(
+		types.WithFrom(types.ZeroAddress),
+		types.WithTo(&contracts.NativeERC20TokenContract),
+		types.WithInput(input)))
+
+	receipt, err := t.txrelayer.SendTransaction(tx, sender)
+	if err != nil {
+		return err
+	}
+
+	if receipt.Status != uint64(types.ReceiptSuccess) {
+		return fmt.Errorf("approve transaction failed on block %d", receipt.BlockNumber)
+	}
+
+	return nil
+}
+
+// waitForEndOfEpoch waits for the end of the current epoch.
+func (t *BaseSanityCheckTest) waitForEpochEnding() (*types.Header, error) {
+	fmt.Println("Waiting for end of epoch")
+
+	currentBlock, err := t.client.GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
+	if err != nil {
+		return nil, err
+	}
+
+	timer := time.NewTimer(2 * time.Minute)
+	ticker := time.NewTicker(2 * time.Second)
+
+	defer func() {
+		timer.Stop()
+		ticker.Stop()
+		fmt.Println("Waiting for end of epoch finished")
+	}()
+
+	for {
+		select {
+		case <-timer.C:
+			return nil, fmt.Errorf("timed out waiting for end of epoch")
+		case <-ticker.C:
+			if currentBlock.Number()%t.config.EpochSize == 0 {
+				return currentBlock.Header, nil
+			}
+
+			currentBlock, err = t.client.GetBlockByNumber(jsonrpc.BlockNumber(currentBlock.Number()+1), false)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+}

--- a/loadtest/sanitycheck/base_sanity_check.go
+++ b/loadtest/sanitycheck/base_sanity_check.go
@@ -97,7 +97,8 @@ func (t *BaseSanityCheckTest) fundAddress(address types.Address, amount *big.Int
 
 // CreateApproveERC20Txn sends approve transaction
 // to ERC20 token for spender so that it is able to spend given tokens
-func (t *BaseSanityCheckTest) approveNativeERC20(sender *crypto.ECDSAKey, amount *big.Int, spender types.Address) error {
+func (t *BaseSanityCheckTest) approveNativeERC20(sender *crypto.ECDSAKey,
+	amount *big.Int, spender types.Address) error {
 	fmt.Println("Approving", amount.String(), "tokens for", spender.String())
 
 	s := time.Now().UTC()
@@ -159,10 +160,16 @@ func (t *BaseSanityCheckTest) waitForEpochEnding() (*types.Header, error) {
 				return currentBlock.Header, nil
 			}
 
-			currentBlock, err = t.client.GetBlockByNumber(jsonrpc.BlockNumber(currentBlock.Number()+1), false)
+			block, err := t.client.GetBlockByNumber(jsonrpc.BlockNumber(currentBlock.Number()+1), false)
 			if err != nil {
 				return nil, err
 			}
+
+			if block == nil {
+				continue
+			}
+
+			currentBlock = block
 		}
 	}
 }

--- a/loadtest/sanitycheck/base_sanity_check.go
+++ b/loadtest/sanitycheck/base_sanity_check.go
@@ -102,7 +102,7 @@ func (t *BaseSanityCheckTest) approveNativeERC20(sender *crypto.ECDSAKey, amount
 
 	s := time.Now().UTC()
 	defer func() {
-		fmt.Println("Approving", amount.String(), "tokens for", spender.String(), "took", time.Since(s))
+		fmt.Println("Approving", amount.String(), "for", spender.String(), "took", time.Since(s))
 	}()
 
 	approveFnParams := &contractsapi.ApproveRootERC20Fn{

--- a/loadtest/sanitycheck/sanity_check_register_validator.go
+++ b/loadtest/sanitycheck/sanity_check_register_validator.go
@@ -1,0 +1,190 @@
+package sanitycheck
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/0xPolygon/polygon-edge/consensus/polybft"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
+	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/jsonrpc"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/umbracle/ethgo"
+)
+
+// RegisterValidatorTest represents a register validator test.
+type RegisterValidatorTest struct {
+	*BaseSanityCheckTest
+}
+
+// NewRegisterValidatorTest creates a new RegisterValidatorTest.
+func NewRegisterValidatorTest(cfg *SanityCheckTestConfig,
+	testAccountKey *crypto.ECDSAKey, client *jsonrpc.EthClient) (*RegisterValidatorTest, error) {
+	baseSanityCheckTest, err := NewBaseSanityCheckTest(cfg, testAccountKey, client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RegisterValidatorTest{
+		BaseSanityCheckTest: baseSanityCheckTest,
+	}, nil
+}
+
+// Name returns the name of the register validator test.
+func (t *RegisterValidatorTest) Name() string {
+	return "Register Validator Test"
+}
+
+// Run runs the register validator test.
+func (t *RegisterValidatorTest) Run() error {
+	printUxSeparator()
+
+	fmt.Println("Running", t.Name())
+	defer fmt.Println("Finished", t.Name())
+
+	fundAmount := ethgo.Ether(2)
+	stakeAmount := ethgo.Ether(1)
+
+	newValidatorAcc, err := wallet.GenerateAccount()
+	if err != nil {
+		return fmt.Errorf("failed to generate new validator key: %w", err)
+	}
+
+	if err := t.fundAddress(newValidatorAcc.Address(), fundAmount); err != nil {
+		return fmt.Errorf("failed to fund new validator address: %w", err)
+	}
+
+	bladeAdminKey, err := t.decodePrivateKey(t.config.ValidatorKeys[0])
+	if err != nil {
+		return err
+	}
+
+	if err := t.whitelistValidators(bladeAdminKey, newValidatorAcc.Address()); err != nil {
+		return fmt.Errorf("failed to whitelist new validator: %w", err)
+	}
+
+	if err := t.registerValidator(newValidatorAcc, stakeAmount); err != nil {
+		return fmt.Errorf("failed to register new validator: %w", err)
+	}
+
+	epochEndingBlock, err := t.waitForEpochEnding()
+	if err != nil {
+		return err
+	}
+
+	extra, err := polybft.GetIbftExtra(epochEndingBlock.ExtraData)
+	if err != nil {
+		return fmt.Errorf("failed to get ibft extra data for epoch ending block. Error: %w", err)
+	}
+
+	fmt.Println("Checking if new validator is added to validator set with its stake")
+
+	if extra.Validators == nil || extra.Validators.IsEmpty() {
+		return fmt.Errorf("validator set delta is empty on an epoch ending block")
+	}
+
+	if !extra.Validators.Added.ContainsAddress(newValidatorAcc.Address()) {
+		return fmt.Errorf("validator %s is not in the added validators", newValidatorAcc.Address())
+	}
+
+	validatorMetaData := extra.Validators.Added.GetValidatorMetadata(newValidatorAcc.Address())
+	if validatorMetaData.VotingPower.Cmp(stakeAmount) != 0 {
+		return fmt.Errorf("voting power of validator %s is incorrect. Expected: %s, Actual: %s",
+			newValidatorAcc.Address(), stakeAmount, validatorMetaData.VotingPower)
+	}
+
+	fmt.Println("Validator", newValidatorAcc.Address(), "is added to the new validator set with correct voting power")
+
+	return nil
+}
+
+// whitelistValidators adds the given validators to the whitelist on StakeManager contract.
+func (t *RegisterValidatorTest) whitelistValidators(bladeAdminKey *crypto.ECDSAKey, validators ...types.Address) error {
+	whitelistFn := contractsapi.WhitelistValidatorsStakeManagerFn{
+		Validators_: validators,
+	}
+
+	encoded, err := whitelistFn.EncodeAbi()
+	if err != nil {
+		return fmt.Errorf("failed to encode whitelist validators data: %w", err)
+	}
+
+	tx := types.NewTx(types.NewLegacyTx(
+		types.WithFrom(bladeAdminKey.Address()),
+		types.WithTo(&contracts.StakeManagerContract),
+		types.WithInput(encoded),
+	))
+
+	receipt, err := t.txrelayer.SendTransaction(tx, bladeAdminKey)
+	if err != nil {
+		return err
+	}
+
+	if receipt.Status == uint64(types.ReceiptFailed) {
+		return fmt.Errorf("whitelist transaction failed on block %d", receipt.BlockNumber)
+	}
+
+	return nil
+}
+
+// registerValidator registers the given validator with the given stake amount.
+// it does the following steps:
+// 1. Approve the stake amount for StakeManager contract.
+// 2. Create KOSK signature.
+// 3. Create RegisterStakeManagerFn and send the transaction.
+func (t *RegisterValidatorTest) registerValidator(validatorAcc *wallet.Account, stakeAmount *big.Int) error {
+	// first we need to approve the stake amount
+	if err := t.approveNativeERC20(validatorAcc.Ecdsa, stakeAmount, contracts.StakeManagerContract); err != nil {
+		return fmt.Errorf("failed to approve stake amount: %w", err)
+	}
+
+	// then we create the KOSK signature
+	chainID, err := t.client.ChainID()
+	if err != nil {
+		return fmt.Errorf("failed to get chain ID: %w", err)
+	}
+
+	koskSignature, err := signer.MakeKOSKSignature(
+		validatorAcc.Bls, validatorAcc.Address(),
+		chainID.Int64(), signer.DomainValidatorSet, contracts.StakeManagerContract)
+	if err != nil {
+		return err
+	}
+
+	// then we create register validator txn and send it
+	sigMarshal, err := koskSignature.ToBigInt()
+	if err != nil {
+		return fmt.Errorf("failed to marshal kosk signature: %w", err)
+	}
+
+	registerFn := &contractsapi.RegisterStakeManagerFn{
+		Signature:   sigMarshal,
+		Pubkey:      validatorAcc.Bls.PublicKey().ToBigInt(),
+		StakeAmount: stakeAmount,
+	}
+
+	encoded, err := registerFn.EncodeAbi()
+	if err != nil {
+		return fmt.Errorf("failed to encode register validator data: %w", err)
+	}
+
+	tx := types.NewTx(types.NewLegacyTx(
+		types.WithFrom(validatorAcc.Address()),
+		types.WithTo(&contracts.StakeManagerContract),
+		types.WithInput(encoded),
+	))
+
+	receipt, err := t.txrelayer.SendTransaction(tx, validatorAcc.Ecdsa)
+	if err != nil {
+		return fmt.Errorf("failed to send register validator transaction: %w", err)
+	}
+
+	if receipt.Status != uint64(types.ReceiptSuccess) {
+		return fmt.Errorf("register validator transaction failed on block %d", receipt.BlockNumber)
+	}
+
+	return nil
+}

--- a/loadtest/sanitycheck/sanity_check_register_validator.go
+++ b/loadtest/sanitycheck/sanity_check_register_validator.go
@@ -39,6 +39,13 @@ func (t *RegisterValidatorTest) Name() string {
 }
 
 // Run runs the register validator test.
+// It does the following steps:
+// 1. Generate a new validator key.
+// 2. Fund the new validator address.
+// 3. Whitelist the new validator.
+// 4. Register the new validator with a stake amount.
+// 5. Wait for the epoch ending block.
+// 6. Check if the new validator is added to the validator set with its stake.
 func (t *RegisterValidatorTest) Run() error {
 	printUxSeparator()
 

--- a/loadtest/sanitycheck/sanity_check_runner.go
+++ b/loadtest/sanitycheck/sanity_check_runner.go
@@ -117,11 +117,17 @@ func registerTests(cfg *SanityCheckTestConfig,
 		return nil, err
 	}
 
+	unstakeAllTest, err := NewUnstakeAllTest(cfg, testAccountKey, client)
+	if err != nil {
+		return nil, err
+	}
+
 	return []SanityCheckTest{
 		stakeTest,
 		unstakeTest,
 		registerValidatorTest,
 		withdrawRewardsTest,
+		unstakeAllTest,
 	}, nil
 }
 

--- a/loadtest/sanitycheck/sanity_check_runner.go
+++ b/loadtest/sanitycheck/sanity_check_runner.go
@@ -161,9 +161,10 @@ func (r *SanityCheckTestRunner) Run() error {
 	}
 
 	printUxSeparator()
-	fmt.Println("Sanity check results:")
 
 	if !r.config.ResultsToJSON {
+		fmt.Println("Sanity check results:")
+
 		for _, result := range results {
 			fmt.Println(result.String())
 		}

--- a/loadtest/sanitycheck/sanity_check_runner.go
+++ b/loadtest/sanitycheck/sanity_check_runner.go
@@ -76,13 +76,19 @@ func NewSanityCheckTestRunner(cfg *SanityCheckTestConfig) (*SanityCheckTestRunne
 
 // registerTests registers the sanity check tests that will be run by the SanityCheckTestRunner.
 func registerTests(cfg *SanityCheckTestConfig, testAccountKey *crypto.ECDSAKey, client *jsonrpc.EthClient) ([]SanityCheckTest, error) {
-	stakeTest, err := NewStakeTest(cfg, testAccountKey, client)
+	// stakeTest, err := NewStakeTest(cfg, testAccountKey, client)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	unsstakeTest, err := NewUnstakeTest(cfg, testAccountKey, client)
 	if err != nil {
 		return nil, err
 	}
 
 	return []SanityCheckTest{
-		stakeTest,
+		//stakeTest,
+		unsstakeTest,
 	}, nil
 }
 

--- a/loadtest/sanitycheck/sanity_check_runner.go
+++ b/loadtest/sanitycheck/sanity_check_runner.go
@@ -1,0 +1,121 @@
+package sanitycheck
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/jsonrpc"
+	"github.com/umbracle/ethgo/wallet"
+)
+
+const (
+	passed      = "PASSED"
+	failed      = "FAILED"
+	uxSeparator = "============================================================="
+)
+
+// SanityCheckTestConfig represents the configuration for sanity check tests.
+type SanityCheckTestConfig struct {
+	Mnemonnic string // Mnemonnic is the mnemonic phrase used for account funding.
+
+	JSONRPCUrl      string        // JSONRPCUrl is the URL of the JSON-RPC server.
+	ReceiptsTimeout time.Duration // ReceiptsTimeout is the timeout for waiting for transaction receipts.
+
+	ValidatorKeys []string // ValidatorKeys is the list of private keys of validators.
+
+	ResultsToJSON bool // ResultsToJSON indicates whether the results should be written in JSON format.
+
+	EpochSize uint64 // EpochSize is the size of the epoch.
+}
+
+// SanityCheckTestRunner represents a runner for sanity check tests on a test network
+type SanityCheckTestRunner struct {
+	config *SanityCheckTestConfig
+
+	testAccountKey *crypto.ECDSAKey
+	client         *jsonrpc.EthClient
+
+	tests []SanityCheckTest
+}
+
+// NewSanityCheckTestRunner creates a new SanityCheckTestRunner
+func NewSanityCheckTestRunner(cfg *SanityCheckTestConfig) (*SanityCheckTestRunner, error) {
+	key, err := wallet.NewWalletFromMnemonic(cfg.Mnemonnic)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := key.MarshallPrivateKey()
+	if err != nil {
+		return nil, err
+	}
+
+	ecdsaKey, err := crypto.NewECDSAKeyFromRawPrivECDSA(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := jsonrpc.NewEthClient(cfg.JSONRPCUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	tests, err := registerTests(cfg, ecdsaKey, client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SanityCheckTestRunner{
+		config:         cfg,
+		tests:          tests,
+		client:         client,
+		testAccountKey: ecdsaKey,
+	}, nil
+}
+
+// registerTests registers the sanity check tests that will be run by the SanityCheckTestRunner.
+func registerTests(cfg *SanityCheckTestConfig, testAccountKey *crypto.ECDSAKey, client *jsonrpc.EthClient) ([]SanityCheckTest, error) {
+	stakeTest, err := NewStakeTest(cfg, testAccountKey, client)
+	if err != nil {
+		return nil, err
+	}
+
+	return []SanityCheckTest{
+		stakeTest,
+	}, nil
+}
+
+// Close closes the BaseLoadTestRunner by closing the underlying client connection.
+// It returns an error if there was a problem closing the connection.
+func (r *SanityCheckTestRunner) Close() error {
+	return r.client.Close()
+}
+
+// Run executes the sanity check test based on the provided SanityCheckTestConfig.
+func (r *SanityCheckTestRunner) Run() {
+	fmt.Println("Running sanity check tests")
+
+	results := make([]string, 0, len(r.tests))
+
+	for _, test := range r.tests {
+		result := passed
+		t := time.Now().UTC()
+
+		if err := test.Run(); err != nil {
+			result = fmt.Sprintf("%s: %v", failed, err)
+		}
+
+		results = append(results, fmt.Sprintf("%s: Execution time: %s. Result: %s", test.Name(), time.Since(t), result))
+	}
+
+	printUxSeparator()
+	fmt.Println("Sanity check results:")
+	for _, result := range results {
+		fmt.Println(result)
+	}
+}
+
+func printUxSeparator() {
+	fmt.Println(uxSeparator)
+}

--- a/loadtest/sanitycheck/sanity_check_runner.go
+++ b/loadtest/sanitycheck/sanity_check_runner.go
@@ -102,14 +102,20 @@ func registerTests(cfg *SanityCheckTestConfig,
 		return nil, err
 	}
 
-	unsstakeTest, err := NewUnstakeTest(cfg, testAccountKey, client)
+	unstakeTest, err := NewUnstakeTest(cfg, testAccountKey, client)
+	if err != nil {
+		return nil, err
+	}
+
+	registerValidatorTest, err := NewRegisterValidatorTest(cfg, testAccountKey, client)
 	if err != nil {
 		return nil, err
 	}
 
 	return []SanityCheckTest{
 		stakeTest,
-		unsstakeTest,
+		unstakeTest,
+		registerValidatorTest,
 	}, nil
 }
 

--- a/loadtest/sanitycheck/sanity_check_runner.go
+++ b/loadtest/sanitycheck/sanity_check_runner.go
@@ -17,7 +17,7 @@ const (
 
 // SanityCheckTestConfig represents the configuration for sanity check tests.
 type SanityCheckTestConfig struct {
-	Mnemonnic string // Mnemonnic is the mnemonic phrase used for account funding.
+	Mnemonic string // Mnemonnic is the mnemonic phrase used for account funding.
 
 	JSONRPCUrl      string        // JSONRPCUrl is the URL of the JSON-RPC server.
 	ReceiptsTimeout time.Duration // ReceiptsTimeout is the timeout for waiting for transaction receipts.
@@ -41,7 +41,7 @@ type SanityCheckTestRunner struct {
 
 // NewSanityCheckTestRunner creates a new SanityCheckTestRunner
 func NewSanityCheckTestRunner(cfg *SanityCheckTestConfig) (*SanityCheckTestRunner, error) {
-	key, err := wallet.NewWalletFromMnemonic(cfg.Mnemonnic)
+	key, err := wallet.NewWalletFromMnemonic(cfg.Mnemonic)
 	if err != nil {
 		return nil, err
 	}
@@ -75,11 +75,12 @@ func NewSanityCheckTestRunner(cfg *SanityCheckTestConfig) (*SanityCheckTestRunne
 }
 
 // registerTests registers the sanity check tests that will be run by the SanityCheckTestRunner.
-func registerTests(cfg *SanityCheckTestConfig, testAccountKey *crypto.ECDSAKey, client *jsonrpc.EthClient) ([]SanityCheckTest, error) {
-	// stakeTest, err := NewStakeTest(cfg, testAccountKey, client)
-	// if err != nil {
-	// 	return nil, err
-	// }
+func registerTests(cfg *SanityCheckTestConfig,
+	testAccountKey *crypto.ECDSAKey, client *jsonrpc.EthClient) ([]SanityCheckTest, error) {
+	stakeTest, err := NewStakeTest(cfg, testAccountKey, client)
+	if err != nil {
+		return nil, err
+	}
 
 	unsstakeTest, err := NewUnstakeTest(cfg, testAccountKey, client)
 	if err != nil {
@@ -87,7 +88,7 @@ func registerTests(cfg *SanityCheckTestConfig, testAccountKey *crypto.ECDSAKey, 
 	}
 
 	return []SanityCheckTest{
-		//stakeTest,
+		stakeTest,
 		unsstakeTest,
 	}, nil
 }
@@ -117,6 +118,7 @@ func (r *SanityCheckTestRunner) Run() {
 
 	printUxSeparator()
 	fmt.Println("Sanity check results:")
+
 	for _, result := range results {
 		fmt.Println(result)
 	}

--- a/loadtest/sanitycheck/sanity_check_runner.go
+++ b/loadtest/sanitycheck/sanity_check_runner.go
@@ -1,10 +1,12 @@
 package sanitycheck
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/jsonrpc"
 	"github.com/umbracle/ethgo/wallet"
 )
@@ -100,7 +102,7 @@ func (r *SanityCheckTestRunner) Close() error {
 }
 
 // Run executes the sanity check test based on the provided SanityCheckTestConfig.
-func (r *SanityCheckTestRunner) Run() {
+func (r *SanityCheckTestRunner) Run() error {
 	fmt.Println("Running sanity check tests")
 
 	results := make([]string, 0, len(r.tests))
@@ -119,9 +121,27 @@ func (r *SanityCheckTestRunner) Run() {
 	printUxSeparator()
 	fmt.Println("Sanity check results:")
 
-	for _, result := range results {
-		fmt.Println(result)
+	if !r.config.ResultsToJSON {
+		for _, result := range results {
+			fmt.Println(result)
+		}
+	} else {
+		jsonData, err := json.Marshal(results)
+		if err != nil {
+			return err
+		}
+
+		fileName := "./sanity_check_results.json"
+
+		err = common.SaveFileSafe(fileName, jsonData, 0600)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("Results saved to JSON file", fileName)
 	}
+
+	return nil
 }
 
 func printUxSeparator() {

--- a/loadtest/sanitycheck/sanity_check_runner.go
+++ b/loadtest/sanitycheck/sanity_check_runner.go
@@ -112,10 +112,16 @@ func registerTests(cfg *SanityCheckTestConfig,
 		return nil, err
 	}
 
+	withdrawRewardsTest, err := NewWithdrawRewardsTest(cfg, testAccountKey, client)
+	if err != nil {
+		return nil, err
+	}
+
 	return []SanityCheckTest{
 		stakeTest,
 		unstakeTest,
 		registerValidatorTest,
+		withdrawRewardsTest,
 	}, nil
 }
 

--- a/loadtest/sanitycheck/sanity_check_stake.go
+++ b/loadtest/sanitycheck/sanity_check_stake.go
@@ -39,6 +39,11 @@ func (t *StakeTest) Name() string {
 }
 
 // Run runs the stake test.
+// It does the following steps:
+// 1. Fund the validator address.
+// 2. Stake the given amount for the validator.
+// 3. Wait for the epoch ending block.
+// 4. Check if the correct validator stake is in the validator set delta.
 func (t *StakeTest) Run() error {
 	printUxSeparator()
 

--- a/loadtest/sanitycheck/sanity_check_stake.go
+++ b/loadtest/sanitycheck/sanity_check_stake.go
@@ -99,9 +99,10 @@ func (t *StakeTest) Run() error {
 		return fmt.Errorf("validator %s is not in the updated validator set", validatorKey.Address())
 	}
 
-	if extra.Validators.Updated.GetValidatorMetadata(validatorKey.Address()).VotingPower.Cmp(currentStake) != 0 {
-		return fmt.Errorf("voting power of validator %s is incorrect. Expected: %s, Actual: %s", validatorKey.Address(),
-			currentStake, extra.Validators.Updated.GetValidatorMetadata(validatorKey.Address()).VotingPower)
+	validatorMetaData := extra.Validators.Updated.GetValidatorMetadata(validatorKey.Address())
+	if validatorMetaData.VotingPower.Cmp(currentStake) != 0 {
+		return fmt.Errorf("voting power of validator %s is incorrect. Expected: %s, Actual: %s",
+			validatorKey.Address(), currentStake, validatorMetaData.VotingPower)
 	}
 
 	fmt.Println("Validator", validatorKey.Address(), "is in the updated validator set with correct voting power")

--- a/loadtest/sanitycheck/sanity_check_stake.go
+++ b/loadtest/sanitycheck/sanity_check_stake.go
@@ -84,7 +84,7 @@ func (t *StakeTest) Run() error {
 		return fmt.Errorf("stake amount is incorrect. Expected: %s, Actual: %s", expectedStake, currentStake)
 	}
 
-	epochEndingBlock, err := t.waitForEpochEnding()
+	epochEndingBlock, err := t.waitForEpochEnding(nil)
 	if err != nil {
 		return err
 	}

--- a/loadtest/sanitycheck/sanity_check_stake.go
+++ b/loadtest/sanitycheck/sanity_check_stake.go
@@ -1,0 +1,166 @@
+package sanitycheck
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/0xPolygon/polygon-edge/consensus/polybft"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/helper/common"
+	"github.com/0xPolygon/polygon-edge/jsonrpc"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/umbracle/ethgo"
+)
+
+// StakeTest represents a stake test.
+type StakeTest struct {
+	*BaseSanityCheckTest
+}
+
+// NewStakeTest creates a new StakeTest.
+func NewStakeTest(cfg *SanityCheckTestConfig,
+	testAccountKey *crypto.ECDSAKey, client *jsonrpc.EthClient) (*StakeTest, error) {
+	base, err := NewBaseSanityCheckTest(cfg, testAccountKey, client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &StakeTest{
+		BaseSanityCheckTest: base,
+	}, nil
+}
+
+// Name returns the name of the stake test.
+func (t *StakeTest) Name() string {
+	return "Stake Test"
+}
+
+// Run runs the stake test.
+func (t *StakeTest) Run() error {
+	printUxSeparator()
+	fmt.Println("Running", t.Name())
+	defer fmt.Println("Finished", t.Name())
+
+	validatorKey, err := t.decodePrivateKey(t.config.ValidatorKeys[0])
+	if err != nil {
+		return err
+	}
+
+	amount := ethgo.Ether(1)
+
+	if err := t.fundAddress(validatorKey.Address(), ethgo.Ether(1)); err != nil {
+		return err
+	}
+
+	previousStake, err := t.getStake(validatorKey.Address())
+	if err != nil {
+		return fmt.Errorf("failed to get stake of validator: %s. Error: %w", validatorKey.Address(), err)
+	}
+
+	fmt.Println("Stake of validator", validatorKey.Address(), "before staking:", previousStake)
+
+	if err := t.stake(validatorKey, amount); err != nil {
+		return fmt.Errorf("failed to stake for validator: %s. Error: %w", validatorKey.Address(), err)
+	}
+
+	currentStake, err := t.getStake(validatorKey.Address())
+	if err != nil {
+		return fmt.Errorf("failed to get new stake of validator: %s. Error: %w", validatorKey.Address(), err)
+	}
+
+	fmt.Println("Stake of validator", validatorKey.Address(), "after staking:", currentStake)
+
+	if currentStake.Cmp(previousStake.Add(previousStake, amount)) != 0 {
+		return fmt.Errorf("stake amount is incorrect. Expected: %s, Actual: %s", previousStake.Add(previousStake, amount), currentStake)
+	}
+
+	epochEndingBlock, err := t.waitForEpochEnding()
+	if err != nil {
+		return err
+	}
+
+	extra, err := polybft.GetIbftExtra(epochEndingBlock.ExtraData)
+	if err != nil {
+		return fmt.Errorf("failed to get ibft extra data for epoch ending block. Error: %w", err)
+	}
+
+	fmt.Println("Checking if correct validator stake is in validator set delta")
+
+	if extra.Validators == nil || extra.Validators.IsEmpty() {
+		return fmt.Errorf("validator set delta is empty on an epoch ending block")
+	}
+
+	if !extra.Validators.Updated.ContainsAddress(validatorKey.Address()) {
+		return fmt.Errorf("validator %s is not in the updated validator set", validatorKey.Address())
+	}
+
+	if extra.Validators.Updated.GetValidatorMetadata(validatorKey.Address()).VotingPower.Cmp(currentStake) != 0 {
+		return fmt.Errorf("voting power of validator %s is incorrect. Expected: %s, Actual: %s", validatorKey.Address(),
+			currentStake, extra.Validators.Updated.GetValidatorMetadata(validatorKey.Address()).VotingPower)
+	}
+
+	fmt.Println("Validator", validatorKey.Address(), "is in the updated validator set with correct voting power")
+
+	return nil
+}
+
+// stake stakes the given amount for the given validator.
+func (t *StakeTest) stake(validatorKey *crypto.ECDSAKey, amount *big.Int) error {
+	if err := t.approveNativeERC20(validatorKey, amount, contracts.StakeManagerContract); err != nil {
+		return err
+	}
+
+	fmt.Println("Staking for validator", validatorKey.Address(), "Amount", amount.String())
+
+	s := time.Now().UTC()
+	defer func() {
+		fmt.Println("Staking for validator", validatorKey.Address(), "took", time.Since(s))
+	}()
+
+	stakeFn := &contractsapi.StakeStakeManagerFn{
+		Amount: amount,
+	}
+
+	encode, err := stakeFn.EncodeAbi()
+	if err != nil {
+		return err
+	}
+
+	tx := types.NewTx(types.NewLegacyTx(types.WithFrom(
+		validatorKey.Address()),
+		types.WithTo(&contracts.StakeManagerContract),
+		types.WithInput(encode)))
+
+	receipt, err := t.txrelayer.SendTransaction(tx, validatorKey)
+	if err != nil {
+		return err
+	}
+
+	if receipt.Status == uint64(types.ReceiptFailed) {
+		return fmt.Errorf("stake transaction failed on block %d", receipt.BlockNumber)
+	}
+
+	return nil
+}
+
+// getStake returns the stake of the given validator on the StakeManager contract.
+func (t *StakeTest) getStake(address types.Address) (*big.Int, error) {
+	stakeOfFn := &contractsapi.StakeOfStakeManagerFn{
+		Validator: address,
+	}
+
+	encode, err := stakeOfFn.EncodeAbi()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := t.txrelayer.Call(t.testAccountKey.Address(), contracts.StakeManagerContract, encode)
+	if err != nil {
+		return nil, err
+	}
+
+	return common.ParseUint256orHex(&response)
+}

--- a/loadtest/sanitycheck/sanity_check_test.go
+++ b/loadtest/sanitycheck/sanity_check_test.go
@@ -6,10 +6,10 @@ import (
 )
 
 func TestSanityCheck(t *testing.T) {
-	//t.Skip("this is only added for the sake of the example and running it in local")
+	t.Skip("this is only added for the sake of the example and running it in local")
 
 	config := &SanityCheckTestConfig{
-		Mnemonnic:       "code code code code code code code code code code code quality",
+		Mnemonic:        "code code code code code code code code code code code quality",
 		JSONRPCUrl:      "http://localhost:10002",
 		ReceiptsTimeout: time.Minute,
 		ValidatorKeys:   []string{"1a7626c5a1d89030f300ca5f63eecac3bae3e56f14033ea2d9ad471e7c93020e"},

--- a/loadtest/sanitycheck/sanity_check_test.go
+++ b/loadtest/sanitycheck/sanity_check_test.go
@@ -3,6 +3,8 @@ package sanitycheck
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSanityCheck(t *testing.T) {
@@ -23,5 +25,5 @@ func TestSanityCheck(t *testing.T) {
 
 	defer runner.Close()
 
-	runner.Run()
+	require.NoError(t, runner.Run())
 }

--- a/loadtest/sanitycheck/sanity_check_test.go
+++ b/loadtest/sanitycheck/sanity_check_test.go
@@ -1,0 +1,27 @@
+package sanitycheck
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSanityCheck(t *testing.T) {
+	t.Skip("this is only added for the sake of the example and running it in local")
+
+	config := &SanityCheckTestConfig{
+		Mnemonnic:       "code code code code code code code code code code code quality",
+		JSONRPCUrl:      "http://localhost:10002",
+		ReceiptsTimeout: time.Minute,
+		ValidatorKeys:   []string{"1a7626c5a1d89030f300ca5f63eecac3bae3e56f14033ea2d9ad471e7c93020e"},
+		EpochSize:       10,
+	}
+
+	runner, err := NewSanityCheckTestRunner(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer runner.Close()
+
+	runner.Run()
+}

--- a/loadtest/sanitycheck/sanity_check_test.go
+++ b/loadtest/sanitycheck/sanity_check_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestSanityCheck(t *testing.T) {
-	t.Skip("this is only added for the sake of the example and running it in local")
+	//t.Skip("this is only added for the sake of the example and running it in local")
 
 	config := &SanityCheckTestConfig{
 		Mnemonnic:       "code code code code code code code code code code code quality",

--- a/loadtest/sanitycheck/sanity_check_unstake.go
+++ b/loadtest/sanitycheck/sanity_check_unstake.go
@@ -14,7 +14,7 @@ import (
 	"github.com/umbracle/ethgo"
 )
 
-// StakeTest represents a stake test.
+// UnstakeTest represents an unstake test.
 type UnstakeTest struct {
 	*StakeTest
 }
@@ -108,7 +108,7 @@ func (t *UnstakeTest) Run() error {
 	return nil
 }
 
-// stake stakes the given amount for the given validator.
+// unstake unstakes the given amount for the given validator.
 func (t *UnstakeTest) unstake(validatorKey *crypto.ECDSAKey, amount *big.Int) error {
 	fmt.Println("Unstaking for validator", validatorKey.Address(), "Amount", amount.String())
 

--- a/loadtest/sanitycheck/sanity_check_unstake.go
+++ b/loadtest/sanitycheck/sanity_check_unstake.go
@@ -67,7 +67,8 @@ func (t *UnstakeTest) Run() error {
 
 	fmt.Println("Stake of validator", validatorKey.Address(), "before unstaking:", previousStake)
 
-	if _, err := t.unstake(validatorKey, amountToUnstake); err != nil {
+	blockNum, err := t.unstake(validatorKey, amountToUnstake)
+	if err != nil {
 		return fmt.Errorf("failed to stake for validator: %s. Error: %w", validatorKey.Address(), err)
 	}
 
@@ -83,7 +84,7 @@ func (t *UnstakeTest) Run() error {
 		return fmt.Errorf("stake amount is incorrect. Expected: %s, Actual: %s", expectedStake, currentStake)
 	}
 
-	epochEndingBlock, err := t.waitForEpochEnding(nil)
+	epochEndingBlock, err := t.waitForEpochEnding(&blockNum)
 	if err != nil {
 		return err
 	}

--- a/loadtest/sanitycheck/sanity_check_unstake.go
+++ b/loadtest/sanitycheck/sanity_check_unstake.go
@@ -98,9 +98,10 @@ func (t *UnstakeTest) Run() error {
 		return fmt.Errorf("validator %s is not in the updated validator set", validatorKey.Address())
 	}
 
-	if extra.Validators.Updated.GetValidatorMetadata(validatorKey.Address()).VotingPower.Cmp(currentStake) != 0 {
-		return fmt.Errorf("voting power of validator %s is incorrect. Expected: %s, Actual: %s", validatorKey.Address(),
-			currentStake, extra.Validators.Updated.GetValidatorMetadata(validatorKey.Address()).VotingPower)
+	validatorMetaData := extra.Validators.Updated.GetValidatorMetadata(validatorKey.Address())
+	if validatorMetaData.VotingPower.Cmp(currentStake) != 0 {
+		return fmt.Errorf("voting power of validator %s is incorrect. Expected: %s, Actual: %s",
+			validatorKey.Address(), currentStake, validatorMetaData.VotingPower)
 	}
 
 	fmt.Println("Validator", validatorKey.Address(), "is in the updated validator set with correct voting power")
@@ -126,8 +127,8 @@ func (t *UnstakeTest) unstake(validatorKey *crypto.ECDSAKey, amount *big.Int) er
 		return err
 	}
 
-	tx := types.NewTx(types.NewLegacyTx(types.WithFrom(
-		validatorKey.Address()),
+	tx := types.NewTx(types.NewLegacyTx(
+		types.WithFrom(validatorKey.Address()),
 		types.WithTo(&contracts.StakeManagerContract),
 		types.WithInput(encoded)))
 

--- a/loadtest/sanitycheck/sanity_check_unstake.go
+++ b/loadtest/sanitycheck/sanity_check_unstake.go
@@ -38,6 +38,11 @@ func (t *UnstakeTest) Name() string {
 }
 
 // Run runs the unstake test.
+// It does the following steps:
+// 1. Fund the validator address.
+// 2. Unstake the given amount for the validator.
+// 3. Wait for the epoch ending block.
+// 4. Check if the correct validator stake is in the validator set delta.
 func (t *UnstakeTest) Run() error {
 	printUxSeparator()
 

--- a/loadtest/sanitycheck/sanity_check_unstake_all.go
+++ b/loadtest/sanitycheck/sanity_check_unstake_all.go
@@ -1,0 +1,97 @@
+package sanitycheck
+
+import (
+	"fmt"
+
+	"github.com/0xPolygon/polygon-edge/consensus/polybft"
+	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/jsonrpc"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/umbracle/ethgo"
+)
+
+// UnstakeAllTest is a test that unstakes all the stake of a validator
+type UnstakeAllTest struct {
+	*UnstakeTest
+	*RegisterValidatorTest
+}
+
+// NewUnstakeAllTest creates a new UnstakeAllTest
+func NewUnstakeAllTest(cfg *SanityCheckTestConfig,
+	testAccountKey *crypto.ECDSAKey, client *jsonrpc.EthClient) (*UnstakeAllTest, error) {
+	unstakeTest, err := NewUnstakeTest(cfg, testAccountKey, client)
+	if err != nil {
+		return nil, err
+	}
+
+	registerValidatorTest, err := NewRegisterValidatorTest(cfg, testAccountKey, client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UnstakeAllTest{
+		UnstakeTest:           unstakeTest,
+		RegisterValidatorTest: registerValidatorTest,
+	}, nil
+}
+
+// Name returns the name of the unstake all test
+func (t *UnstakeAllTest) Name() string {
+	return "Unstake All Test"
+}
+
+// Name returns the name of the unstake all test
+// It does the following steps:
+// 1. Register a new validator.
+// 2. Unstake all the stake of the validator.
+// 3. Wait for the epoch ending block.
+// 4. Check if the validator is removed from the validator set.
+func (t *UnstakeAllTest) Run() error {
+	printUxSeparator()
+
+	fmt.Println("Running", t.Name())
+	defer fmt.Println("Finished", t.Name())
+
+	validatorAcc, err := t.RegisterValidatorTest.runTest()
+	if err != nil {
+		return err
+	}
+
+	blockNum, err := t.UnstakeTest.unstake(validatorAcc.Ecdsa, ethgo.Ether(1))
+	if err != nil {
+		return err
+	}
+
+	var epochEndingBlock *types.Header
+
+	if blockNum%t.config.EpochSize != 0 {
+		epochEndingBlock, err = t.waitForEpochEnding(&blockNum)
+		if err != nil {
+			return err
+		}
+	} else {
+		epochEndingBlock, err = t.client.GetHeaderByNumber(jsonrpc.BlockNumber(blockNum))
+		if err != nil {
+			return err
+		}
+	}
+
+	extra, err := polybft.GetIbftExtra(epochEndingBlock.ExtraData)
+	if err != nil {
+		return fmt.Errorf("failed to get ibft extra data for epoch ending block. Error: %w", err)
+	}
+
+	fmt.Println("Checking if validator is removed from validator set since it unstaked all")
+
+	if extra.Validators == nil || extra.Validators.IsEmpty() {
+		return fmt.Errorf("validator set delta is empty on an epoch ending block")
+	}
+
+	if len(extra.Validators.Removed) != 1 {
+		return fmt.Errorf("expected 1 validator to be removed from the validator set, got %d", len(extra.Validators.Removed))
+	}
+
+	fmt.Println("Validator", validatorAcc.Address(), "is removed from the validator set")
+
+	return nil
+}

--- a/loadtest/sanitycheck/sanity_check_withdraw_rewards.go
+++ b/loadtest/sanitycheck/sanity_check_withdraw_rewards.go
@@ -60,7 +60,7 @@ func (t *WithdrawRewardsTest) Run() error {
 	}
 
 	// lets wait for one epoch so that there are some rewards accumulated
-	_, err = t.waitForEpochEnding()
+	_, err = t.waitForEpochEnding(nil)
 	if err != nil {
 		return err
 	}

--- a/loadtest/sanitycheck/sanity_check_withdraw_rewards.go
+++ b/loadtest/sanitycheck/sanity_check_withdraw_rewards.go
@@ -1,0 +1,138 @@
+package sanitycheck
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/helper/common"
+	"github.com/0xPolygon/polygon-edge/jsonrpc"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/umbracle/ethgo"
+)
+
+// WithdrawRewardsTest represents a withdraw rewards test.
+type WithdrawRewardsTest struct {
+	*BaseSanityCheckTest
+}
+
+// NewWithdrawRewardsTest creates a new WithdrawRewardsTest.
+func NewWithdrawRewardsTest(cfg *SanityCheckTestConfig,
+	testAccountKey *crypto.ECDSAKey, client *jsonrpc.EthClient) (*WithdrawRewardsTest, error) {
+	base, err := NewBaseSanityCheckTest(cfg, testAccountKey, client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &WithdrawRewardsTest{
+		BaseSanityCheckTest: base,
+	}, nil
+}
+
+// Name returns the name of the withdraw rewards test.
+func (t *WithdrawRewardsTest) Name() string {
+	return "Withdraw Rewards Test"
+}
+
+// Run runs the withdraw rewards test.
+func (t *WithdrawRewardsTest) Run() error {
+	printUxSeparator()
+
+	fmt.Println("Running", t.Name())
+	defer fmt.Println("Finished", t.Name())
+
+	validatorKey, err := t.decodePrivateKey(t.config.ValidatorKeys[0])
+	if err != nil {
+		return err
+	}
+
+	if err := t.fundAddress(validatorKey.Address(), ethgo.Ether(1)); err != nil {
+		return err
+	}
+
+	// lets wait for one epoch so that there are some rewards accumulated
+	_, err = t.waitForEpochEnding()
+	if err != nil {
+		return err
+	}
+
+	pendingRewardsBefore, err := t.getPendingRewards(validatorKey.Address())
+	if err != nil {
+		return fmt.Errorf("failed to get pending rewards: %w", err)
+	}
+
+	fmt.Println("Pending rewards for validator before withdrawal", validatorKey.Address(), pendingRewardsBefore)
+
+	if pendingRewardsBefore.Cmp(big.NewInt(0)) == 0 {
+		return fmt.Errorf("no pending rewards for validator: %s", validatorKey.Address())
+	}
+
+	if err := t.withdrawRewards(validatorKey); err != nil {
+		return fmt.Errorf("failed to withdraw rewards: %w", err)
+	}
+
+	// check if the pending rewards are zero after withdrawing
+	pendingRewardsAfter, err := t.getPendingRewards(validatorKey.Address())
+	if err != nil {
+		return fmt.Errorf("failed to get pending rewards: %w", err)
+	}
+
+	fmt.Println("Pending rewards for validator after withdrawal", validatorKey.Address(), pendingRewardsAfter)
+
+	// check if the pending rewards after withdrawing are less than before
+	// we do not check if they are 0 because epoch ending block can arrive before this check,
+	// and the validator can get new rewards
+	if pendingRewardsAfter.Cmp(pendingRewardsBefore) >= 0 {
+		return fmt.Errorf("pending rewards after withdrawing are not less than before: %d < %d",
+			pendingRewardsAfter, pendingRewardsBefore)
+	}
+
+	return nil
+}
+
+// withdrawRewards withdraws the pending rewards for the given validator.
+func (t *WithdrawRewardsTest) withdrawRewards(validatorKey *crypto.ECDSAKey) error {
+	encoded, err := contractsapi.EpochManager.Abi.Methods["withdrawReward"].Encode([]interface{}{})
+	if err != nil {
+		return fmt.Errorf("failed to encode withdraw rewards function: %w", err)
+	}
+
+	tx := types.NewTx(types.NewLegacyTx(
+		types.WithFrom(validatorKey.Address()),
+		types.WithTo(&contracts.EpochManagerContract),
+		types.WithInput(encoded),
+	))
+
+	receipt, err := t.txrelayer.SendTransaction(tx, validatorKey)
+	if err != nil {
+		return fmt.Errorf("failed to send withdraw rewards transaction: %w", err)
+	}
+
+	if receipt.Status != uint64(types.ReceiptSuccess) {
+		return fmt.Errorf("withdraw rewards transaction failed on block: %d", receipt.BlockNumber)
+	}
+
+	return nil
+}
+
+// getPendingRewards returns the pending rewards for the given validator.
+func (t *WithdrawRewardsTest) getPendingRewards(validatorAddr types.Address) (*big.Int, error) {
+	encoded, err := contractsapi.EpochManager.Abi.Methods["pendingRewards"].Encode([]interface{}{validatorAddr})
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode pending rewards function: %w", err)
+	}
+
+	response, err := t.txrelayer.Call(validatorAddr, contracts.EpochManagerContract, encoded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call pending rewards function: %w", err)
+	}
+
+	amount, err := common.ParseUint256orHex(&response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pending rewards: %w", err)
+	}
+
+	return amount, nil
+}

--- a/loadtest/sanitycheck/sanity_check_withdraw_rewards.go
+++ b/loadtest/sanitycheck/sanity_check_withdraw_rewards.go
@@ -37,6 +37,13 @@ func (t *WithdrawRewardsTest) Name() string {
 }
 
 // Run runs the withdraw rewards test.
+// It does the following:
+// 1. Funds the validator account.
+// 2. Waits for one epoch.
+// 3. Gets the pending rewards for the validator.
+// 4. Withdraws the rewards.
+// 5. Gets the pending rewards for the validator again.
+// 6. Checks if the pending rewards after withdrawing are less than before.
 func (t *WithdrawRewardsTest) Run() error {
 	printUxSeparator()
 

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -796,6 +796,9 @@ func TestSubscribe(t *testing.T) {
 		// wait for ctx to close
 		<-ctx.Done()
 
+		// since Subscribe routine also needs to process ctx Done we have to wait a little bit
+		time.Sleep(100 * time.Millisecond)
+
 		server.EmitEvent(event)
 
 		_, received := waitForEvent(t, eventCh, time.Second*5)
@@ -819,6 +822,9 @@ func TestSubscribe(t *testing.T) {
 
 		// wait for server to close
 		<-server.closeCh
+
+		// since Subscribe routine needs to process closeCh we have to wait a little bit
+		time.Sleep(100 * time.Millisecond)
 
 		server.EmitEvent(event)
 

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -63,7 +63,8 @@ function createGenesis() {
     --premine 0x85da99c8a7c2c95964c8efd687e95e632fc533d6 \
     --premine 0x0000000000000000000000000000000000000000 \
     --epoch-size 10 \
-    --reward-wallet 0xDEADBEEF:1000000 \
+    --epoch-reward 1000000000 \
+    --reward-wallet 0xDEADBEEF \
     --native-token-config "Blade:BLADE:18:true" \
     --blade-admin $address1 \
     --proxy-contracts-admin 0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed \

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1820,6 +1820,8 @@ func TestResetAccount(t *testing.T) {
 						addr1: test.newNonce,
 					})
 					pool.handlePromoteRequest(<-pool.promoteReqCh)
+					// wait for resetAccounts routine to execute before asserts
+					time.Sleep(100 * time.Millisecond)
 				} else {
 					pool.resetAccounts(map[types.Address]uint64{
 						addr1: test.newNonce,

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -3708,13 +3708,16 @@ func TestBatchTx_SingleAccount(t *testing.T) {
 	subscription := pool.eventManager.subscribe([]proto.EventType{proto.EventType_ENQUEUED, proto.EventType_PROMOTED})
 
 	txHashMap := map[types.Hash]struct{}{}
-	// mutex for txHashMap
-	mux := &sync.RWMutex{}
-	counter := uint64(0)
-	enqueuedCount := 0
-	promotedCount := 0
-	ev := (*proto.TxPoolEvent)(nil)
-	wg := sync.WaitGroup{}
+
+	var (
+		mux           sync.RWMutex // mutex for txHashMap
+		counter       uint64
+		enqueuedCount int
+		promotedCount int
+		ev            *proto.TxPoolEvent
+		wg            sync.WaitGroup
+	)
+
 	wg.Add(1)
 
 	// wait for all the submitted transactions to be promoted
@@ -3731,9 +3734,9 @@ func TestBatchTx_SingleAccount(t *testing.T) {
 			}
 
 			// check if valid transaction hash
-			mux.Lock()
+			mux.RLock()
 			_, hashExists := txHashMap[types.StringToHash(ev.TxHash)]
-			mux.Unlock()
+			mux.RUnlock()
 
 			assert.True(t, hashExists)
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -3710,13 +3710,9 @@ func TestBatchTx_SingleAccount(t *testing.T) {
 	mux := &sync.RWMutex{}
 	counter := uint64(0)
 
-	wg := sync.WaitGroup{}
-	wg.Add(int(defaultMaxAccountEnqueued))
-
 	// run max number of addTx concurrently
 	for i := 0; i < int(defaultMaxAccountEnqueued); i++ {
 		go func(i uint64) {
-			defer wg.Done()
 			tx := newTx(addr, i, 1, types.LegacyTxType)
 
 			tx.ComputeHash()
@@ -3737,14 +3733,11 @@ func TestBatchTx_SingleAccount(t *testing.T) {
 	promotedCount := 0
 	ev := (*proto.TxPoolEvent)(nil)
 
-	// wait for all txs to be sent
-	wg.Wait()
-
 	// wait for all the submitted transactions to be promoted
 	for {
 		select {
 		case ev = <-subscription.subscriptionChannel:
-		case <-time.After(time.Second * 3):
+		case <-time.After(time.Second * 6):
 			t.Fatalf("timeout. processed: %d/%d and %d/%d. Added: %d",
 				enqueuedCount, defaultMaxAccountEnqueued, promotedCount, defaultMaxAccountEnqueued,
 				atomic.LoadUint64(&counter))

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -3752,6 +3752,9 @@ func TestBatchTx_SingleAccount(t *testing.T) {
 		}
 	}()
 
+	// wait a little bit to start a previous routine
+	time.Sleep(100 * time.Millisecond)
+
 	// run max number of addTx concurrently
 	for i := 0; i < int(defaultMaxAccountEnqueued); i++ {
 		go func(i uint64) {


### PR DESCRIPTION
# Description

This PR adds sanity check framework to `blade` with some sanity check tests, that can be run on a specified network (`testnet`).

The PR also adds a command to `blade`, which can be used to run sanity check tests:

```
Runs a sanity check tests on a specified network

Usage:
   sanity-check [flags]

Flags:
      --epoch-size uint             epoch size on the network for which the sanity check is run (default 10)
  -h, --help                        help for sanity-check
      --jsonrpc string              the JSON-RPC interface (default "http://0.0.0.0:8545")
      --mnemonic string             the mnemonic used to fund accounts if needed for the sanity check
      --receipts-timeout duration   the timeout for waiting for transaction receipts (default 30s)
      --to-json                     saves results to JSON file
      --validator-keys strings      private keys of validators on the network for which the sanity check is run

Global Flags:
      --json   get all outputs in json format (default false)
```

### Tests added through this PR
1. Stake test for validator
2. Unstake test for validator
3. Register a new validator with stake
4. Withdraw validator rewards test.
5. Unstake all (remove validator) test.

### To run tests locally on your machine, follow these steps:
1. Run this command from blade repo:
```
./scripts/cluster polybft
```
2. In blade repo, you will see folders like `test-chain-1`, `test-chain-2`, `test-chain-3`, `test-chain-4`. Inside each of them, collect private keys located in files `consensus/validator.key`. You will need them for the `--validator-keys` flag.
3. Run `sanity-check` command:
```
./blade sanity-check --mnemonic "code code code code code code code code code code code quality" --jsonrpc "http://localhost:10002" --receipts-timeout 2m --validator-keys [list of keys from previous step separated by a coma]
```

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually