### PR TITLE
TestE2E_Consensus_RegisterValidator fix

### DIFF
--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -13,9 +13,9 @@ import (
 // ValidatorInfo is data transfer object which holds validator information,
 // provided by smart contract
 type ValidatorInfo struct {
-	Address             types.Address `json:"address"`
 	Stake               *big.Int      `json:"stake"`
 	WithdrawableRewards *big.Int      `json:"withdrawableRewards"`
+	Address             types.Address `json:"address"`
 	IsActive            bool          `json:"isActive"`
 	IsWhitelisted       bool          `json:"isWhitelisted"`
 }

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -243,6 +243,11 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 	// register the second validator with stake
 	require.NoError(t, secondValidator.RegisterValidatorWithStake(stakeAmount))
 
+	// get owner's latest block and wait for 1 block before checks
+	latestBlock, err := owner.JSONRPC().BlockNumber()
+	require.NoError(t, err)
+	require.NoError(t, cluster.WaitForBlock(latestBlock+1, 5*time.Second))
+
 	firstValidatorInfo, err := validatorHelper.GetValidatorInfo(firstValidatorAddr, relayer)
 	require.NoError(t, err)
 	require.True(t, firstValidatorInfo.IsActive)


### PR DESCRIPTION
# Description

TestE2E_Consensus_RegisterValidator e2e test fixed in order to wait at least 1 block before asserts, otherwise it happens that block is not synced yet when check for 2nd validator is executed. In addition changed fields order in ValidatorInfo struct in order to reduce size from 48 to 40 bytes.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually