### PR TITLE
e2e register validator fix

### DIFF
--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -258,11 +258,34 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 	require.True(t, secondValidatorInfo.IsActive)
 	require.True(t, secondValidatorInfo.Stake.Cmp(stakeAmount) == 0)
 
+	// wait until both of the validators mine one block to check if they joined consensus
+	var (
+		firstMined  bool
+		secondMined bool
+	)
+
+	require.NoError(t, cluster.WaitUntil(3*time.Minute, 2*time.Second, func() bool {
+		latestBlock, err := cluster.Servers[0].JSONRPC().GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
+		require.NoError(t, err)
+
+		blockMiner := latestBlock.Header.Miner
+
+		if !firstMined {
+			firstMined = bytes.Equal(firstValidatorAddr.Bytes(), blockMiner)
+		}
+
+		if !secondMined {
+			secondMined = bytes.Equal(secondValidatorAddr.Bytes(), blockMiner)
+		}
+
+		return firstMined && secondMined
+	}))
+
 	currentBlock, err := owner.JSONRPC().GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
 	require.NoError(t, err)
 
-	// wait for couple of epochs to have some rewards accumulated
-	require.NoError(t, cluster.WaitForBlock(currentBlock.Header.Number+(polybftConfig.EpochSize*2), time.Minute))
+	// wait 1 epoch to have some rewards accumulated
+	require.NoError(t, cluster.WaitForBlock(currentBlock.Header.Number+polybftConfig.EpochSize, time.Minute))
 
 	bigZero := big.NewInt(0)
 
@@ -275,17 +298,6 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, secondValidatorInfo.IsActive)
 	require.True(t, secondValidatorInfo.WithdrawableRewards.Cmp(bigZero) > 0)
-
-	// wait until one of the validators mine one block to check if they joined consensus
-	require.NoError(t, cluster.WaitUntil(3*time.Minute, 2*time.Second, func() bool {
-		latestBlock, err := cluster.Servers[0].JSONRPC().GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
-		require.NoError(t, err)
-
-		blockMiner := latestBlock.Header.Miner
-
-		return bytes.Equal(firstValidatorAddr.Bytes(), blockMiner) ||
-			bytes.Equal(secondValidatorAddr.Bytes(), blockMiner)
-	}))
 }
 
 func TestE2E_Consensus_Validator_Unstake(t *testing.T) {


### PR DESCRIPTION
# Description

This PR addresses TestE2E_Consensus_RegisterValidator issue when 2nd staked validator hasn't been yet selected for proposer. Test fails because 2nd validator reward is still 0. Through this PR check that at least 1 validator joined consensus is moved up and changed to check that both validators joined consensus This way we are sure that both staked validators have at least 1 mined block  before checking their rewards.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually