### PR TITLE
TestE2E_Bridge_NonMintableERC20Token_WithPremine fix

### DIFF
--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -1355,6 +1355,12 @@ func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 
 	// this test case will check first if they can withdraw some of the premined amount of non-mintable token
 	t.Run("do a withdraw for premined validator address and premined non-validator address", func(t *testing.T) {
+		waitOneBlockFn := func(server *framework.TestServer) {
+			currentBlock, err := server.JSONRPC().GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
+			require.NoError(t, err)
+			require.NoError(t, cluster.WaitForBlock(currentBlock.Header.Number+1, time.Second*5))
+		}
+
 		validatorSrv := cluster.Servers[1]
 		validatorAcc, err := validatorHelper.GetAccountFromDir(validatorSrv.DataDir())
 		require.NoError(t, err)
@@ -1374,11 +1380,8 @@ func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 			false)
 		require.NoError(t, err)
 
-		currentBlock, err := validatorSrv.JSONRPC().GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
-		require.NoError(t, err)
-
 		// Wait for 1 block before getting expected child balance
-		require.NoError(t, cluster.WaitForBlock(currentBlock.Header.Number+1, time.Second*5))
+		waitOneBlockFn(validatorSrv)
 
 		validatorBalanceAfterWithdraw, err := childEthEndpoint.GetBalance(
 			validatorAcc.Address(), jsonrpc.LatestBlockNumberOrHash)
@@ -1396,17 +1399,14 @@ func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 			false)
 		require.NoError(t, err)
 
-		currentBlock, err = validatorSrv.JSONRPC().GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
-		require.NoError(t, err)
-
 		// Wait for 1 block before getting expected child balance
-		require.NoError(t, cluster.WaitForBlock(currentBlock.Header.Number+1, time.Second*5))
+		waitOneBlockFn(validatorSrv)
 
 		nonValidatorBalanceAfterWithdraw, err := childEthEndpoint.GetBalance(
 			nonValidatorKey.Address(), jsonrpc.LatestBlockNumberOrHash)
 		require.NoError(t, err)
 
-		currentBlock, err = childEthEndpoint.GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
+		currentBlock, err := childEthEndpoint.GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
 		require.NoError(t, err)
 
 		currentExtra, err := polybft.GetIbftExtra(currentBlock.Header.ExtraData)

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -1374,6 +1374,12 @@ func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 			false)
 		require.NoError(t, err)
 
+		currentBlock, err := validatorSrv.JSONRPC().GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
+		require.NoError(t, err)
+
+		// Wait for 1 block before getting expected child balance
+		require.NoError(t, cluster.WaitForBlock(currentBlock.Header.Number+1, time.Second*5))
+
 		validatorBalanceAfterWithdraw, err := childEthEndpoint.GetBalance(
 			validatorAcc.Address(), jsonrpc.LatestBlockNumberOrHash)
 		require.NoError(t, err)
@@ -1390,11 +1396,17 @@ func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 			false)
 		require.NoError(t, err)
 
+		currentBlock, err = validatorSrv.JSONRPC().GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
+		require.NoError(t, err)
+
+		// Wait for 1 block before getting expected child balance
+		require.NoError(t, cluster.WaitForBlock(currentBlock.Header.Number+1, time.Second*5))
+
 		nonValidatorBalanceAfterWithdraw, err := childEthEndpoint.GetBalance(
 			nonValidatorKey.Address(), jsonrpc.LatestBlockNumberOrHash)
 		require.NoError(t, err)
 
-		currentBlock, err := childEthEndpoint.GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
+		currentBlock, err = childEthEndpoint.GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
 		require.NoError(t, err)
 
 		currentExtra, err := polybft.GetIbftExtra(currentBlock.Header.ExtraData)


### PR DESCRIPTION
# Description

Added waiting for 1 block before getting expected child balance. 
Expected when test passing:
Root expected 10000000000 Child Expected 99999999999660791450108544

Expected when test failing:
Root expected 10000000000 Child Expected 100000000000000000000000000

It seems expected balance is occasionally grabbed before subtraction.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually