### PR TITLE
Bump Go 1.22

### DIFF
--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Run Go Test
         run: make benchmark-test
       - name: Run Go Test Failed

--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.22.x
+          go-version: ${{ vars.GOLANG_VERSION }}
       - name: Run Go Test
         run: make benchmark-test
       - name: Run Go Test Failed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.22.x
+          go-version: ${{ vars.GOLANG_VERSION }}
       - name: Build Blade
         run: go build -o blade -tags netgo -ldflags="-s -w -X \"github.com/${GITHUB_REPOSITORY}/versioning.Version=${GITHUB_REF_NAME}\" -X \"github.com/${GITHUB_REPOSITORY}/versioning.Commit=${GITHUB_SHA}\"" && tar -czvf blade.tar.gz blade
         env:
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.22.x
+          go-version: ${{ vars.GOLANG_VERSION }}
       - name: Reproduce builds
         continue-on-error: true
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Build Blade
         run: go build -o blade -tags netgo -ldflags="-s -w -X \"github.com/${GITHUB_REPOSITORY}/versioning.Version=${GITHUB_REF_NAME}\" -X \"github.com/${GITHUB_REPOSITORY}/versioning.Commit=${GITHUB_SHA}\"" && tar -czvf blade.tar.gz blade
         env:
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Reproduce builds
         continue-on-error: true
         run: |

--- a/.github/workflows/e2e-legacy-test.yml
+++ b/.github/workflows/e2e-legacy-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.22.x
+          go-version: ${{ vars.GOLANG_VERSION }}
       - name: Run tests
         run: make test-e2e-legacy
       - name: Run tests failed

--- a/.github/workflows/e2e-legacy-test.yml
+++ b/.github/workflows/e2e-legacy-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Run tests
         run: make test-e2e-legacy
       - name: Run tests failed

--- a/.github/workflows/e2e-polybft-test.yml
+++ b/.github/workflows/e2e-polybft-test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
           check-latest: true
       - name: Generate OpenSSL certificate
         run: openssl req -x509 -out localhost.crt -keyout localhost.key -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' -extensions EXT -config <(printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")

--- a/.github/workflows/e2e-polybft-test.yml
+++ b/.github/workflows/e2e-polybft-test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.22.x
+          go-version: ${{ vars.GOLANG_VERSION }}
           check-latest: true
       - name: Generate OpenSSL certificate
         run: openssl req -x509 -out localhost.crt -keyout localhost.key -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' -extensions EXT -config <(printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")

--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Run Fuzz Test
         run: make fuzz-test
       - name: Run fuzz tests failed

--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.22.x
+          go-version: ${{ vars.GOLANG_VERSION }}
       - name: Run Fuzz Test
         run: make fuzz-test
       - name: Run fuzz tests failed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
           cache: false
       - name: Lint
         uses: golangci/golangci-lint-action@v4.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.22.x
+          go-version: ${{ vars.GOLANG_VERSION }}
           cache: false
       - name: Lint
         uses: golangci/golangci-lint-action@v4.0.0

--- a/.github/workflows/property-polybft-test.yml
+++ b/.github/workflows/property-polybft-test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.22.x
+          go-version: ${{ vars.GOLANG_VERSION }}
       - name: Run tests
         run: make test-property-polybft
       - name: Run tests failed

--- a/.github/workflows/property-polybft-test.yml
+++ b/.github/workflows/property-polybft-test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Run tests
         run: make test-property-polybft
       - name: Run tests failed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.22.x
+          go-version: ${{ vars.GOLANG_VERSION }}
       - name: Prepare
         id: prepare
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Prepare
         id: prepare
         run: |
@@ -53,7 +53,7 @@ jobs:
           		--clean --skip-validate
         env:
           PACKAGE_NAME: github.com/${GITHUB_REPOSITORY}
-          GOLANG_CROSS_VERSION: v1.21.6
+          GOLANG_CROSS_VERSION: v1.22.6
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.prepare.outputs.tag_name }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/sanity-check-test.yml
+++ b/.github/workflows/sanity-check-test.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Build Blade
         run: make build
       - name: Configure AWS Credentials

--- a/.github/workflows/sanity-check-test.yml
+++ b/.github/workflows/sanity-check-test.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.22.x
+          go-version: ${{ vars.GOLANG_VERSION }}
       - name: Build Blade
         run: make build
       - name: Configure AWS Credentials

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.22.x
+          go-version: ${{ vars.GOLANG_VERSION }}
       - name: Install Dependencies
         run: ./setup-ci.sh
       - name: Run Go Test

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install Dependencies
         run: ./setup-ci.sh
       - name: Run Go Test

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS builder
+FROM golang:1.22-alpine AS builder
 
 RUN apk add make git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/0xPolygon/polygon-edge
 
-go 1.21
+go 1.22
 
 require (
 	cloud.google.com/go/secretmanager v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -64,12 +64,6 @@ require (
 )
 
 require (
-	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/wlynxg/anet v0.0.4 // indirect
-)
-
-require (
 	cloud.google.com/go/auth v0.9.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.4 // indirect
 	cloud.google.com/go/compute/metadata v0.5.0 // indirect
@@ -121,6 +115,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-toolsmith/astcopy v1.0.2 // indirect
 	github.com/go-toolsmith/astequal v1.0.3 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
@@ -190,6 +185,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/ginkgo/v2 v2.20.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
@@ -241,6 +237,7 @@ require (
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.55.0
+	github.com/wlynxg/anet v0.0.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.52.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,7 +4,7 @@
 
 When deploying with `polybft` consensus, there are some additional dependencies:
 
-* [go 1.21.x](https://go.dev/dl/)
+* [go 1.22.x](https://go.dev/dl/)
 * [jq](https://jqlang.github.io/jq)
 * [curl](https://everything.curl.dev/get)
 


### PR DESCRIPTION
# Description

This PR bumps the golang version to v1.22, because a couple of recent dependency upgrades have bumped their minimum version to 1.22:
- https://github.com/Ethernal-Tech/blade/pull/351
- https://github.com/Ethernal-Tech/blade/pull/352

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
