### PR TITLE
Introduction of bridge type

### DIFF
--- a/consensus/polybft/bridge.go
+++ b/consensus/polybft/bridge.go
@@ -1,0 +1,116 @@
+package polybft
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+	bolt "go.etcd.io/bbolt"
+)
+
+var _ Bridge = (*bridge)(nil)
+
+// bridge is a struct that manages different bridges
+type bridge struct {
+	bridgeManagers map[uint64]BridgeManager
+}
+
+// Bridge is an interface that defines function that a bridge must implement
+type Bridge interface {
+	Close()
+	PostBlock(req *PostBlockRequest) error
+	PostEpoch(req *PostEpochRequest) error
+	BridgeBatch(pendingBlockNumber uint64) ([]*BridgeBatchSigned, error)
+	InsertEpoch(epoch uint64, tx *bolt.Tx) error
+}
+
+var _ Bridge = (*dummyBridge)(nil)
+
+type dummyBridge struct{}
+
+func (d *dummyBridge) Close()                                {}
+func (d *dummyBridge) PostBlock(req *PostBlockRequest) error { return nil }
+func (d *dummyBridge) PostEpoch(req *PostEpochRequest) error { return nil }
+func (d *dummyBridge) BridgeBatch(pendingBlockNumber uint64) ([]*BridgeBatchSigned, error) {
+	return nil, nil
+}
+func (d *dummyBridge) InsertEpoch(epoch uint64, tx *bolt.Tx) error { return nil }
+
+// newBridge creates a new instance of bridge
+func newBridge(bridgeBackend BridgeBackend,
+	runtimeConfig *runtimeConfig,
+	eventProvider *EventProvider,
+	logger hclog.Logger,
+	state *State) (Bridge, error) {
+	bridgeManagers := make(map[uint64]BridgeManager)
+
+	for chainID := range runtimeConfig.GenesisConfig.Bridge {
+		bridgeManager, err := newBridgeManager(bridgeBackend, runtimeConfig, eventProvider, logger, chainID, state)
+		if err != nil {
+			return nil, err
+		}
+
+		bridgeManagers[chainID] = bridgeManager
+	}
+
+	return &bridge{
+		bridgeManagers: bridgeManagers,
+	}, nil
+}
+
+// Close calls bridge manager close which stops ongoing go routines in manager
+func (b *bridge) Close() {
+	for _, bridgeManager := range b.bridgeManagers {
+		bridgeManager.Close()
+	}
+}
+
+// PostBlock is a function executed on every block finalization (either by consensus or syncer)
+// and calls PostBlock in each bridge manager
+func (b *bridge) PostBlock(req *PostBlockRequest) error {
+	for chainID, bridgeManager := range b.bridgeManagers {
+		if err := bridgeManager.PostBlock(req); err != nil {
+			return fmt.Errorf("erorr bridge post block, chainID: %d, err: %w", chainID, err)
+		}
+	}
+
+	return nil
+}
+
+// PostEpoch is a function executed on epoch ending / start of new epoch
+// and calls PostEpoch in each bridge manager
+func (b *bridge) PostEpoch(req *PostEpochRequest) error {
+	for chainID, bridgeManager := range b.bridgeManagers {
+		if err := bridgeManager.PostEpoch(req); err != nil {
+			return fmt.Errorf("erorr bridge post epoch, chainID: %d, err: %w", chainID, err)
+		}
+	}
+
+	return nil
+}
+
+// BridgeBatch returns the pending signed bridge batches as a list of signed bridge batches
+func (b *bridge) BridgeBatch(pendingBlockNumber uint64) ([]*BridgeBatchSigned, error) {
+	bridgeBatches := make([]*BridgeBatchSigned, 0, len(b.bridgeManagers))
+
+	for chainID, bridgeManager := range b.bridgeManagers {
+		bridgeBatch, err := bridgeManager.BridgeBatch(pendingBlockNumber)
+		if err != nil {
+			return nil, fmt.Errorf("error while getting signed batches chainID: %d, err: %w", chainID, err)
+		}
+
+		bridgeBatches = append(bridgeBatches, bridgeBatch)
+	}
+
+	return bridgeBatches, nil
+}
+
+// InsertEpoch cals InsertEpoch in each bridge manager on chain
+func (b *bridge) InsertEpoch(epoch uint64, dbTx *bolt.Tx) error {
+	for _, brigeManager := range b.bridgeManagers {
+		if err := brigeManager.InsertEpoch(epoch, dbTx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/consensus/polybft/bridge_manager_test.go
+++ b/consensus/polybft/bridge_manager_test.go
@@ -1,0 +1,35 @@
+package polybft
+
+import (
+	"math/big"
+
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/Ethernal-Tech/ethgo"
+	bolt "go.etcd.io/bbolt"
+)
+
+type mockBridgeManager struct {
+	chainID uint64
+	state   *State
+}
+
+func (mbm *mockBridgeManager) Close()                                        {}
+func (mbm *mockBridgeManager) AddLog(chainID *big.Int, log *ethgo.Log) error { return nil }
+func (mbm *mockBridgeManager) PostBlock(req *PostBlockRequest) error         { return nil }
+func (mbm *mockBridgeManager) PostEpoch(req *PostEpochRequest) error         { return nil }
+func (mbm *mockBridgeManager) BuildExitEventRoot(epoch uint64) (types.Hash, error) {
+	return types.ZeroHash, nil
+}
+func (mbm *mockBridgeManager) BridgeBatch(pendingBlockNumber uint64) (*BridgeBatchSigned, error) {
+	return nil, nil
+}
+func (mbm *mockBridgeManager) GenerateProof(eventID uint64, pType proofType) (types.Proof, error) {
+	return types.Proof{}, nil
+}
+func (mbm *mockBridgeManager) InsertEpoch(epoch uint64, dbTx *bolt.Tx) error {
+	if err := mbm.state.EpochStore.insertEpoch(epoch, dbTx, mbm.chainID); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/consensus/polybft/bridge_manager_test.go
+++ b/consensus/polybft/bridge_manager_test.go
@@ -23,9 +23,6 @@ func (mbm *mockBridgeManager) BuildExitEventRoot(epoch uint64) (types.Hash, erro
 func (mbm *mockBridgeManager) BridgeBatch(pendingBlockNumber uint64) (*BridgeBatchSigned, error) {
 	return nil, nil
 }
-func (mbm *mockBridgeManager) GenerateProof(eventID uint64, pType proofType) (types.Proof, error) {
-	return types.Proof{}, nil
-}
 func (mbm *mockBridgeManager) InsertEpoch(epoch uint64, dbTx *bolt.Tx) error {
 	if err := mbm.state.EpochStore.insertEpoch(epoch, dbTx, mbm.chainID); err != nil {
 		return err

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -166,8 +166,7 @@ func newConsensusRuntime(log hcf.Logger, config *runtimeConfig) (*consensusRunti
 			runtime,
 			runtime.config,
 			runtime.eventProvider,
-			runtime.logger,
-			config.State); err != nil {
+			runtime.logger); err != nil {
 			return nil, err
 		}
 	} else {

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -128,7 +128,7 @@ type consensusRuntime struct {
 	eventProvider *EventProvider
 
 	// bridgeManagers handles storing, processing and executing bridge events
-	bridgeManagers map[uint64]BridgeManager
+	bridge Bridge
 
 	// governanceManager is used for handling governance events gotten from proposals execution
 	// also handles updating client configuration based on governance proposals
@@ -159,22 +159,19 @@ func newConsensusRuntime(log hcf.Logger, config *runtimeConfig) (*consensusRunti
 		proposerCalculator: proposerCalculator,
 		logger:             log.Named("consensus_runtime"),
 		eventProvider:      NewEventProvider(config.blockchain),
-		bridgeManagers:     make(map[uint64]BridgeManager),
 	}
 
 	if runtime.IsBridgeEnabled() {
-		for chainID := range config.GenesisConfig.Bridge {
-			var bridgeManager BridgeManager
-
-			bridgeManager, err = newBridgeManager(runtime, config, runtime.eventProvider, log, chainID)
-			if err != nil {
-				return nil, err
-			}
-
-			runtime.bridgeManagers[chainID] = bridgeManager
+		if runtime.bridge, err = newBridge(
+			runtime,
+			runtime.config,
+			runtime.eventProvider,
+			runtime.logger,
+			config.State); err != nil {
+			return nil, err
 		}
 	} else {
-		runtime.bridgeManagers[0] = &dummyBridgeManager{}
+		runtime.bridge = &dummyBridge{}
 	}
 
 	if err := runtime.initStakeManager(log, dbTx); err != nil {
@@ -200,9 +197,7 @@ func newConsensusRuntime(log hcf.Logger, config *runtimeConfig) (*consensusRunti
 
 // close is used to tear down allocated resources
 func (c *consensusRuntime) close() {
-	for _, bridgeManager := range c.bridgeManagers {
-		bridgeManager.Close()
-	}
+	c.bridge.Close()
 }
 
 // initStakeManager initializes stake manager
@@ -347,13 +342,10 @@ func (c *consensusRuntime) OnBlockInserted(fullBlock *types.FullBlock) {
 		return
 	}
 
-	// handle bridge events
-	for _, bridgeManager := range c.bridgeManagers {
-		if err := bridgeManager.PostBlock(postBlock); err != nil {
-			c.logger.Error("failed to post block in bridge manager", "err", err)
+	if err := c.bridge.PostBlock(postBlock); err != nil {
+		c.logger.Error("failed to post block in bridge", "err", err)
 
-			return
-		}
+		return
 	}
 
 	// handle governance events that happened in block
@@ -427,32 +419,24 @@ func (c *consensusRuntime) FSM() error {
 	valSet := validator.NewValidatorSet(epoch.Validators, c.logger)
 
 	ff := &fsm{
-		config:                        epoch.CurrentClientConfig,
-		forks:                         c.config.Forks,
-		parent:                        parent,
-		backend:                       c.config.blockchain,
-		polybftBackend:                c.config.polybftBackend,
-		epochNumber:                   epoch.Number,
-		blockBuilder:                  blockBuilder,
-		validators:                    valSet,
-		isEndOfEpoch:                  isEndOfEpoch,
-		isEndOfSprint:                 isEndOfSprint,
-		isFirstBlockOfEpoch:           isFirstBlockOfEpoch,
-		proposerSnapshot:              proposerSnapshot,
-		logger:                        c.logger.Named("fsm"),
-		proposerBridgeBatchToRegister: make(map[uint64]*BridgeBatchSigned),
+		config:              epoch.CurrentClientConfig,
+		forks:               c.config.Forks,
+		parent:              parent,
+		backend:             c.config.blockchain,
+		polybftBackend:      c.config.polybftBackend,
+		epochNumber:         epoch.Number,
+		blockBuilder:        blockBuilder,
+		validators:          valSet,
+		isEndOfEpoch:        isEndOfEpoch,
+		isEndOfSprint:       isEndOfSprint,
+		isFirstBlockOfEpoch: isFirstBlockOfEpoch,
+		proposerSnapshot:    proposerSnapshot,
+		logger:              c.logger.Named("fsm"),
 	}
 
 	if isEndOfSprint {
-		for chainID, bridgeManager := range c.bridgeManagers {
-			bridgeBatch, err := bridgeManager.BridgeBatch(pendingBlockNumber)
-			if err != nil {
-				return err
-			}
-
-			if bridgeBatch != nil {
-				ff.proposerBridgeBatchToRegister[chainID] = bridgeBatch
-			}
+		if ff.proposerBridgeBatchToRegister, err = c.bridge.BridgeBatch(pendingBlockNumber); err != nil {
+			return err
 		}
 	}
 
@@ -528,10 +512,8 @@ func (c *consensusRuntime) restartEpoch(header *types.Header, dbTx *bolt.Tx) (*e
 		c.logger.Error("Could not clean previous epochs from db.", "error", err)
 	}
 
-	for chainID := range c.bridgeManagers {
-		if err := c.state.EpochStore.insertEpoch(epochNumber, dbTx, chainID); err != nil {
-			return nil, fmt.Errorf("an error occurred while inserting new epoch in db. Reason: %w", err)
-		}
+	if err := c.bridge.InsertEpoch(epochNumber, dbTx); err != nil {
+		return nil, err
 	}
 
 	c.logger.Info(
@@ -551,10 +533,8 @@ func (c *consensusRuntime) restartEpoch(header *types.Header, dbTx *bolt.Tx) (*e
 		Forks:             c.config.Forks,
 	}
 
-	for _, bridgeManager := range c.bridgeManagers {
-		if err := bridgeManager.PostEpoch(reqObj); err != nil {
-			return nil, err
-		}
+	if err := c.bridge.PostEpoch(reqObj); err != nil {
+		return nil, err
 	}
 
 	if err := c.governanceManager.PostEpoch(reqObj); err != nil {

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1165,7 +1165,5 @@ func createTestBridge(t *testing.T, state *State) Bridge {
 
 	manager := &mockBridgeManager{state: state, chainID: 1}
 
-	return &bridge{
-		bridgeManagers: map[uint64]BridgeManager{1: manager},
-	}
+	return bridge{1: manager}
 }

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -236,7 +236,7 @@ func TestConsensusRuntime_OnBlockInserted_EndOfEpoch(t *testing.T) {
 			CurrentClientConfig: config.GenesisConfig,
 		},
 		lastBuiltBlock: &types.Header{Number: header.Number - 1},
-		bridgeManagers: map[uint64]BridgeManager{0: &dummyBridgeManager{}},
+		bridge:         &dummyBridge{},
 		stakeManager:   &dummyStakeManager{},
 		eventProvider:  NewEventProvider(blockchainMock),
 		governanceManager: &dummyGovernanceManager{
@@ -367,7 +367,7 @@ func TestConsensusRuntime_FSM_NotEndOfEpoch_NotEndOfSprint(t *testing.T) {
 		},
 		lastBuiltBlock: lastBlock,
 		state:          newTestState(t),
-		bridgeManagers: map[uint64]BridgeManager{0: &dummyBridgeManager{}},
+		bridge:         &dummyBridge{},
 	}
 	runtime.setIsActiveValidator(true)
 
@@ -435,7 +435,7 @@ func TestConsensusRuntime_FSM_EndOfEpoch_BuildCommitEpoch(t *testing.T) {
 		config:             config,
 		lastBuiltBlock:     &types.Header{Number: 9},
 		stakeManager:       &dummyStakeManager{},
-		bridgeManagers:     map[uint64]BridgeManager{0: &dummyBridgeManager{}},
+		bridge:             &dummyBridge{},
 	}
 
 	err := runtime.FSM()

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -98,7 +98,7 @@ type fsm struct {
 	isFirstBlockOfEpoch bool
 
 	// proposerBridgeBatchToRegister is a batch that is registered via state transaction by proposer
-	proposerBridgeBatchToRegister map[uint64]*BridgeBatchSigned
+	proposerBridgeBatchToRegister []*BridgeBatchSigned
 
 	// logger instance
 	logger hclog.Logger

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -721,7 +721,7 @@ func TestFSM_VerifyStateTransaction_BridgeBatches(t *testing.T) {
 			isEndOfSprint:                 true,
 			parent:                        &types.Header{Number: 9},
 			validators:                    validatorSet,
-			proposerBridgeBatchToRegister: map[uint64]*BridgeBatchSigned{0: bridgeBatch},
+			proposerBridgeBatchToRegister: []*BridgeBatchSigned{bridgeBatch},
 			logger:                        hclog.NewNullLogger(),
 		}
 
@@ -762,7 +762,7 @@ func TestFSM_VerifyStateTransaction_BridgeBatches(t *testing.T) {
 			isEndOfSprint:                 true,
 			parent:                        &types.Header{Number: 9},
 			validators:                    validatorSet,
-			proposerBridgeBatchToRegister: map[uint64]*BridgeBatchSigned{0: bridgeBatch},
+			proposerBridgeBatchToRegister: []*BridgeBatchSigned{bridgeBatch},
 			commitEpochInput:              createTestCommitEpochInput(t, 0, 10),
 			distributeRewardsInput:        createTestDistributeRewardsInput(t, 0, nil, 10),
 			logger:                        hclog.NewNullLogger(),
@@ -1500,7 +1500,7 @@ func TestFSM_DecodeBridgeBatchStateTxs(t *testing.T) {
 	_, signedBridgeBatch, _ := buildBridgeBatchAndBridgeEvents(t, eventsSize, uint64(3), from)
 
 	f := &fsm{
-		proposerBridgeBatchToRegister: map[uint64]*BridgeBatchSigned{0: signedBridgeBatch},
+		proposerBridgeBatchToRegister: []*BridgeBatchSigned{signedBridgeBatch},
 		commitEpochInput:              createTestCommitEpochInput(t, 0, 10),
 		distributeRewardsInput:        createTestDistributeRewardsInput(t, 0, nil, 10),
 		logger:                        hclog.NewNullLogger(),

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -216,7 +216,7 @@ func TestPolybft_Close(t *testing.T) {
 		closeCh: make(chan struct{}),
 		syncer:  syncer,
 		runtime: &consensusRuntime{
-			bridgeManagers: map[uint64]BridgeManager{0: &dummyBridgeManager{}},
+			bridge: &dummyBridge{},
 		},
 		state: &State{db: &bbolt.DB{}},
 	}


### PR DESCRIPTION
# Description

This pull request introduces a new Bridge type that manages multiple bridge managers. The Bridge type contains a map of bridge managers, with the chainID as the key. The primary purpose of the Bridge type is to serve as a wrapper around these bridge managers. It iterates through all the bridge managers and invokes their respective functions.

`Bridge` type functions:

- `Close()`  
- `PostBlockAsync(req *PostBlockRequest)`
- `PostBlock(req *PostBlockRequest) error`
- `PostEpoch(req *PostEpochRequest) error`
- `BridgeBatch(pendingBlockNumber uint64) ([]*BridgeBatchSigned, error)`
- `InsertEpoch(epoch uint64, tx *bolt.Tx) error`


# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
