### PR TITLE
`Syncer` stuck fix

### DIFF
--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -408,6 +408,10 @@ func (tp *syncerMock) Sync(func(*types.FullBlock) bool) error {
 	return args.Error(0)
 }
 
+func (tp *syncerMock) UpdateBlockTimeout(time.Duration) {
+	tp.Called()
+}
+
 func init() {
 	// setup custom hash header func
 	setupHeaderHashFunc()

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -770,11 +770,13 @@ func (p *Polybft) GetValidatorsWithTx(blockNumber uint64, parents []*types.Heade
 func (p *Polybft) SetBlockTime(blockTime time.Duration) {
 	// if block time is greater than default base round timeout,
 	// set base round timeout as twice the block time
+	syncerBlockTimeout := blockTime * 3
 	if blockTime >= core.DefaultBaseRoundTimeout {
 		p.ibft.SetBaseRoundTimeout(blockTime * baseRoundTimeoutScaleFactor)
+		syncerBlockTimeout *= baseRoundTimeoutScaleFactor
 	}
 
-	p.syncer.UpdateBlockTimeout(blockTime * 3)
+	p.syncer.UpdateBlockTimeout(syncerBlockTimeout)
 }
 
 // ProcessHeaders updates the snapshot based on the verified headers

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -101,9 +101,6 @@ type Polybft struct {
 	// runtime handles consensus runtime features like epoch, state and event management
 	runtime *consensusRuntime
 
-	// block time duration
-	blockTime time.Duration
-
 	// dataDir is the data directory to store the info
 	dataDir string
 
@@ -489,9 +486,6 @@ func (p *Polybft) Initialize() error {
 		return fmt.Errorf("cannot create topics: %w", err)
 	}
 
-	// set block time
-	p.blockTime = time.Duration(p.config.BlockTime)
-
 	// initialize polybft consensus data directory
 	p.dataDir = filepath.Join(p.config.Config.Path, "polybft")
 	// create the data dir if not exists
@@ -779,6 +773,8 @@ func (p *Polybft) SetBlockTime(blockTime time.Duration) {
 	if blockTime >= core.DefaultBaseRoundTimeout {
 		p.ibft.SetBaseRoundTimeout(blockTime * baseRoundTimeoutScaleFactor)
 	}
+
+	p.syncer.UpdateBlockTimeout(blockTime * 3)
 }
 
 // ProcessHeaders updates the snapshot based on the verified headers

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -176,10 +176,14 @@ func (s *syncer) Sync(callback func(*types.FullBlock) bool) error {
 	skipList := make(map[peer.ID]bool)
 
 	for {
+		s.lock.RLock()
+		blockTimeout := s.blockTimeout
+		s.lock.RUnlock()
+
 		// Wait for a new event to arrive
 		select {
 		case <-s.newStatusCh:
-		case <-time.After(s.blockTimeout * 2):
+		case <-time.After(blockTimeout * 2):
 			// fetch local latest block
 			if header := s.blockchain.Header(); header != nil {
 				localLatest = header.Number

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -186,6 +186,7 @@ func (s *syncer) Sync(callback func(*types.FullBlock) bool) error {
 			s.logger.Debug("new peer status arrived, start syncing")
 		case <-time.After(blockTimeout):
 			s.logger.Debug("timeout while waiting for new peer status, start manual syncing")
+			s.initializePeerMap() // fetch peer statuses just in case
 		}
 
 		// fetch local latest block

--- a/syncer/types.go
+++ b/syncer/types.go
@@ -70,6 +70,8 @@ type Syncer interface {
 	HasSyncPeer() bool
 	// Sync starts routine to sync blocks
 	Sync(func(*types.FullBlock) bool) error
+	// UpdateBlockTimeout updates block timeout in syncer
+	UpdateBlockTimeout(time.Duration)
 }
 
 type Progression interface {


### PR DESCRIPTION
# Description

### Problem 

If for some reason, the node does not get status change events from its peers, a situation may arise where the consensus will stuck, and no blocks will be created.

For example, let's say we have a situation where we have 5 validator nodes, and they are building block 100. 4 nodes (which is quorum) send the commit messages to each other, but for some reason, only 3 of the nodes receive enough commit messages and they insert the block to their state. Because of some network issues, the other two, even though they've sent their commit messages, did not receive enough to insert the block through consensus, so they remain reliable to `syncer` to insert the new block. But because network was in some weird state, where some messages were not received, the `syncer` also on the two problematic nodes did not receive status change events from connected peers, so they missed that block through `syncer` as well.

### Solution

The `syncer` has a field called `block timeout` (basically `block time * 3`) used as a way to stop the syncing from some peer if it does not respond in appropriate time. The PR uses the same field to check if we did not receive anything from some peer, and if not, it will manually ping the best peer, without the need to wait for its status change.

We have all the peers in a peer map, and that map holds the last block on each peer, so the algorithm will always choose a peer that is responsive and has the highest block number.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually
