### PR TITLE
LT gossip msg size -> 16 MB

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
       max_enqueued: "20000000"
       is_london_fork_active: true
       is_bridge_active: false
-      gossip_msg_size: "8388608"
+      gossip_msg_size: "16777216"
       notification: false
     secrets:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
@@ -168,7 +168,7 @@ jobs:
       max_enqueued: "20000000"
       is_london_fork_active: true
       is_bridge_active: false
-      gossip_msg_size: "8388608"
+      gossip_msg_size: "16777216"
       logs: true
       build_blade_output: ${{ needs.ci.outputs.build_blade }}
       lint_output: ${{ needs.ci.outputs.lint }}

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -902,16 +902,6 @@ func (c *consensusRuntime) BuildPrePrepareMessage(
 	certificate *proto.RoundChangeCertificate,
 	view *proto.View,
 ) *proto.IbftMessage {
-	// Add debug log for cases when RCC is not nil
-	if certificate != nil {
-		c.logger.Debug("BuildPrePrepareMessage", "rawProposal length", len(rawProposal),
-			"certificate length", len(certificate.String()))
-
-		for i, rcMsg := range certificate.RoundChangeMessages {
-			c.logger.Debug("BuildPrePrepareMessage", "RC msg index", i, "RC msg length", len(rcMsg.String()))
-		}
-	}
-
 	if len(rawProposal) == 0 {
 		c.logger.Error("can not build pre-prepare message, since proposal is empty")
 

--- a/gasprice/gasprice_test.go
+++ b/gasprice/gasprice_test.go
@@ -18,6 +18,8 @@ import (
 func TestGasHelper_MaxPriorityFeePerGas(t *testing.T) {
 	t.Parallel()
 
+	defaultGasPrice := DefaultGasHelperConfig.LastPrice
+
 	var cases = []struct {
 		Name       string
 		Expected   *big.Int
@@ -118,7 +120,7 @@ func TestGasHelper_MaxPriorityFeePerGas(t *testing.T) {
 		{
 			Name: "Number of blocks in chain smaller than numOfBlocksToCheck",
 			Expected: DefaultGasHelperConfig.LastPrice.Mul(
-				DefaultGasHelperConfig.LastPrice, big.NewInt(2)), // at least two times of default last price
+				defaultGasPrice, big.NewInt(2)), // at least two times of default last price
 			GetBackend: func() Blockchain {
 				backend := createTestBlocks(t, 10)
 				createTestTxs(t, backend, 3, 200)
@@ -129,7 +131,7 @@ func TestGasHelper_MaxPriorityFeePerGas(t *testing.T) {
 		{
 			Name: "Number of blocks in chain higher than numOfBlocksToCheck",
 			Expected: DefaultGasHelperConfig.LastPrice.Mul(
-				DefaultGasHelperConfig.LastPrice, big.NewInt(2)), // at least two times of default last price
+				defaultGasPrice, big.NewInt(2)), // at least two times of default last price
 			GetBackend: func() Blockchain {
 				backend := createTestBlocks(t, 30)
 				createTestTxs(t, backend, 3, 200)
@@ -140,7 +142,7 @@ func TestGasHelper_MaxPriorityFeePerGas(t *testing.T) {
 		{
 			Name: "Not enough transactions in first 20 blocks, so read some more blocks",
 			Expected: DefaultGasHelperConfig.LastPrice.Mul(
-				DefaultGasHelperConfig.LastPrice, big.NewInt(2)), // at least two times of default last price
+				defaultGasPrice, big.NewInt(2)), // at least two times of default last price
 			GetBackend: func() Blockchain {
 				backend := createTestBlocks(t, 50)
 				createTestTxs(t, backend, 1, 200)

--- a/network/gossip_test.go
+++ b/network/gossip_test.go
@@ -31,7 +31,7 @@ func WaitForSubscribers(ctx context.Context, srv *Server, topic string, expected
 }
 
 func TestSimpleGossip(t *testing.T) {
-	numServers := 9
+	numServers := 8
 	sentMessage := fmt.Sprintf("%d", time.Now().UTC().Unix())
 
 	servers, createErr := createServers(numServers, nil)


### PR DESCRIPTION
# Description

Gossip max message size set to 16 MB because libp2p has throttling feature and discards messages during high traffic. In order to avoid LT failing we need 1 round more. i.e. Blade will recover during round 2 and we need only one more PREPREPARE message to be sent.
In addition some minor fixes/changes were added into UTs.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually