### PR TITLE
Gracefully close bolt DB

### DIFF
--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -714,6 +714,7 @@ func (p *Polybft) Close() error {
 
 	close(p.closeCh)
 	p.runtime.close()
+	p.state.db.Close()
 
 	return nil
 }

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
 )
 
 // the test initializes polybft and chain mock (map of headers) after which a new header is verified
@@ -217,6 +218,7 @@ func TestPolybft_Close(t *testing.T) {
 		runtime: &consensusRuntime{
 			bridgeManager: &dummyBridgeManager{},
 		},
+		state: &State{db: &bbolt.DB{}},
 	}
 
 	assert.NoError(t, polybft.Close())


### PR DESCRIPTION
# Description

Unlike state trie and blockchain databases blade doesn't call Close method for consensus runtime state database (bolt DB). We should have Close for this database as well in order to avoid database corruption when shutting down blade gracefully. Close method will wait for ongoing transactions to finish and only then will close the database. I think the most appropriate place for bolt DB Close is in ithe Polybft Close method after runtime closing. 

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually