### PR TITLE
Future epoch commitment fix

### DIFF
--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -159,7 +159,15 @@ func (s *stateSyncManager) saveVote(msg *TransportMessage) error {
 	valSet := s.validatorSet
 	s.lock.RUnlock()
 
-	if valSet == nil {
+	if valSet == nil || msg.EpochNumber < epoch || msg.EpochNumber > epoch+1{
+	     return nil
+	}
+	
+	if msg.EpochNumber == epoch+1 {
+	    if err := s.state.EpochStore.insertEpoch(epoch+1, nil); err != nil {
+		return fmt.Errorf("error saving msg vote from a future epoch: %d. Error: %w", epoch+1, err)
+	    }
+	}
 		return nil
 	}
 

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -166,11 +166,9 @@ func (s *stateSyncManager) saveVote(msg *TransportMessage) error {
 	if msg.EpochNumber != epoch && msg.EpochNumber != epoch+1 {
 		// Epoch metadata is undefined or received a message for the irrelevant epoch
 		return nil
-	} else {
-		if msg.EpochNumber == epoch+1 {
-			if err := s.state.EpochStore.insertEpoch(epoch+1, nil); err != nil {
-				return fmt.Errorf("error inserting epoch: %w", err)
-			}
+	} else if msg.EpochNumber == epoch+1 {
+		if err := s.state.EpochStore.insertEpoch(epoch+1, nil); err != nil {
+			return fmt.Errorf("error inserting epoch: %w", err)
 		}
 	}
 

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -159,9 +159,19 @@ func (s *stateSyncManager) saveVote(msg *TransportMessage) error {
 	valSet := s.validatorSet
 	s.lock.RUnlock()
 
-	if valSet == nil || msg.EpochNumber != epoch {
+	if valSet == nil {
+		return nil
+	}
+
+	if msg.EpochNumber != epoch && msg.EpochNumber != epoch+1 {
 		// Epoch metadata is undefined or received a message for the irrelevant epoch
 		return nil
+	} else {
+		if msg.EpochNumber == epoch+1 {
+			if err := s.state.EpochStore.insertEpoch(epoch+1, nil); err != nil {
+				return fmt.Errorf("error inserting epoch: %w", err)
+			}
+		}
 	}
 
 	if err := s.verifyVoteSignature(valSet, types.StringToAddress(msg.From), msg.Signature, msg.Hash); err != nil {

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -159,24 +159,14 @@ func (s *stateSyncManager) saveVote(msg *TransportMessage) error {
 	valSet := s.validatorSet
 	s.lock.RUnlock()
 
-	if valSet == nil || msg.EpochNumber < epoch || msg.EpochNumber > epoch+1{
-	     return nil
-	}
-	
-	if msg.EpochNumber == epoch+1 {
-	    if err := s.state.EpochStore.insertEpoch(epoch+1, nil); err != nil {
-		return fmt.Errorf("error saving msg vote from a future epoch: %d. Error: %w", epoch+1, err)
-	    }
-	}
+	if valSet == nil || msg.EpochNumber < epoch || msg.EpochNumber > epoch+1 {
+		// Epoch metadata is undefined or received a message for the irrelevant epoch
 		return nil
 	}
 
-	if msg.EpochNumber != epoch && msg.EpochNumber != epoch+1 {
-		// Epoch metadata is undefined or received a message for the irrelevant epoch
-		return nil
-	} else if msg.EpochNumber == epoch+1 {
+	if msg.EpochNumber == epoch+1 {
 		if err := s.state.EpochStore.insertEpoch(epoch+1, nil); err != nil {
-			return fmt.Errorf("error inserting epoch: %w", err)
+			return fmt.Errorf("error saving msg vote from a future epoch: %d. Error: %w", epoch+1, err)
 		}
 	}
 

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -150,7 +150,8 @@ func TestStateSyncManager_MessagePool(t *testing.T) {
 		msg, err := val.sign(vals.GetValidator("0"), signer.DomainStateReceiver)
 		require.NoError(t, err)
 
-		msg.EpochNumber = 1
+		// invalid epoch +2
+		msg.EpochNumber = 2
 
 		require.NoError(t, s.saveVote(msg))
 


### PR DESCRIPTION
# Description

If some validators have entered into new epoch while some validators are still in old epoch, messages from new epochs will be discarded in old validators. This PR fixes that issue and inserts commitment messages from epoch+1 into BoltDB. Solution is checked with e2e tests and the issue doesn't occur anymore.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually