### PR TITLE
TestBatchTx_SingleAccount use context timeout instead of time.After

### DIFF
--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -3908,10 +3908,13 @@ func TestBatchTx_SingleAccount(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
+		ctx, cancelFn := context.WithTimeout(context.Background(), time.Second*15)
+		defer cancelFn()
+
 		for {
 			select {
 			case ev = <-subscription.subscriptionChannel:
-			case <-time.After(time.Second * 6):
+			case <-ctx.Done():
 				timeoutElapsed = true
 
 				return
@@ -3936,7 +3939,7 @@ func TestBatchTx_SingleAccount(t *testing.T) {
 				assert.Equal(t, defaultMaxAccountEnqueued, pool.Length())
 
 				// all transactions are promoted
-				break
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
# Description

time.After replaced with context timeout which should use less system resources.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually