### PR TITLE
Access keys have higher priority

### DIFF
--- a/network/gossip_test.go
+++ b/network/gossip_test.go
@@ -31,7 +31,7 @@ func WaitForSubscribers(ctx context.Context, srv *Server, topic string, expected
 }
 
 func TestSimpleGossip(t *testing.T) {
-	numServers := 8
+	numServers := 6
 	sentMessage := fmt.Sprintf("%d", time.Now().UTC().Unix())
 
 	servers, createErr := createServers(numServers, nil)

--- a/secrets/alibaba/alibaba_ssm.go
+++ b/secrets/alibaba/alibaba_ssm.go
@@ -230,14 +230,15 @@ func (a *AlibabaSsmManager) getSdkConfig() (*openapi.Config, error) {
 	accessKey := os.Getenv("ALICLOUD_ACCESS_KEY")
 	secretKey := os.Getenv("ALICLOUD_SECRET_KEY")
 
-	if accessKey != "" && secretKey != "" {
+	switch {
+	case accessKey != "" && secretKey != "":
 		config = &openapi.Config{
 			// Required, please ensure that the environment variable ALICLOUD_ACCESS_KEY is set.
 			AccessKeyId: tea.String(accessKey),
 			// Required, please ensure that the environment variable ALICLOUD_SECRET_KEY is set.
 			AccessKeySecret: tea.String(secretKey),
 		}
-	} else if a.role != "" {
+	case a.role != "":
 		creds, err := getCredentials(a.role)
 		if err != nil {
 			return nil, err
@@ -251,7 +252,7 @@ func (a *AlibabaSsmManager) getSdkConfig() (*openapi.Config, error) {
 			// Required
 			SecurityToken: creds.SecurityToken,
 		}
-	} else {
+	default:
 		return nil, errors.New("neither access keys nor role is set")
 	}
 

--- a/secrets/alibaba/alibaba_ssm.go
+++ b/secrets/alibaba/alibaba_ssm.go
@@ -227,7 +227,17 @@ func (a *AlibabaSsmManager) logError(err error) {
 func (a *AlibabaSsmManager) getSdkConfig() (*openapi.Config, error) {
 	var config *openapi.Config
 
-	if a.role != "" {
+	accessKey := os.Getenv("ALICLOUD_ACCESS_KEY")
+	secretKey := os.Getenv("ALICLOUD_SECRET_KEY")
+
+	if accessKey != "" && secretKey != "" {
+		config = &openapi.Config{
+			// Required, please ensure that the environment variable ALICLOUD_ACCESS_KEY is set.
+			AccessKeyId: tea.String(accessKey),
+			// Required, please ensure that the environment variable ALICLOUD_SECRET_KEY is set.
+			AccessKeySecret: tea.String(secretKey),
+		}
+	} else if a.role != "" {
 		creds, err := getCredentials(a.role)
 		if err != nil {
 			return nil, err
@@ -242,12 +252,7 @@ func (a *AlibabaSsmManager) getSdkConfig() (*openapi.Config, error) {
 			SecurityToken: creds.SecurityToken,
 		}
 	} else {
-		config = &openapi.Config{
-			// Required, please ensure that the environment variable ALICLOUD_ACCESS_KEY is set.
-			AccessKeyId: tea.String(os.Getenv("ALICLOUD_ACCESS_KEY")),
-			// Required, please ensure that the environment variable ALICLOUD_SECRET_KEY is set.
-			AccessKeySecret: tea.String(os.Getenv("ALICLOUD_SECRET_KEY")),
-		}
+		return nil, errors.New("neither access keys nor role is set")
 	}
 
 	// oos.eu-central-1.aliyuncs.com

--- a/secrets/alibaba/alibaba_ssm.go
+++ b/secrets/alibaba/alibaba_ssm.go
@@ -225,10 +225,11 @@ func (a *AlibabaSsmManager) logError(err error) {
 }
 
 func (a *AlibabaSsmManager) getSdkConfig() (*openapi.Config, error) {
-	var config *openapi.Config
-
-	accessKey := os.Getenv("ALICLOUD_ACCESS_KEY")
-	secretKey := os.Getenv("ALICLOUD_SECRET_KEY")
+	var (
+		config    *openapi.Config
+		accessKey = os.Getenv("ALICLOUD_ACCESS_KEY")
+		secretKey = os.Getenv("ALICLOUD_SECRET_KEY")
+	)
 
 	switch {
 	case accessKey != "" && secretKey != "":


### PR DESCRIPTION
# Description

Alibaba secret manager changed in the way that access keys have higher priority than a role. This way the same config for init command can be used locally and on instances.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Alibaba deployment is working ok.