### PR TITLE
Fix binding generation

### DIFF
--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -612,11 +612,13 @@ func generateType(generatedData *generatedData, name string, obj *abi.Type, res 
 
 // generateNestedType generates code for nested types found in smart contracts structs
 func generateNestedType(generatedData *generatedData, name string, obj *abi.Type, res *[]string) (string, error) {
+	internalType := getInternalType(name, obj)
+
 	for _, s := range generatedData.structs {
-		if s == name {
+		if s == internalType {
 			// do not generate the same type again if it's already generated
 			// this happens when two functions use the same struct type as one of its parameters
-			return "*" + name, nil
+			return "*" + internalType, nil
 		}
 	}
 


### PR DESCRIPTION
# Description

Fixes issue when two functions use the same struct in parameters (The same struct gets generated twice in the bindings).

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually