### PR TITLE
Test improvements

### DIFF
--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -201,6 +201,9 @@ func (t *TestServer) Start() {
 	}
 
 	t.node = node
+
+	// Wait some time for network to be initialized in order to avoid 'parallel' start issue in tests
+	time.Sleep(250 * time.Millisecond)
 }
 
 func (t *TestServer) Stop() {

--- a/jsonrpc/throttling_test.go
+++ b/jsonrpc/throttling_test.go
@@ -22,17 +22,17 @@ func TestThrottling(t *testing.T) {
 		delay    time.Duration
 	}{
 		// 1st 5 starts immediately, no error, order of execution is irrelevant
-		{200 * time.Millisecond, 0},
-		{1000 * time.Millisecond, 0},
-		{1000 * time.Millisecond, 0},
-		{1000 * time.Millisecond, 0},
-		{1000 * time.Millisecond, 0},
+		{300 * time.Millisecond, 0},
+		{1200 * time.Millisecond, 0},
+		{1200 * time.Millisecond, 0},
+		{1200 * time.Millisecond, 0},
+		{1200 * time.Millisecond, 0},
 
 		// 6th & 8th attempt should fail, from now on order of execution is relevant, hence delay > 0
 		{20 * time.Millisecond, 100 * time.Millisecond},
-		{200 * time.Millisecond, 300 * time.Millisecond},
-		{20 * time.Millisecond, 400 * time.Millisecond},
-		{200 * time.Millisecond, 600 * time.Millisecond},
+		{300 * time.Millisecond, 500 * time.Millisecond},
+		{20 * time.Millisecond, 600 * time.Millisecond},
+		{200 * time.Millisecond, 1000 * time.Millisecond},
 	}
 
 	th := NewThrottling(maxRequests, 20*time.Millisecond)


### PR DESCRIPTION
# Description

Increased intervals in TestThrottling UT in order to improve stability. Added sleep into TestServer Start in order to wait with immediate another server start. This should prevent 'parallel' start issue in e2e tests. Solution verified with 7 CI running and additionally 7 UT runs. All runs were green.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually