### PR TITLE
Modify throttling UT times

### DIFF
--- a/jsonrpc/throttling_test.go
+++ b/jsonrpc/throttling_test.go
@@ -26,13 +26,13 @@ func TestThrottling(t *testing.T) {
 		{1000 * time.Millisecond, 0, false},
 
 		// 6th & 8th attempt should fail, from now on order of execution is relevant, hence delay > 0
-		{100 * time.Millisecond, 50 * time.Millisecond, true},
-		{200 * time.Millisecond, 250 * time.Millisecond, false},
-		{100 * time.Millisecond, 300 * time.Millisecond, true},
-		{200 * time.Millisecond, 500 * time.Millisecond, false},
+		{20 * time.Millisecond, 100 * time.Millisecond, true},
+		{200 * time.Millisecond, 300 * time.Millisecond, false},
+		{20 * time.Millisecond, 400 * time.Millisecond, true},
+		{200 * time.Millisecond, 600 * time.Millisecond, false},
 	}
 
-	th := NewThrottling(5, time.Millisecond*20)
+	th := NewThrottling(5, 20*time.Millisecond)
 	sfn := func(value int, sleep time.Duration) func() (interface{}, error) {
 		return func() (interface{}, error) {
 			time.Sleep(sleep)

--- a/network/gossip_test.go
+++ b/network/gossip_test.go
@@ -86,7 +86,8 @@ func TestSimpleGossip(t *testing.T) {
 	for {
 		select {
 		case <-time.After(time.Second * 15):
-			t.Fatalf("Multicast messages not received before timeout")
+			t.Fatalf("Multicast messages not received before timeout. "+
+				"Received: %d, expected: %d", messagesGossiped, len(servers))
 		case message := <-messageCh:
 			if message.Message == sentMessage {
 				messagesGossiped++


### PR DESCRIPTION
# Description

Throttling UT  strongly depends on CI instance performance. It requires exact order of threads execution and that can only be achieved with sleep times. Now try with at least 100ms difference between attempts/go routines.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually