### PR TITLE
Test head stream concurrent UT fix

### DIFF
--- a/jsonrpc/filter_manager_test.go
+++ b/jsonrpc/filter_manager_test.go
@@ -688,6 +688,9 @@ func TestHeadStream_Concurrent(t *testing.T) {
 
 	b := newBlockStream(&block{header: header{Number: 0}})
 
+	// All subscribers start from the same point
+	head := b.getHead()
+
 	// Write co-routine with jitter
 	go func() {
 		seed := time.Now().UTC().UnixNano()
@@ -705,9 +708,6 @@ func TestHeadStream_Concurrent(t *testing.T) {
 
 	// Run n subscribers following and verifying
 	errCh := make(chan error, nReaders)
-
-	// All subscribers start from the same point
-	head := b.getHead()
 
 	for i := 0; i < nReaders; i++ {
 		go func(i int) {

--- a/jsonrpc/filter_manager_test.go
+++ b/jsonrpc/filter_manager_test.go
@@ -719,7 +719,7 @@ func TestHeadStream_Concurrent(t *testing.T) {
 
 				for _, block := range blocks {
 					if num := uint64(block.Number); num != expect {
-						errCh <- fmt.Errorf("subscriber %05d bad event want=%d, got=%d", i, num, expect)
+						errCh <- fmt.Errorf("subscriber %05d bad event want=%d, got=%d", i, expect, num)
 
 						return
 					}


### PR DESCRIPTION
# Description

getHead() needs to be called before go routine pushing blocks into block stream starts. Otherwise stream can progress to some block number > 0 and the test will fail. That occurred here: https://github.com/Ethernal-Tech/blade/actions/runs/10036123249/job/27733323461

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually