### PR TITLE
Implementation of `eth_sign`

### DIFF
--- a/jsonrpc/client.go
+++ b/jsonrpc/client.go
@@ -304,3 +304,14 @@ func (e *EthClient) Unlock(addr types.Address, password string, duration uint64)
 
 	return isUnlocked, nil
 }
+
+// Sign calculates an ECDSA signature
+func (e *EthClient) Sign(addr types.Address, data []byte) (string, error) {
+	var res string
+
+	if err := e.client.Call("eth_sign", &res, addr, hex.EncodeToHex(data)); err != nil {
+		return "", err
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
# Description

This PR implements the `eth_sign` json-rpc endpoint where a user can send a hashed message to be signed by its private key that is stored by the nodes account management.

**Parameters**

- Address of the account whose private key will be used to sign the message
- Message to sign

**Returns**

Signature

Example:

```
// Request
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sign","params":["0x9b2055d370f73ec7d8a03e965129118dc8f5bf83", "0xdeadbeaf"],"id":1}'
// Result
{
  "id":1,
  "jsonrpc": "2.0",
  "result": "0xa3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a12d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee1b"
}
```

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually