### PR TITLE
Implementation of `eth_sendTransaction`

### DIFF
--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -29,12 +29,15 @@ var (
 func TestE2E_JsonRPC(t *testing.T) {
 	const epochSize = uint64(5)
 
-	preminedAcct, err := crypto.GenerateECDSAKey()
+	preminedAcctOne, err := crypto.GenerateECDSAKey()
+	require.NoError(t, err)
+
+	preminedAcctTwo, err := crypto.GenerateECDSAKey()
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 4,
 		framework.WithEpochSize(int(epochSize)),
-		framework.WithPremine(preminedAcct.Address()),
+		framework.WithPremine(preminedAcctOne.Address(), preminedAcctTwo.Address()),
 		framework.WithBurnContract(&polybft.BurnContractInfo{BlockNumber: 0, Address: types.ZeroAddress}),
 		framework.WithHTTPS(),
 		framework.WithTLSCertificate("/etc/ssl/certs/localhost.pem", "/etc/ssl/private/localhost.key"),
@@ -44,6 +47,9 @@ func TestE2E_JsonRPC(t *testing.T) {
 	cluster.WaitForReady(t)
 
 	ethClient, err := jsonrpc.NewEthClient(cluster.Servers[0].JSONRPCAddr())
+	require.NoError(t, err)
+
+	chainID, err := ethClient.ChainID()
 	require.NoError(t, err)
 
 	t.Run("eth_blockNumber", func(t *testing.T) {
@@ -105,7 +111,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_getCode", func(t *testing.T) {
-		deployTxn := cluster.Deploy(t, preminedAcct, contractsapi.TestSimple.Bytecode)
+		deployTxn := cluster.Deploy(t, preminedAcctOne, contractsapi.TestSimple.Bytecode)
 		require.True(t, deployTxn.Succeed())
 
 		target := types.Address(deployTxn.Receipt().ContractAddress)
@@ -119,7 +125,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		key1, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
-		txn := cluster.Transfer(t, preminedAcct, key1.Address(), ethgo.Ether(1))
+		txn := cluster.Transfer(t, preminedAcctOne, key1.Address(), ethgo.Ether(1))
 		require.True(t, txn.Succeed())
 
 		txn = cluster.Deploy(t, key1, contractsapi.TestSimple.Bytecode)
@@ -147,13 +153,13 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_getTransactionByHash and eth_getTransactionReceipt", func(t *testing.T) {
-		txn := cluster.Transfer(t, preminedAcct, types.StringToAddress("0xDEADBEEF"), one)
+		txn := cluster.Transfer(t, preminedAcctOne, types.StringToAddress("0xDEADBEEF"), one)
 		require.True(t, txn.Succeed())
 
 		ethTxn, err := ethClient.GetTransactionByHash(types.Hash(txn.Receipt().TransactionHash))
 		require.NoError(t, err)
 
-		require.Equal(t, ethTxn.From(), preminedAcct.Address())
+		require.Equal(t, ethTxn.From(), preminedAcctOne.Address())
 
 		receipt, err := ethClient.GetTransactionReceipt(ethTxn.Hash())
 		require.NoError(t, err)
@@ -162,20 +168,20 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_getTransactionCount", func(t *testing.T) {
-		nonce, err := ethClient.GetNonce(preminedAcct.Address(), jsonrpc.LatestBlockNumberOrHash)
+		nonce, err := ethClient.GetNonce(preminedAcctOne.Address(), jsonrpc.LatestBlockNumberOrHash)
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, nonce, uint64(0)) // since we used this account in previous tests
 
-		txn := cluster.Transfer(t, preminedAcct, types.StringToAddress("0xDEADBEEF"), one)
+		txn := cluster.Transfer(t, preminedAcctOne, types.StringToAddress("0xDEADBEEF"), one)
 		require.True(t, txn.Succeed())
 
-		newNonce, err := ethClient.GetNonce(preminedAcct.Address(), jsonrpc.LatestBlockNumberOrHash)
+		newNonce, err := ethClient.GetNonce(preminedAcctOne.Address(), jsonrpc.LatestBlockNumberOrHash)
 		require.NoError(t, err)
 		require.Equal(t, nonce+1, newNonce)
 	})
 
 	t.Run("eth_getBalance", func(t *testing.T) {
-		balance, err := ethClient.GetBalance(preminedAcct.Address(), jsonrpc.LatestBlockNumberOrHash)
+		balance, err := ethClient.GetBalance(preminedAcctOne.Address(), jsonrpc.LatestBlockNumberOrHash)
 		require.NoError(t, err)
 		require.True(t, balance.Cmp(big.NewInt(0)) >= 0)
 
@@ -183,7 +189,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 
 		tokens := ethgo.Ether(1)
 
-		txn := cluster.Transfer(t, preminedAcct, receiver, tokens)
+		txn := cluster.Transfer(t, preminedAcctOne, receiver, tokens)
 		require.True(t, txn.Succeed())
 
 		newBalance, err := ethClient.GetBalance(receiver, jsonrpc.LatestBlockNumberOrHash)
@@ -192,14 +198,14 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_estimateGas", func(t *testing.T) {
-		deployTxn := cluster.Deploy(t, preminedAcct, contractsapi.TestSimple.Bytecode)
+		deployTxn := cluster.Deploy(t, preminedAcctOne, contractsapi.TestSimple.Bytecode)
 		require.True(t, deployTxn.Succeed())
 
 		target := types.Address(deployTxn.Receipt().ContractAddress)
 		input := contractsapi.TestSimple.Abi.GetMethod("getValue").ID()
 
 		estimatedGas, err := ethClient.EstimateGas(&jsonrpc.CallMsg{
-			From: preminedAcct.Address(),
+			From: preminedAcctOne.Address(),
 			To:   &target,
 			Data: input,
 		})
@@ -214,7 +220,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_call", func(t *testing.T) {
-		deployTxn := cluster.Deploy(t, preminedAcct, contractsapi.TestSimple.Bytecode)
+		deployTxn := cluster.Deploy(t, preminedAcctOne, contractsapi.TestSimple.Bytecode)
 		require.True(t, deployTxn.Succeed())
 
 		target := types.Address(deployTxn.Receipt().ContractAddress)
@@ -249,15 +255,12 @@ func TestE2E_JsonRPC(t *testing.T) {
 		receiver := types.StringToAddress("0xDEADFFFF")
 		tokenAmount := ethgo.Ether(1)
 
-		chainID, err := ethClient.ChainID()
-		require.NoError(t, err)
-
 		gasPrice, err := ethClient.GasPrice()
 		require.NoError(t, err)
 
 		newAccountKey, newAccountAddr := tests.GenerateKeyAndAddr(t)
 
-		transferTxn := cluster.Transfer(t, preminedAcct, newAccountAddr, tokenAmount)
+		transferTxn := cluster.Transfer(t, preminedAcctOne, newAccountAddr, tokenAmount)
 		require.True(t, transferTxn.Succeed())
 
 		newAccountBalance, err := ethClient.GetBalance(newAccountAddr, jsonrpc.LatestBlockNumberOrHash)
@@ -288,7 +291,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		key1, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
-		txn := cluster.Transfer(t, preminedAcct, key1.Address(), one)
+		txn := cluster.Transfer(t, preminedAcctOne, key1.Address(), one)
 		require.True(t, txn.Succeed())
 		txReceipt := txn.Receipt()
 
@@ -303,7 +306,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		key1, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
-		txn := cluster.Transfer(t, preminedAcct, key1.Address(), one)
+		txn := cluster.Transfer(t, preminedAcctOne, key1.Address(), one)
 		require.True(t, txn.Succeed())
 		txReceipt := txn.Receipt()
 
@@ -315,7 +318,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_getBlockReceipts", func(t *testing.T) {
-		txn := cluster.Transfer(t, preminedAcct, types.StringToAddress("0xDEADBEEF"), one)
+		txn := cluster.Transfer(t, preminedAcctOne, types.StringToAddress("0xDEADBEEF"), one)
 		require.True(t, txn.Succeed())
 		receipt := txn.Receipt()
 
@@ -330,7 +333,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_createAccessList", func(t *testing.T) {
-		deployTxn := cluster.Deploy(t, preminedAcct, contractsapi.TestSimple.Bytecode)
+		deployTxn := cluster.Deploy(t, preminedAcctOne, contractsapi.TestSimple.Bytecode)
 		require.True(t, deployTxn.Succeed())
 		contractAddr := types.Address(deployTxn.Receipt().ContractAddress)
 
@@ -341,7 +344,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 
 		tx := types.NewTx(
 			types.NewDynamicFeeTx(
-				types.WithFrom(preminedAcct.Address()),
+				types.WithFrom(preminedAcctOne.Address()),
 				types.WithTo(&contractAddr),
 				types.WithInput(inputValue),
 			))
@@ -374,19 +377,16 @@ func TestE2E_JsonRPC(t *testing.T) {
 	t.Run("eth_signTransaction", func(t *testing.T) {
 		accPassword := "testpassword"
 
-		keyRaw, err := preminedAcct.MarshallPrivateKey()
+		keyRaw, err := preminedAcctOne.MarshallPrivateKey()
 		require.NoError(t, err)
 
 		hexKey := hex.EncodeToString(keyRaw)
 
 		accAddr, err := ethClient.ImportRawKey(hexKey, accPassword)
 		require.NoError(t, err)
-		require.Equal(t, preminedAcct.Address(), accAddr)
+		require.Equal(t, preminedAcctOne.Address(), accAddr)
 
-		nonce, err := ethClient.GetNonce(preminedAcct.Address(), jsonrpc.LatestBlockNumberOrHash)
-		require.NoError(t, err)
-
-		chainID, err := ethClient.ChainID()
+		nonce, err := ethClient.GetNonce(preminedAcctOne.Address(), jsonrpc.LatestBlockNumberOrHash)
 		require.NoError(t, err)
 
 		gasPrice, err := ethClient.GasPrice()
@@ -395,7 +395,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 		target := types.StringToAddress("0xDEADBEEF")
 
 		txn := &jsonrpc.CallMsg{
-			From:     preminedAcct.Address(),
+			From:     preminedAcctOne.Address(),
 			To:       &target,
 			Gas:      21000,
 			GasPrice: new(big.Int).SetUint64(gasPrice * 2),
@@ -405,14 +405,14 @@ func TestE2E_JsonRPC(t *testing.T) {
 			Type:     uint64(types.LegacyTxType),
 		}
 
-		isUnlocked, err := ethClient.Unlock(preminedAcct.Address(), accPassword, 90 /* seconds */) // unlock for 90 seconds
+		isUnlocked, err := ethClient.Unlock(preminedAcctOne.Address(), accPassword, 90 /* seconds */) // unlock for 90 seconds
 		require.NoError(t, err)
 		require.True(t, isUnlocked)
 
 		res, err := ethClient.SignTransaction(txn)
 		require.NoError(t, err)
 		require.NotEmpty(t, res.Raw)
-		require.Equal(t, preminedAcct.Address(), res.Tx.From())
+		require.Equal(t, preminedAcctOne.Address(), res.Tx.From())
 
 		hash, err := ethClient.SendRawTransaction(res.Raw)
 		require.NoError(t, err)
@@ -426,6 +426,46 @@ func TestE2E_JsonRPC(t *testing.T) {
 
 			return true
 		}))
+	})
+
+	t.Run("eth_sendTransaction", func(t *testing.T) {
+		accPassword := "testpassword"
+
+		keyRaw, err := preminedAcctTwo.MarshallPrivateKey()
+		require.NoError(t, err)
+
+		hexKey := hex.EncodeToString(keyRaw)
+
+		accAddr, err := ethClient.ImportRawKey(hexKey, accPassword)
+		require.NoError(t, err)
+		require.Equal(t, preminedAcctTwo.Address(), accAddr)
+
+		nonce, err := ethClient.GetNonce(preminedAcctTwo.Address(), jsonrpc.LatestBlockNumberOrHash)
+		require.NoError(t, err)
+
+		gasPrice, err := ethClient.GasPrice()
+		require.NoError(t, err)
+
+		target := preminedAcctOne.Address()
+
+		txn := &jsonrpc.CallMsg{
+			From:     preminedAcctTwo.Address(),
+			To:       &target,
+			Gas:      21000,
+			GasPrice: new(big.Int).SetUint64(gasPrice * 2),
+			Nonce:    nonce,
+			ChainID:  chainID,
+			Value:    big.NewInt(1),
+			Type:     uint64(types.LegacyTxType),
+		}
+
+		isUnlocked, err := ethClient.Unlock(preminedAcctTwo.Address(), accPassword, 90 /* seconds */) // unlock for 90 seconds
+		require.NoError(t, err)
+		require.True(t, isUnlocked)
+
+		hash, err := ethClient.SendTransactionCallMsg(txn)
+		require.NoError(t, err)
+		require.NotEqual(t, types.ZeroHash, hash)
 	})
 }
 

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -448,22 +448,21 @@ func TestE2E_JsonRPC(t *testing.T) {
 
 		target := preminedAcctOne.Address()
 
-		txn := &jsonrpc.CallMsg{
-			From:     preminedAcctTwo.Address(),
-			To:       &target,
-			Gas:      21000,
-			GasPrice: new(big.Int).SetUint64(gasPrice * 2),
-			Nonce:    nonce,
-			ChainID:  chainID,
-			Value:    big.NewInt(1),
-			Type:     uint64(types.LegacyTxType),
-		}
+		txn := types.NewTx(types.NewLegacyTx(
+			types.WithFrom(preminedAcctTwo.Address()),
+			types.WithTo(&target),
+			types.WithGas(21000),
+			types.WithGasPrice(new(big.Int).SetUint64(gasPrice*2)),
+			types.WithNonce(nonce),
+			types.WithChainID(chainID),
+			types.WithValue(big.NewInt(1)),
+		))
 
 		isUnlocked, err := ethClient.Unlock(preminedAcctTwo.Address(), accPassword, 90 /* seconds */) // unlock for 90 seconds
 		require.NoError(t, err)
 		require.True(t, isUnlocked)
 
-		hash, err := ethClient.SendTransactionCallMsg(txn)
+		hash, err := ethClient.SendTransaction(txn)
 		require.NoError(t, err)
 		require.NotEqual(t, types.ZeroHash, hash)
 	})

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -80,6 +80,15 @@ func BigMin(x, y *big.Int) *big.Int {
 	return x
 }
 
+// BigMax returns the larger of x or y.
+func BigMax(x, y *big.Int) *big.Int {
+	if x.Cmp(y) > 0 {
+		return x
+	}
+
+	return y
+}
+
 func ConvertUnmarshalledUint(x interface{}) (uint64, error) {
 	switch tx := x.(type) {
 	case float64:

--- a/jsonrpc/client.go
+++ b/jsonrpc/client.go
@@ -137,15 +137,6 @@ func (e *EthClient) SendTransaction(txn *types.Transaction) (types.Hash, error) 
 	return hash, err
 }
 
-// SendTransaction creates new message call transaction or a contract creation
-// but uses CallMsg instead of Transaction
-func (e *EthClient) SendTransactionCallMsg(msg *CallMsg) (types.Hash, error) {
-	var hash types.Hash
-	err := e.client.Call("eth_sendTransaction", &hash, msg)
-
-	return hash, err
-}
-
 // GetTransactionReceipt returns the receipt of a transaction by transaction hash
 func (e *EthClient) GetTransactionReceipt(hash types.Hash) (*ethgo.Receipt, error) {
 	var receipt *ethgo.Receipt

--- a/jsonrpc/client.go
+++ b/jsonrpc/client.go
@@ -137,6 +137,15 @@ func (e *EthClient) SendTransaction(txn *types.Transaction) (types.Hash, error) 
 	return hash, err
 }
 
+// SendTransaction creates new message call transaction or a contract creation
+// but uses CallMsg instead of Transaction
+func (e *EthClient) SendTransactionCallMsg(msg *CallMsg) (types.Hash, error) {
+	var hash types.Hash
+	err := e.client.Call("eth_sendTransaction", &hash, msg)
+
+	return hash, err
+}
+
 // GetTransactionReceipt returns the receipt of a transaction by transaction hash
 func (e *EthClient) GetTransactionReceipt(hash types.Hash) (*ethgo.Receipt, error) {
 	var receipt *ethgo.Receipt

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -322,19 +322,7 @@ func (e *Eth) BlockNumber() (interface{}, error) {
 
 // SignTransaction sign transaction with key of account, key need to be unlocked
 func (e *Eth) SignTransaction(txn *txnArgs) (interface{}, error) {
-	account := accounts.Account{Address: *txn.From}
-
-	keyStore, err := getKeystore(e.accManager)
-	if err != nil {
-		return nil, err
-	}
-
-	tx, err := DecodeTxn(txn, e.store, true)
-	if err != nil {
-		return nil, err
-	}
-
-	signedTx, err := keyStore.SignTx(account, tx)
+	signedTx, err := e.signTx(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -360,10 +348,19 @@ func (e *Eth) SendRawTransaction(buf argBytes) (interface{}, error) {
 	return tx.Hash().String(), nil
 }
 
-// SendTransaction rejects eth_sendTransaction json-rpc call as we don't support wallet management
-func (e *Eth) SendTransaction(_ *txnArgs) (interface{}, error) {
-	return nil, fmt.Errorf("request calls to eth_sendTransaction method are not supported," +
-		" use eth_sendRawTransaction instead")
+// SendTransaction creates a transaction for the given argument, sign it and submit it to the tx pool
+func (e *Eth) SendTransaction(args *txnArgs) (interface{}, error) {
+	signedTx, err := e.signTx(args)
+	if err != nil {
+		return nil, err
+	}
+
+	err = e.store.AddTx(signedTx)
+	if err != nil {
+		return nil, err
+	}
+
+	return signedTx.Hash().String(), nil
 }
 
 // GetTransactionByHash returns a transaction by its hash.
@@ -1041,4 +1038,25 @@ func (e *Eth) FeeHistory(blockCount argUint64, newestBlock BlockNumber,
 	}
 
 	return result, nil
+}
+
+// signTx signs a transaction with the account's private key if it exists in store
+func (e *Eth) signTx(args *txnArgs) (*types.Transaction, error) {
+	if err := args.setDefaults(e.priceLimit, e); err != nil {
+		return nil, err
+	}
+
+	tx, err := DecodeTxn(args, e.store, true)
+	if err != nil {
+		return nil, err
+	}
+
+	account := accounts.Account{Address: tx.From()}
+
+	keyStore, err := getKeystore(e.accManager)
+	if err != nil {
+		return nil, err
+	}
+
+	return keyStore.SignTx(account, tx)
 }

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -348,7 +348,7 @@ func (e *Eth) SendRawTransaction(buf argBytes) (interface{}, error) {
 	return tx.Hash().String(), nil
 }
 
-// SendTransaction creates a transaction for the given argument, sign it and submit it to the tx pool
+// SendTransaction creates a transaction for the given argument, signs it, and submits it to the tx pool
 func (e *Eth) SendTransaction(args *txnArgs) (interface{}, error) {
 	signedTx, err := e.signTx(args)
 	if err != nil {


### PR DESCRIPTION
# Description

This PR implements `eth_sendTransaction` json-rpc endpoint.

`eth_sendTransaction` creates new message call transaction or a contract creation, if the data field contains code, and signs it using the account specified in from.

**Parameters**

Object - The transaction object

Example:

```
params: [
  {
    from: "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
    to: "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
    gas: "0x76c0", // 30400
    gasPrice: "0x9184e72a000", // 10000000000000
    value: "0x9184e72a", // 2441406250
    input:
      "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
  },
]
```

**Returns**

DATA, 32 Bytes - the transaction hash, or the zero hash if the transaction is not yet available.

Example:

```
// Request
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{see above}],"id":1}'
// Result
{
  "id":1,
  "jsonrpc": "2.0",
  "result": "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331"
}
```

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually