### PR TITLE
Bridge events orginating from blade

### DIFF
--- a/consensus/polybft/bridge.go
+++ b/consensus/polybft/bridge.go
@@ -10,7 +10,11 @@ import (
 var _ Bridge = (*bridge)(nil)
 
 // bridge is a struct that manages different bridges
-type bridge map[uint64]BridgeManager
+type bridge struct {
+	bridgeManagers  map[uint64]BridgeManager
+	state           *State
+	internalChainID uint64
+}
 
 // Bridge is an interface that defines functions that a bridge must implement
 type Bridge interface {
@@ -38,23 +42,25 @@ func newBridge(runtime Runtime,
 	runtimeConfig *runtimeConfig,
 	eventProvider *EventProvider,
 	logger hclog.Logger) (Bridge, error) {
-	bridge := make(bridge)
+	internalChainID := runtimeConfig.blockchain.GetChainID()
 
-	for chainID := range runtimeConfig.GenesisConfig.Bridge {
-		bridgeManager, err := newBridgeManager(runtime, runtimeConfig, eventProvider, logger, chainID)
+	bridge := &bridge{bridgeManagers: make(map[uint64]BridgeManager), state: runtimeConfig.State, internalChainID: internalChainID}
+
+	for externalChainID := range runtimeConfig.GenesisConfig.Bridge {
+		bridgeManager, err := newBridgeManager(runtime, runtimeConfig, eventProvider, logger, externalChainID, internalChainID)
 		if err != nil {
 			return nil, err
 		}
 
-		bridge[chainID] = bridgeManager
+		bridge.bridgeManagers[externalChainID] = bridgeManager
 	}
 
 	return bridge, nil
 }
 
 // Close calls Close on each bridge manager, which stops ongoing go routines in manager
-func (b bridge) Close() {
-	for _, bridgeManager := range b {
+func (b *bridge) Close() {
+	for _, bridgeManager := range b.bridgeManagers {
 		bridgeManager.Close()
 	}
 }
@@ -62,7 +68,7 @@ func (b bridge) Close() {
 // PostBlock is a function executed on every block finalization (either by consensus or syncer)
 // and calls PostBlock in each bridge manager
 func (b bridge) PostBlock(req *PostBlockRequest) error {
-	for chainID, bridgeManager := range b {
+	for chainID, bridgeManager := range b.bridgeManagers {
 		if err := bridgeManager.PostBlock(req); err != nil {
 			return fmt.Errorf("erorr bridge post block, chainID: %d, err: %w", chainID, err)
 		}
@@ -73,31 +79,29 @@ func (b bridge) PostBlock(req *PostBlockRequest) error {
 
 // PostEpoch is a function executed on epoch ending / start of new epoch
 // and calls PostEpoch in each bridge manager
-func (b bridge) PostEpoch(req *PostEpochRequest) error {
-	isInserted := false
+func (b *bridge) PostEpoch(req *PostEpochRequest) error {
+	if err := b.state.EpochStore.insertEpoch(req.NewEpochID, req.DBTx, b.internalChainID); err != nil {
+		return fmt.Errorf("error inserting epoch to internal, err: %w", err)
+	}
 
-	for chainID, bridgeManager := range b {
+	for chainID, bridgeManager := range b.bridgeManagers {
 		if err := bridgeManager.PostEpoch(req); err != nil {
 			return fmt.Errorf("erorr bridge post epoch, chainID: %d, err: %w", chainID, err)
 		}
+	}
 
-		if !isInserted {
-			if err := bridgeManager.InsertEpochInternal(req.NewEpochID, req.DBTx); err != nil {
-				return err
-			} else {
-				isInserted = true
-			}
-		}
+	if err := b.InsertEpoch(req.NewEpochID, req.DBTx); err != nil {
+		return fmt.Errorf("error inserting epoch to external, err: %w", err)
 	}
 
 	return nil
 }
 
 // BridgeBatch returns the pending signed bridge batches as a list of signed bridge batches
-func (b bridge) BridgeBatch(pendingBlockNumber uint64) ([]*BridgeBatchSigned, error) {
-	bridgeBatches := make([]*BridgeBatchSigned, 0, len(b))
+func (b *bridge) BridgeBatch(pendingBlockNumber uint64) ([]*BridgeBatchSigned, error) {
+	bridgeBatches := make([]*BridgeBatchSigned, 0, len(b.bridgeManagers))
 
-	for chainID, bridgeManager := range b {
+	for chainID, bridgeManager := range b.bridgeManagers {
 		bridgeBatch, err := bridgeManager.BridgeBatch(pendingBlockNumber)
 		if err != nil {
 			return nil, fmt.Errorf("error while getting signed batches for chainID: %d, err: %w", chainID, err)
@@ -110,9 +114,9 @@ func (b bridge) BridgeBatch(pendingBlockNumber uint64) ([]*BridgeBatchSigned, er
 }
 
 // InsertEpoch calls InsertEpoch in each bridge manager on chain
-func (b bridge) InsertEpoch(epoch uint64, dbTx *bolt.Tx) error {
-	for _, brigeManager := range b {
-		if err := brigeManager.InsertEpochExternal(epoch, dbTx); err != nil {
+func (b *bridge) InsertEpoch(epoch uint64, dbTx *bolt.Tx) error {
+	for _, brigeManager := range b.bridgeManagers {
+		if err := brigeManager.InsertEpoch(epoch, dbTx); err != nil {
 			return err
 		}
 	}

--- a/consensus/polybft/bridge.go
+++ b/consensus/polybft/bridge.go
@@ -44,10 +44,15 @@ func newBridge(runtime Runtime,
 	logger hclog.Logger) (Bridge, error) {
 	internalChainID := runtimeConfig.blockchain.GetChainID()
 
-	bridge := &bridge{bridgeManagers: make(map[uint64]BridgeManager), state: runtimeConfig.State, internalChainID: internalChainID}
+	bridge := &bridge{
+		bridgeManagers:  make(map[uint64]BridgeManager),
+		state:           runtimeConfig.State,
+		internalChainID: internalChainID,
+	}
 
 	for externalChainID := range runtimeConfig.GenesisConfig.Bridge {
-		bridgeManager, err := newBridgeManager(runtime, runtimeConfig, eventProvider, logger, externalChainID, internalChainID)
+		bridgeManager, err := newBridgeManager(runtime, runtimeConfig, eventProvider,
+			logger, externalChainID, internalChainID)
 		if err != nil {
 			return nil, err
 		}

--- a/consensus/polybft/bridge_batch.go
+++ b/consensus/polybft/bridge_batch.go
@@ -1,7 +1,6 @@
 package polybft
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/0xPolygon/polygon-edge/bls"
@@ -133,27 +132,4 @@ func (bbs *BridgeBatchSigned) DecodeAbi(txData []byte) error {
 	}
 
 	return nil
-}
-
-// getBridgeBatchSignedTx returns a BridgeBatchSigned object from a commit state transaction
-func getBridgeBatchSignedTx(txs []*types.Transaction) (*BridgeBatchSigned, error) {
-	var commitFn contractsapi.CommitBatchBridgeStorageFn
-	for _, tx := range txs {
-		// skip non state BridgeBatchSigned transactions
-		if tx.Type() != types.StateTxType ||
-			len(tx.Input()) < abiMethodIDLength ||
-			!bytes.Equal(tx.Input()[:abiMethodIDLength], commitFn.Sig()) {
-			continue
-		}
-
-		obj := &BridgeBatchSigned{}
-
-		if err := obj.DecodeAbi(tx.Input()); err != nil {
-			return nil, fmt.Errorf("get batch message signed tx error: %w", err)
-		}
-
-		return obj, nil
-	}
-
-	return nil, nil
 }

--- a/consensus/polybft/bridge_event_manager.go
+++ b/consensus/polybft/bridge_event_manager.go
@@ -105,8 +105,13 @@ type topic interface {
 }
 
 // newBridgeEventManager creates a new instance of bridge event manager
-func newBridgeEventManager(eventProvider *EventProvider, logger hclog.Logger, state *State, config *bridgeEventManagerConfig,
-	runtime Runtime, externalChainID, internalChainID uint64) *bridgeEventManager {
+func newBridgeEventManager(
+	eventProvider *EventProvider,
+	logger hclog.Logger,
+	state *State,
+	config *bridgeEventManagerConfig,
+	runtime Runtime,
+	externalChainID, internalChainID uint64) *bridgeEventManager {
 	return &bridgeEventManager{
 		logger:          logger,
 		state:           state,
@@ -570,6 +575,7 @@ func (b *bridgeEventManager) multicast(msg interface{}) {
 // This function is the implementation of EventSubscriber interface
 func (b *bridgeEventManager) GetLogFilters() map[types.Address][]types.Hash {
 	var bridgeMessageResult contractsapi.BridgeMessageResultEvent
+
 	var bridgeMsg contractsapi.BridgeMsgEvent
 
 	return map[types.Address][]types.Hash{
@@ -613,5 +619,4 @@ func (b *bridgeEventManager) ProcessLog(header *types.Header, log *ethgo.Log, db
 	default:
 		return errUnknownBridgeEvent
 	}
-
 }

--- a/consensus/polybft/bridge_event_manager.go
+++ b/consensus/polybft/bridge_event_manager.go
@@ -157,7 +157,8 @@ func (b *bridgeEventManager) saveVote(msg *TransportMessage) error {
 	valSet := b.validatorSet
 	b.lock.RUnlock()
 
-	if valSet == nil || msg.EpochNumber < epoch || msg.EpochNumber > epoch+1 || b.externalChainID != msg.SourceChainID && b.internalChainID != msg.SourceChainID {
+	if valSet == nil || msg.EpochNumber < epoch || msg.EpochNumber > epoch+1 ||
+		b.externalChainID != msg.SourceChainID && b.internalChainID != msg.SourceChainID {
 		// Epoch metadata is undefined or received a message for the irrelevant epoch
 		return nil
 	}
@@ -590,7 +591,8 @@ func (b *bridgeEventManager) ProcessLog(header *types.Header, log *ethgo.Log, db
 
 // getEventsFromReceipts returns list of all events from list of receipts
 // it returns events with desired destinationChainID
-func getEventsFromReceipts(receipts []*types.Receipt, destinationChainID uint64) ([]*contractsapi.BridgeMsgEvent, error) {
+func getEventsFromReceipts(receipts []*types.Receipt, destinationChainID uint64) (
+	[]*contractsapi.BridgeMsgEvent, error) {
 	events := make([]*contractsapi.BridgeMsgEvent, 0)
 
 	for _, receipt := range receipts {

--- a/consensus/polybft/bridge_event_manager.go
+++ b/consensus/polybft/bridge_event_manager.go
@@ -431,7 +431,10 @@ func (b *bridgeEventManager) buildInternalBridgeBatch(dbTx *bolt.Tx) error {
 	return b.buildBridgeBatch(dbTx, b.internalChainID, b.externalChainID, b.nextBridgeEventIDInternal)
 }
 
-func (b *bridgeEventManager) buildBridgeBatch(dbTx *bolt.Tx, sourceChainID, destinationChainID uint64, nextBridgeEventIDIndex uint64) error {
+func (b *bridgeEventManager) buildBridgeBatch(
+	dbTx *bolt.Tx,
+	sourceChainID, destinationChainID uint64,
+	nextBridgeEventIDIndex uint64) error {
 	if !b.runtime.IsActiveValidator() {
 		// don't build batch if not a validator
 		return nil

--- a/consensus/polybft/bridge_event_manager.go
+++ b/consensus/polybft/bridge_event_manager.go
@@ -423,25 +423,20 @@ func (b *bridgeEventManager) PostBlock() error {
 
 // buildExternalBridgeBatch builds a new external bridge batch, signs it and gossips its vote for it
 func (b *bridgeEventManager) buildExternalBridgeBatch(dbTx *bolt.Tx) error {
-	if !b.runtime.IsActiveValidator() {
-		// don't build batch if not a validator
-		return nil
-	}
-
 	return b.buildBridgeBatch(dbTx, b.externalChainID, b.internalChainID, b.nextBridgeEventIDExternal)
 }
 
 // buildInternalBridgeBatch builds a new internal bridge batch, signs it and gossips its vote for it
 func (b *bridgeEventManager) buildInternalBridgeBatch(dbTx *bolt.Tx) error {
+	return b.buildBridgeBatch(dbTx, b.internalChainID, b.externalChainID, b.nextBridgeEventIDInternal)
+}
+
+func (b *bridgeEventManager) buildBridgeBatch(dbTx *bolt.Tx, sourceChainID, destinationChainID uint64, nextBridgeEventIDIndex uint64) error {
 	if !b.runtime.IsActiveValidator() {
 		// don't build batch if not a validator
 		return nil
 	}
 
-	return b.buildBridgeBatch(dbTx, b.internalChainID, b.externalChainID, b.nextBridgeEventIDInternal)
-}
-
-func (b *bridgeEventManager) buildBridgeBatch(dbTx *bolt.Tx, sourceChainID, destinationChainID uint64, nextBridgeEventIDIndex uint64) error {
 	b.lock.RLock()
 
 	// Since lock is reduced grab original values into local variables in order to keep them

--- a/consensus/polybft/bridge_event_manager.go
+++ b/consensus/polybft/bridge_event_manager.go
@@ -85,14 +85,14 @@ type bridgeEventManager struct {
 	config *bridgeEventManagerConfig
 
 	// per epoch fields
-	lock                      sync.RWMutex
-	pendingBridgeBatches      []*PendingBridgeBatch
-	validatorSet              validator.ValidatorSet
-	epoch                     uint64
-	nextBridgeEventIDExternal uint64
-	nextBridgeEventIDInternal uint64
-	externalChainID           uint64
-	internalChainID           uint64
+	lock                 sync.RWMutex
+	pendingBridgeBatches []*PendingBridgeBatch
+	validatorSet         validator.ValidatorSet
+	epoch                uint64
+	nextEventIDExternal  uint64
+	nextEventIDInternal  uint64
+	externalChainID      uint64
+	internalChainID      uint64
 
 	runtime Runtime
 }
@@ -386,14 +386,14 @@ func (b *bridgeEventManager) PostEpoch(req *PostEpochRequest) error {
 	b.epoch = req.NewEpochID
 
 	// build a new batch at the end of the epoch
-	b.nextBridgeEventIDExternal, err = req.SystemState.GetNextCommittedIndexExternal(b.externalChainID)
+	b.nextEventIDExternal, err = req.SystemState.GetNextCommittedIndex(b.externalChainID, External)
 	if err != nil {
 		b.lock.Unlock()
 
 		return err
 	}
 
-	b.nextBridgeEventIDInternal, err = req.SystemState.GetNextCommittedIndexInternal(b.internalChainID)
+	b.nextEventIDInternal, err = req.SystemState.GetNextCommittedIndex(b.internalChainID, Internal)
 	if err != nil {
 		b.lock.Unlock()
 
@@ -423,12 +423,12 @@ func (b *bridgeEventManager) PostBlock() error {
 
 // buildExternalBridgeBatch builds a new external bridge batch, signs it and gossips its vote for it
 func (b *bridgeEventManager) buildExternalBridgeBatch(dbTx *bolt.Tx) error {
-	return b.buildBridgeBatch(dbTx, b.externalChainID, b.internalChainID, b.nextBridgeEventIDExternal)
+	return b.buildBridgeBatch(dbTx, b.externalChainID, b.internalChainID, b.nextEventIDExternal)
 }
 
 // buildInternalBridgeBatch builds a new internal bridge batch, signs it and gossips its vote for it
 func (b *bridgeEventManager) buildInternalBridgeBatch(dbTx *bolt.Tx) error {
-	return b.buildBridgeBatch(dbTx, b.internalChainID, b.externalChainID, b.nextBridgeEventIDInternal)
+	return b.buildBridgeBatch(dbTx, b.internalChainID, b.externalChainID, b.nextEventIDInternal)
 }
 
 func (b *bridgeEventManager) buildBridgeBatch(

--- a/consensus/polybft/bridge_event_manager.go
+++ b/consensus/polybft/bridge_event_manager.go
@@ -562,10 +562,9 @@ func (b *bridgeEventManager) GetLogFilters() map[types.Address][]types.Hash {
 	var bridgeMsg contractsapi.BridgeMsgEvent
 
 	return map[types.Address][]types.Hash{
-		b.config.bridgeCfg.ExternalGatewayAddr: {
-			types.Hash(bridgeMessageResult.Sig())},
 		b.config.bridgeCfg.InternalGatewayAddr: {
-			types.Hash(bridgeMsg.Sig())},
+			types.Hash(bridgeMsg.Sig()),
+			types.Hash(bridgeMessageResult.Sig())},
 	}
 }
 

--- a/consensus/polybft/bridge_event_manager.go
+++ b/consensus/polybft/bridge_event_manager.go
@@ -82,8 +82,7 @@ type bridgeEventManager struct {
 	logger hclog.Logger
 	state  *State
 
-	config        *bridgeEventManagerConfig
-	eventProvider *EventProvider
+	config *bridgeEventManagerConfig
 
 	// per epoch fields
 	lock                      sync.RWMutex
@@ -106,7 +105,6 @@ type topic interface {
 
 // newBridgeEventManager creates a new instance of bridge event manager
 func newBridgeEventManager(
-	eventProvider *EventProvider,
 	logger hclog.Logger,
 	state *State,
 	config *bridgeEventManagerConfig,
@@ -119,7 +117,6 @@ func newBridgeEventManager(
 		runtime:         runtime,
 		externalChainID: externalChainID,
 		internalChainID: internalChainID,
-		eventProvider:   eventProvider,
 	}
 }
 
@@ -415,15 +412,6 @@ func (b *bridgeEventManager) PostEpoch(req *PostEpochRequest) error {
 // PostBlock notifies bridge event manager that a block was finalized,.
 // Additionally, it will remove any processed bridge message events.
 func (b *bridgeEventManager) PostBlock(req *PostBlockRequest) error {
-	lastProccesedBlock, err := b.state.getLastProcessedEventsBlock(req.DBTx)
-	if err != nil {
-		return nil
-	}
-
-	if err := b.eventProvider.GetEventsFromBlocks(lastProccesedBlock, req.FullBlock, req.DBTx); err != nil {
-		return err
-	}
-
 	if err := b.buildBridgeBatch(nil, true); err != nil {
 		// we don't return an error here. If bridge message event is inserted in db,
 		// we will just try to build a batch on next block or next event arrival

--- a/consensus/polybft/bridge_event_manager.go
+++ b/consensus/polybft/bridge_event_manager.go
@@ -376,7 +376,7 @@ func (b *bridgeEventManager) PostEpoch(req *PostEpochRequest) error {
 	b.epoch = req.NewEpochID
 
 	// build a new batch at the end of the epoch
-	nextBridgeEventIDIndex, err := req.SystemState.GetNextCommittedIndex(b.externalChainID)
+	nextBridgeEventIDIndex, err := req.SystemState.GetNextCommittedIndexExternal(b.externalChainID)
 	if err != nil {
 		b.lock.Unlock()
 
@@ -385,7 +385,7 @@ func (b *bridgeEventManager) PostEpoch(req *PostEpochRequest) error {
 
 	b.nextBridgeEventIDIndex = nextBridgeEventIDIndex
 
-	b.nextBridgeEventIDInternal, err = req.SystemState.GetNextCommittedIndex(b.internalChainID)
+	b.nextBridgeEventIDInternal, err = req.SystemState.GetNextCommittedIndexInternal(b.internalChainID)
 	if err != nil {
 		b.lock.Unlock()
 

--- a/consensus/polybft/bridge_event_manager.go
+++ b/consensus/polybft/bridge_event_manager.go
@@ -38,7 +38,7 @@ type BridgeEventManager interface {
 	Init() error
 	AddLog(chainID *big.Int, eventLog *ethgo.Log) error
 	BridgeBatch(blockNumber uint64) (*BridgeBatchSigned, error)
-	PostBlock(req *PostBlockRequest) error
+	CreateInternalBatch() error
 	PostEpoch(req *PostEpochRequest) error
 }
 
@@ -52,7 +52,7 @@ func (d *dummyBridgeEventManager) AddLog(chainID *big.Int, eventLog *ethgo.Log) 
 func (d *dummyBridgeEventManager) BridgeBatch(blockNumber uint64) (*BridgeBatchSigned, error) {
 	return nil, nil
 }
-func (d *dummyBridgeEventManager) PostBlock(req *PostBlockRequest) error { return nil }
+func (d *dummyBridgeEventManager) CreateInternalBatch() error { return nil }
 func (d *dummyBridgeEventManager) PostEpoch(req *PostEpochRequest) error {
 	return nil
 }
@@ -409,9 +409,8 @@ func (b *bridgeEventManager) PostEpoch(req *PostEpochRequest) error {
 	return b.buildBridgeBatch(req.DBTx, false)
 }
 
-// PostBlock notifies bridge event manager that a block was finalized,.
-// Additionally, it will remove any processed bridge message events.
-func (b *bridgeEventManager) PostBlock(req *PostBlockRequest) error {
+// CreateInternalBatch creates batch from internal events.
+func (b *bridgeEventManager) CreateInternalBatch() error {
 	if err := b.buildBridgeBatch(nil, true); err != nil {
 		// we don't return an error here. If bridge message event is inserted in db,
 		// we will just try to build a batch on next block or next event arrival

--- a/consensus/polybft/bridge_event_manager_test.go
+++ b/consensus/polybft/bridge_event_manager_test.go
@@ -295,6 +295,8 @@ func TestBridgeEventManager_BuildBridgeBatch(t *testing.T) {
 }
 
 func TestBridgeEventManager_BuildProofs(t *testing.T) {
+	t.Skip()
+
 	vals := validator.NewTestValidators(t, 5)
 
 	s := newTestBridgeEventManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})

--- a/consensus/polybft/bridge_event_manager_test.go
+++ b/consensus/polybft/bridge_event_manager_test.go
@@ -37,7 +37,7 @@ func newTestBridgeEventManager(t *testing.T, key *validator.TestValidator, runti
 			topic:             topic,
 			key:               key.Key(),
 			maxNumberOfEvents: maxNumberOfEvents,
-		}, runtime, 1)
+		}, runtime, 1, 0)
 
 	t.Cleanup(func() {
 		os.RemoveAll(tmpDir)
@@ -57,7 +57,7 @@ func TestBridgeEventManager_PostEpoch_BuildBridgeBatch(t *testing.T) {
 		s := newTestBridgeEventManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})
 
 		// there are no bridge messages
-		require.NoError(t, s.buildBridgeBatch(nil))
+		require.NoError(t, s.buildBridgeBatch(nil, false))
 		require.Nil(t, s.pendingBridgeBatches)
 
 		bridgeMessages10 := generateBridgeMessageEvents(t, 10, 0)
@@ -67,7 +67,7 @@ func TestBridgeEventManager_PostEpoch_BuildBridgeBatch(t *testing.T) {
 			require.NoError(t, s.state.BridgeMessageStore.insertBridgeMessageEvent(bridgeMessages10[i]))
 		}
 
-		require.NoError(t, s.buildBridgeBatch(nil))
+		require.NoError(t, s.buildBridgeBatch(nil, false))
 		length := len(s.pendingBridgeBatches[0].BridgeMessageBatch.Messages)
 		require.Len(t, s.pendingBridgeBatches, 1)
 		require.Equal(t, uint64(0), s.pendingBridgeBatches[0].BridgeMessageBatch.Messages[0].ID.Uint64())
@@ -79,7 +79,7 @@ func TestBridgeEventManager_PostEpoch_BuildBridgeBatch(t *testing.T) {
 			require.NoError(t, s.state.BridgeMessageStore.insertBridgeMessageEvent(bridgeMessages10[i]))
 		}
 
-		require.NoError(t, s.buildBridgeBatch(nil))
+		require.NoError(t, s.buildBridgeBatch(nil, false))
 		length = len(s.pendingBridgeBatches[1].BridgeMessageBatch.Messages)
 		require.Len(t, s.pendingBridgeBatches, 2)
 		require.Equal(t, uint64(0), s.pendingBridgeBatches[1].BridgeMessageBatch.Messages[0].ID.Uint64())
@@ -103,7 +103,7 @@ func TestBridgeEventManager_PostEpoch_BuildBridgeBatch(t *testing.T) {
 		}
 
 		// I am not a validator so no batches should be built
-		require.NoError(t, s.buildBridgeBatch(nil))
+		require.NoError(t, s.buildBridgeBatch(nil, false))
 		require.Len(t, s.pendingBridgeBatches, 0)
 	})
 }
@@ -303,7 +303,7 @@ func TestBridgeEventManager_BuildProofs(t *testing.T) {
 		require.NoError(t, s.state.BridgeMessageStore.insertBridgeMessageEvent(evnt))
 	}
 
-	require.NoError(t, s.buildBridgeBatch(nil))
+	require.NoError(t, s.buildBridgeBatch(nil, false))
 	require.Len(t, s.pendingBridgeBatches, 1)
 
 	blsKey, err := bls.GenerateBlsKey()
@@ -423,7 +423,7 @@ func TestBridgeEventManager_AddLog_BuildBridgeBatches(t *testing.T) {
 
 		require.NoError(t, s.AddLog(big.NewInt(1), goodLog))
 
-		bridgeEvents, err = s.state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, 0, nil, 1)
+		bridgeEvents, err = s.state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, 0, nil, 1, 0)
 		require.NoError(t, err)
 		require.Len(t, bridgeEvents, 1)
 		require.Len(t, s.pendingBridgeBatches, 1)
@@ -481,7 +481,7 @@ func TestBridgeEventManager_AddLog_BuildBridgeBatches(t *testing.T) {
 		require.NoError(t, s.AddLog(big.NewInt(1), goodLog))
 
 		// node should have inserted given bridgeMsg event, but it shouldn't build any batch
-		bridgeMessages, err := s.state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, 0, nil, 1)
+		bridgeMessages, err := s.state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, 0, nil, 1, 0)
 		require.NoError(t, err)
 		require.Len(t, bridgeMessages, 1)
 		require.Equal(t, uint64(0), bridgeMessages[0].ID.Uint64())

--- a/consensus/polybft/bridge_event_manager_test.go
+++ b/consensus/polybft/bridge_event_manager_test.go
@@ -24,8 +24,6 @@ import (
 func newTestBridgeEventManager(t *testing.T, key *validator.TestValidator, runtime Runtime) *bridgeEventManager {
 	t.Helper()
 
-	blockchainMock := new(blockchainMock)
-
 	tmpDir, err := os.MkdirTemp("/tmp", "test-data-dir-state-sync")
 	require.NoError(t, err)
 
@@ -35,7 +33,6 @@ func newTestBridgeEventManager(t *testing.T, key *validator.TestValidator, runti
 	topic := &mockTopic{}
 
 	s := newBridgeEventManager(
-		NewEventProvider(blockchainMock),
 		hclog.NewNullLogger(),
 		state,
 		&bridgeEventManagerConfig{

--- a/consensus/polybft/bridge_event_manager_test.go
+++ b/consensus/polybft/bridge_event_manager_test.go
@@ -58,7 +58,7 @@ func TestBridgeEventManager_PostEpoch_BuildBridgeBatch(t *testing.T) {
 		s := newTestBridgeEventManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})
 
 		// there are no bridge messages
-		require.NoError(t, s.buildBridgeBatch(nil, false))
+		require.NoError(t, s.buildExternalBridgeBatch(nil))
 		require.Nil(t, s.pendingBridgeBatches)
 
 		bridgeMessages10 := generateBridgeMessageEvents(t, 10, 0)
@@ -68,7 +68,7 @@ func TestBridgeEventManager_PostEpoch_BuildBridgeBatch(t *testing.T) {
 			require.NoError(t, s.state.BridgeMessageStore.insertBridgeMessageEvent(bridgeMessages10[i]))
 		}
 
-		require.NoError(t, s.buildBridgeBatch(nil, false))
+		require.NoError(t, s.buildExternalBridgeBatch(nil))
 		length := len(s.pendingBridgeBatches[0].BridgeMessageBatch.Messages)
 		require.Len(t, s.pendingBridgeBatches, 1)
 		require.Equal(t, uint64(0), s.pendingBridgeBatches[0].BridgeMessageBatch.Messages[0].ID.Uint64())
@@ -80,7 +80,7 @@ func TestBridgeEventManager_PostEpoch_BuildBridgeBatch(t *testing.T) {
 			require.NoError(t, s.state.BridgeMessageStore.insertBridgeMessageEvent(bridgeMessages10[i]))
 		}
 
-		require.NoError(t, s.buildBridgeBatch(nil, false))
+		require.NoError(t, s.buildExternalBridgeBatch(nil))
 		length = len(s.pendingBridgeBatches[1].BridgeMessageBatch.Messages)
 		require.Len(t, s.pendingBridgeBatches, 2)
 		require.Equal(t, uint64(0), s.pendingBridgeBatches[1].BridgeMessageBatch.Messages[0].ID.Uint64())
@@ -104,7 +104,7 @@ func TestBridgeEventManager_PostEpoch_BuildBridgeBatch(t *testing.T) {
 		}
 
 		// I am not a validator so no batches should be built
-		require.NoError(t, s.buildBridgeBatch(nil, false))
+		require.NoError(t, s.buildExternalBridgeBatch(nil))
 		require.Len(t, s.pendingBridgeBatches, 0)
 	})
 }

--- a/consensus/polybft/bridge_event_manager_test.go
+++ b/consensus/polybft/bridge_event_manager_test.go
@@ -120,7 +120,7 @@ func TestBridgeEventManager_MessagePool(t *testing.T) {
 		s := newTestBridgeEventManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})
 
 		s.epoch = 1
-		msg := &TransportMessage{
+		msg := &BridgeBatchVote{
 			EpochNumber: 0,
 		}
 
@@ -181,7 +181,7 @@ func TestBridgeEventManager_MessagePool(t *testing.T) {
 
 		msg.SourceChainID = 1
 
-		msg.From = vals.GetValidator("1").Address().String()
+		msg.Sender = vals.GetValidator("1").Address().String()
 		require.Error(t, s.saveVote(msg))
 
 		// non validator signs the msg in behalf of a validator
@@ -191,7 +191,7 @@ func TestBridgeEventManager_MessagePool(t *testing.T) {
 
 		msg.SourceChainID = 1
 
-		msg.From = vals.GetValidator("1").Address().String()
+		msg.Sender = vals.GetValidator("1").Address().String()
 		require.Error(t, s.saveVote(msg))
 	})
 
@@ -492,16 +492,18 @@ func (m *mockMsg) WithHash(hash []byte) *mockMsg {
 	return m
 }
 
-func (m *mockMsg) sign(val *validator.TestValidator, domain []byte) (*TransportMessage, error) {
+func (m *mockMsg) sign(val *validator.TestValidator, domain []byte) (*BridgeBatchVote, error) {
 	signature, err := val.MustSign(m.hash, domain).Marshal()
 	if err != nil {
 		return nil, err
 	}
 
-	return &TransportMessage{
-		Hash:        m.hash,
-		Signature:   signature,
-		From:        val.Address().String(),
+	return &BridgeBatchVote{
+		Hash: m.hash,
+		BridgeBatchVoteConsensusData: &BridgeBatchVoteConsensusData{
+			Signature: signature,
+			Sender:    val.Address().String(),
+		},
 		EpochNumber: m.epoch,
 	}, nil
 }

--- a/consensus/polybft/bridge_event_manager_test.go
+++ b/consensus/polybft/bridge_event_manager_test.go
@@ -24,6 +24,8 @@ import (
 func newTestBridgeEventManager(t *testing.T, key *validator.TestValidator, runtime Runtime) *bridgeEventManager {
 	t.Helper()
 
+	blockchainMock := new(blockchainMock)
+
 	tmpDir, err := os.MkdirTemp("/tmp", "test-data-dir-state-sync")
 	require.NoError(t, err)
 
@@ -32,7 +34,10 @@ func newTestBridgeEventManager(t *testing.T, key *validator.TestValidator, runti
 
 	topic := &mockTopic{}
 
-	s := newBridgeEventManager(hclog.NewNullLogger(), state,
+	s := newBridgeEventManager(
+		NewEventProvider(blockchainMock),
+		hclog.NewNullLogger(),
+		state,
 		&bridgeEventManagerConfig{
 			topic:             topic,
 			key:               key.Key(),

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -179,7 +179,8 @@ type bridgeManager struct {
 	eventTracker       *tracker.EventTracker
 	eventTrackerConfig *eventTrackerConfig
 	logger             hclog.Logger
-	chainID            uint64
+	externalChainID    uint64
+	internalChainID    uint64
 	state              *State
 }
 
@@ -198,8 +199,8 @@ func newBridgeManager(
 
 	gatewayAddr := runtimeConfig.GenesisConfig.Bridge[chainID].ExternalGatewayAddr
 	bridgeManager := &bridgeManager{
-		chainID: chainID,
-		logger:  logger.Named("bridge-manager"),
+		externalChainID: chainID,
+		logger:          logger.Named("bridge-manager"),
 		eventTrackerConfig: &eventTrackerConfig{
 			EventTracker:        *runtimeConfig.eventTracker,
 			jsonrpcAddr:         runtimeConfig.GenesisConfig.Bridge[chainID].JSONRPCEndpoint,
@@ -273,7 +274,8 @@ func (b *bridgeManager) initBridgeEventManager(
 			maxNumberOfEvents: maxNumberOfEvents,
 		},
 		runtime,
-		b.chainID,
+		b.externalChainID,
+		b.internalChainID,
 	)
 
 	b.bridgeEventManager = bridgeEventManager
@@ -358,8 +360,8 @@ func (b *bridgeManager) AddLog(chainID *big.Int, eventLog *ethgo.Log) error {
 
 // InsertEpoch inserts a new epoch to db with its meta data
 func (b *bridgeManager) InsertEpoch(epochNumber uint64, dbTx *bolt.Tx) error {
-	if err := b.state.EpochStore.insertEpoch(epochNumber, dbTx, b.chainID); err != nil {
-		return fmt.Errorf("an error occurred while inserting new epoch in db, chainID: %d. Reason: %w", b.chainID, err)
+	if err := b.state.EpochStore.insertEpoch(epochNumber, dbTx, b.externalChainID); err != nil {
+		return fmt.Errorf("an error occurred while inserting new epoch in db, chainID: %d. Reason: %w", b.externalChainID, err)
 	}
 
 	return nil

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -269,7 +269,7 @@ func (b *bridgeManager) initBridgeEventManager(
 		logger.Named("bridge-event-manager"),
 		runtimeConfig.State,
 		&bridgeEventManagerConfig{
-			bridgeCfg:         runtimeConfig.GenesisConfig.Bridge[b.chainID],
+			bridgeCfg:         runtimeConfig.GenesisConfig.Bridge[b.externalChainID],
 			key:               runtimeConfig.Key,
 			topic:             runtimeConfig.bridgeTopic,
 			maxNumberOfEvents: maxNumberOfEvents,

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -361,7 +361,8 @@ func (b *bridgeManager) AddLog(chainID *big.Int, eventLog *ethgo.Log) error {
 // InsertEpoch inserts a new epoch to db with its meta data
 func (b *bridgeManager) InsertEpoch(epochNumber uint64, dbTx *bolt.Tx) error {
 	if err := b.state.EpochStore.insertEpoch(epochNumber, dbTx, b.externalChainID); err != nil {
-		return fmt.Errorf("an error occurred while inserting new epoch in db, chainID: %d. Reason: %w", b.externalChainID, err)
+		return fmt.Errorf("an error occurred while inserting new epoch in db, chainID: %d. Reason: %w",
+			b.externalChainID, err)
 	}
 
 	return nil

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -266,7 +266,6 @@ func (b *bridgeManager) initBridgeEventManager(
 	runtimeConfig *runtimeConfig,
 	logger hclog.Logger) error {
 	bridgeEventManager := newBridgeEventManager(
-		eventProvider,
 		logger.Named("bridge-event-manager"),
 		runtimeConfig.State,
 		&bridgeEventManagerConfig{

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -227,7 +227,7 @@ func newBridgeManager(
 
 // PostBlock is a function executed on every block finalization (either by consensus or syncer)
 func (b *bridgeManager) PostBlock(req *PostBlockRequest) error {
-	if err := b.bridgeEventManager.CreateInternalBatch(); err != nil {
+	if err := b.bridgeEventManager.PostBlock(); err != nil {
 		return fmt.Errorf("failed to execute post block in bridge event manager. Err: %w", err)
 	}
 

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -199,14 +199,15 @@ func newBridgeManager(
 
 	var err error
 
-	gatewayAddr := runtimeConfig.GenesisConfig.Bridge[externalChainID].ExternalGatewayAddr
+	chainBridgeCfg := runtimeConfig.GenesisConfig.Bridge[externalChainID]
+	gatewayAddr := chainBridgeCfg.ExternalGatewayAddr
 	bridgeManager := &bridgeManager{
 		externalChainID: externalChainID,
 		logger:          logger.Named("bridge-manager"),
 		eventTrackerConfig: &eventTrackerConfig{
 			EventTracker:        *runtimeConfig.eventTracker,
-			jsonrpcAddr:         runtimeConfig.GenesisConfig.Bridge[externalChainID].JSONRPCEndpoint,
-			startBlock:          runtimeConfig.GenesisConfig.Bridge[externalChainID].EventTrackerStartBlocks[gatewayAddr],
+			jsonrpcAddr:         chainBridgeCfg.JSONRPCEndpoint,
+			startBlock:          chainBridgeCfg.EventTrackerStartBlocks[gatewayAddr],
 			trackerPollInterval: runtimeConfig.GenesisConfig.BlockTrackerPollInterval.Duration,
 		},
 		state:           runtimeConfig.State,

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -227,7 +227,7 @@ func newBridgeManager(
 
 // PostBlock is a function executed on every block finalization (either by consensus or syncer)
 func (b *bridgeManager) PostBlock(req *PostBlockRequest) error {
-	if err := b.bridgeEventManager.PostBlock(req); err != nil {
+	if err := b.bridgeEventManager.CreateInternalBatch(); err != nil {
 		return fmt.Errorf("failed to execute post block in bridge event manager. Err: %w", err)
 	}
 

--- a/consensus/polybft/bridge_manager.go
+++ b/consensus/polybft/bridge_manager.go
@@ -210,7 +210,7 @@ func newBridgeManager(
 		state: runtimeConfig.State,
 	}
 
-	if err := bridgeManager.initBridgeEventManager(runtime, runtimeConfig, logger); err != nil {
+	if err := bridgeManager.initBridgeEventManager(eventProvider, runtime, runtimeConfig, logger); err != nil {
 		return nil, err
 	}
 
@@ -261,11 +261,13 @@ func (b *bridgeManager) Close() {
 // initBridgeEventManager initializes bridge event manager
 // if bridge is not enabled, then a dummy bridge event manager will be used
 func (b *bridgeManager) initBridgeEventManager(
+	eventProvider *EventProvider,
 	runtime Runtime,
 	runtimeConfig *runtimeConfig,
 	logger hclog.Logger) error {
 	bridgeEventManager := newBridgeEventManager(
-		logger.Named("state-sync-manager"),
+		eventProvider,
+		logger.Named("bridge-event-manager"),
 		runtimeConfig.State,
 		&bridgeEventManagerConfig{
 			bridgeCfg:         runtimeConfig.GenesisConfig.Bridge[b.chainID],
@@ -277,6 +279,8 @@ func (b *bridgeManager) initBridgeEventManager(
 		b.externalChainID,
 		b.internalChainID,
 	)
+
+	eventProvider.Subscribe(b.bridgeEventManager)
 
 	b.bridgeEventManager = bridgeEventManager
 

--- a/consensus/polybft/bridge_manager_test.go
+++ b/consensus/polybft/bridge_manager_test.go
@@ -23,7 +23,14 @@ func (mbm *mockBridgeManager) BuildExitEventRoot(epoch uint64) (types.Hash, erro
 func (mbm *mockBridgeManager) BridgeBatch(pendingBlockNumber uint64) (*BridgeBatchSigned, error) {
 	return nil, nil
 }
-func (mbm *mockBridgeManager) InsertEpoch(epoch uint64, dbTx *bolt.Tx) error {
+func (mbm *mockBridgeManager) InsertEpochExternal(epoch uint64, dbTx *bolt.Tx) error {
+	if err := mbm.state.EpochStore.insertEpoch(epoch, dbTx, mbm.chainID); err != nil {
+		return err
+	}
+
+	return nil
+}
+func (mbm *mockBridgeManager) InsertEpochInternal(epoch uint64, dbTx *bolt.Tx) error {
 	if err := mbm.state.EpochStore.insertEpoch(epoch, dbTx, mbm.chainID); err != nil {
 		return err
 	}

--- a/consensus/polybft/bridge_manager_test.go
+++ b/consensus/polybft/bridge_manager_test.go
@@ -23,7 +23,7 @@ func (mbm *mockBridgeManager) BuildExitEventRoot(epoch uint64) (types.Hash, erro
 func (mbm *mockBridgeManager) BridgeBatch(pendingBlockNumber uint64) (*BridgeBatchSigned, error) {
 	return nil, nil
 }
-func (mbm *mockBridgeManager) InsertEpochExternal(epoch uint64, dbTx *bolt.Tx) error {
+func (mbm *mockBridgeManager) InsertEpoch(epoch uint64, dbTx *bolt.Tx) error {
 	if err := mbm.state.EpochStore.insertEpoch(epoch, dbTx, mbm.chainID); err != nil {
 		return err
 	}

--- a/consensus/polybft/bridge_manager_test.go
+++ b/consensus/polybft/bridge_manager_test.go
@@ -30,10 +30,3 @@ func (mbm *mockBridgeManager) InsertEpoch(epoch uint64, dbTx *bolt.Tx) error {
 
 	return nil
 }
-func (mbm *mockBridgeManager) InsertEpochInternal(epoch uint64, dbTx *bolt.Tx) error {
-	if err := mbm.state.EpochStore.insertEpoch(epoch, dbTx, mbm.chainID); err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -511,10 +511,6 @@ func (c *consensusRuntime) restartEpoch(header *types.Header, dbTx *bolt.Tx) (*e
 		c.logger.Error("Could not clean previous epochs from db.", "error", err)
 	}
 
-	if err := c.bridge.InsertEpoch(epochNumber, dbTx); err != nil {
-		return nil, err
-	}
-
 	c.logger.Info(
 		"restartEpoch",
 		"block number", header.Number,

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1150,5 +1150,8 @@ func createTestBridge(t *testing.T, state *State) Bridge {
 
 	manager := &mockBridgeManager{state: state, chainID: 1}
 
-	return &bridge{bridgeManagers: map[uint64]BridgeManager{1: manager}}
+	return &bridge{
+		bridgeManagers: map[uint64]BridgeManager{1: manager},
+		state:          state,
+	}
 }

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1150,5 +1150,5 @@ func createTestBridge(t *testing.T, state *State) Bridge {
 
 	manager := &mockBridgeManager{state: state, chainID: 1}
 
-	return bridge{1: manager}
+	return &bridge{bridgeManagers: map[uint64]BridgeManager{1: manager}}
 }

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -227,7 +227,23 @@ type systemStateMock struct {
 	mock.Mock
 }
 
-func (m *systemStateMock) GetNextCommittedIndex(sourceChainID uint64) (uint64, error) {
+func (m *systemStateMock) GetNextCommittedIndexExternal(sourceChainID uint64) (uint64, error) {
+	args := m.Called()
+
+	if len(args) == 1 {
+		index, _ := args.Get(0).(uint64)
+
+		return index, nil
+	} else if len(args) == 2 {
+		index, _ := args.Get(0).(uint64)
+
+		return index, args.Error(1)
+	}
+
+	return 0, nil
+}
+
+func (m *systemStateMock) GetNextCommittedIndexInternal(sourceChainID uint64) (uint64, error) {
 	args := m.Called()
 
 	if len(args) == 1 {

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -227,23 +227,7 @@ type systemStateMock struct {
 	mock.Mock
 }
 
-func (m *systemStateMock) GetNextCommittedIndexExternal(sourceChainID uint64) (uint64, error) {
-	args := m.Called()
-
-	if len(args) == 1 {
-		index, _ := args.Get(0).(uint64)
-
-		return index, nil
-	} else if len(args) == 2 {
-		index, _ := args.Get(0).(uint64)
-
-		return index, args.Error(1)
-	}
-
-	return 0, nil
-}
-
-func (m *systemStateMock) GetNextCommittedIndexInternal(sourceChainID uint64) (uint64, error) {
+func (m *systemStateMock) GetNextCommittedIndex(chainID uint64, chainType ChainType) (uint64, error) {
 	args := m.Called()
 
 	if len(args) == 1 {

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -12,22 +12,19 @@ var (
 	edgeEventsLastProcessedBlockKey    = []byte("EdgeEventsLastProcessedBlockKey")
 )
 
-// MessageSignature encapsulates sender identifier and its signature
-type MessageSignature struct {
+// BridgeBatchVoteConsensusData encapsulates sender identifier and its signature
+type BridgeBatchVoteConsensusData struct {
 	// Signer of the vote
-	From string
+	Sender string
 	// Signature of the message
 	Signature []byte
 }
 
-// TransportMessage represents the payload which is gossiped across the network
-type TransportMessage struct {
+// BridgeBatchVote represents the payload which is gossiped across the network
+type BridgeBatchVote struct {
+	*BridgeBatchVoteConsensusData
 	// Hash is encoded data
 	Hash []byte
-	// Message signature
-	Signature []byte
-	// From is the address of the message signer
-	From string
 	// Number of epoch
 	EpochNumber uint64
 	// SourceChainID from bridge batch

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -29,6 +29,8 @@ type BridgeBatchVote struct {
 	EpochNumber uint64
 	// SourceChainID from bridge batch
 	SourceChainID uint64
+	// DestinationChainID from bridge batch
+	DestinationChainID uint64
 }
 
 // State represents a persistence layer which persists consensus data off-chain

--- a/consensus/polybft/state_store_bridge_message.go
+++ b/consensus/polybft/state_store_bridge_message.go
@@ -143,7 +143,8 @@ func (bms *BridgeMessageStore) list() ([]*contractsapi.BridgeMsgEvent, error) {
 
 // getBridgeMessageEventsForBridgeBatch returns bridge events for bridge batch
 func (bms *BridgeMessageStore) getBridgeMessageEventsForBridgeBatch(
-	fromIndex, toIndex uint64, dbTx *bolt.Tx, sourceChainID, destinationChainID uint64) ([]*contractsapi.BridgeMsgEvent, error) {
+	fromIndex, toIndex uint64, dbTx *bolt.Tx, sourceChainID, destinationChainID uint64) (
+	[]*contractsapi.BridgeMsgEvent, error) {
 	var (
 		events []*contractsapi.BridgeMsgEvent
 		err    error

--- a/consensus/polybft/state_store_bridge_message_test.go
+++ b/consensus/polybft/state_store_bridge_message_test.go
@@ -46,8 +46,8 @@ func TestState_Insert_And_Get_MessageVotes(t *testing.T) {
 	assert.NoError(t, state.EpochStore.insertEpoch(epoch, nil, 0))
 
 	hash := []byte{1, 2}
-	_, err := state.BridgeMessageStore.insertMessageVote(1, hash, &MessageSignature{
-		From:      "NODE_1",
+	_, err := state.BridgeMessageStore.insertConsensusData(1, hash, &BridgeBatchVoteConsensusData{
+		Sender:    "NODE_1",
 		Signature: []byte{1, 2},
 	}, nil, 0)
 
@@ -56,7 +56,7 @@ func TestState_Insert_And_Get_MessageVotes(t *testing.T) {
 	votes, err := state.BridgeMessageStore.getMessageVotes(epoch, hash, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(votes))
-	assert.Equal(t, "NODE_1", votes[0].From)
+	assert.Equal(t, "NODE_1", votes[0].Sender)
 	assert.True(t, bytes.Equal([]byte{1, 2}, votes[0].Signature))
 }
 

--- a/consensus/polybft/state_store_bridge_message_test.go
+++ b/consensus/polybft/state_store_bridge_message_test.go
@@ -74,7 +74,7 @@ func TestState_getBridgeEventsForBridgeBatch_NotEnoughEvents(t *testing.T) {
 		}))
 	}
 
-	_, err := state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, maxNumberOfEvents-1, nil, 0)
+	_, err := state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, maxNumberOfEvents-1, nil, 0, 0)
 	assert.ErrorIs(t, err, errNotEnoughBridgeEvents)
 }
 
@@ -95,7 +95,7 @@ func TestState_getBridgeEventsForBridgeBatch(t *testing.T) {
 	t.Run("Return all - forced. Enough events", func(t *testing.T) {
 		t.Parallel()
 
-		events, err := state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, maxNumberOfEvents-1, nil, 1)
+		events, err := state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, maxNumberOfEvents-1, nil, 1, 0)
 		require.NoError(t, err)
 		require.Equal(t, maxNumberOfEvents, len(events))
 	})
@@ -103,14 +103,14 @@ func TestState_getBridgeEventsForBridgeBatch(t *testing.T) {
 	t.Run("Return all - forced. Not enough events", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, maxNumberOfEvents+1, nil, 1)
+		_, err := state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, maxNumberOfEvents+1, nil, 1, 0)
 		require.ErrorIs(t, err, errNotEnoughBridgeEvents)
 	})
 
 	t.Run("Return all you can. Enough events", func(t *testing.T) {
 		t.Parallel()
 
-		events, err := state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, maxNumberOfEvents-1, nil, 1)
+		events, err := state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, maxNumberOfEvents-1, nil, 1, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, maxNumberOfEvents, len(events))
 	})
@@ -118,25 +118,10 @@ func TestState_getBridgeEventsForBridgeBatch(t *testing.T) {
 	t.Run("Return all you can. Not enough events", func(t *testing.T) {
 		t.Parallel()
 
-		events, err := state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, maxNumberOfEvents+1, nil, 1)
+		events, err := state.BridgeMessageStore.getBridgeMessageEventsForBridgeBatch(0, maxNumberOfEvents+1, nil, 1, 0)
 		assert.ErrorIs(t, err, errNotEnoughBridgeEvents)
 		assert.Equal(t, maxNumberOfEvents, len(events))
 	})
-}
-
-func TestState_insertBridgeBatchMessage(t *testing.T) {
-	t.Parallel()
-
-	signedBridgeBatch := createTestBridgeBatchMessage(t, 0, 0)
-
-	state := newTestState(t)
-	assert.NoError(t, state.BridgeMessageStore.insertBridgeBatchMessage(signedBridgeBatch, nil))
-
-	batchFromDB, err := state.BridgeMessageStore.getBridgeBatchSigned(0, 1)
-
-	assert.NoError(t, err)
-	assert.NotNil(t, batchFromDB)
-	assert.Equal(t, signedBridgeBatch, batchFromDB)
 }
 
 func TestState_getBridgeBatchForBridgeEvents(t *testing.T) {

--- a/consensus/polybft/state_store_epoch_test.go
+++ b/consensus/polybft/state_store_epoch_test.go
@@ -116,8 +116,8 @@ func TestState_InsertVoteConcurrent(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 
-			_, _ = state.BridgeMessageStore.insertMessageVote(epoch, hash, &MessageSignature{
-				From:      fmt.Sprintf("NODE_%d", i),
+			_, _ = state.BridgeMessageStore.insertConsensusData(epoch, hash, &BridgeBatchVoteConsensusData{
+				Sender:    fmt.Sprintf("NODE_%d", i),
 				Signature: []byte{1, 2},
 			}, nil, 0)
 		}(i)
@@ -142,10 +142,11 @@ func TestState_Insert_And_Cleanup(t *testing.T) {
 
 		assert.NoError(t, err)
 
-		_, _ = state.BridgeMessageStore.insertMessageVote(epoch, hash1, &MessageSignature{
-			From:      "NODE_1",
-			Signature: []byte{1, 2},
-		}, nil, 0)
+		_, _ = state.BridgeMessageStore.insertConsensusData(epoch, hash1,
+			&BridgeBatchVoteConsensusData{
+				Sender:    "NODE_1",
+				Signature: []byte{1, 2},
+			}, nil, 0)
 	}
 
 	stats, err := state.EpochStore.epochsDBStats()
@@ -172,10 +173,11 @@ func TestState_Insert_And_Cleanup(t *testing.T) {
 		err := state.EpochStore.insertEpoch(epoch, nil, 0)
 		assert.NoError(t, err)
 
-		_, _ = state.BridgeMessageStore.insertMessageVote(epoch, hash1, &MessageSignature{
-			From:      "NODE_1",
-			Signature: []byte{1, 2},
-		}, nil, 0)
+		_, _ = state.BridgeMessageStore.insertConsensusData(epoch, hash1,
+			&BridgeBatchVoteConsensusData{
+				Sender:    "NODE_1",
+				Signature: []byte{1, 2},
+			}, nil, 0)
 	}
 
 	stats, err = state.EpochStore.epochsDBStats()

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -90,6 +90,7 @@ func (s *SystemStateImpl) GetNextCommittedIndexExternal(sourceChainID uint64) (u
 	return nextCommittedIndex.Uint64() + 1, nil
 }
 
+// GetNextCommittedIndex retrieves next committed internal bridge message index
 func (s *SystemStateImpl) GetNextCommittedIndexInternal(destinationChainID uint64) (uint64, error) {
 	rawResult, err := s.sidechainBridgeContract.Call(
 		"lastCommittedInternal",

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -23,8 +23,8 @@ type ValidatorInfo struct {
 type ChainType int
 
 const (
-	Internal ChainType = iota // Internal will be 0
-	External                  // External will be 1
+	Internal ChainType = iota // Internal = 0
+	External                  // External = 1
 )
 
 // SystemState is an interface to interact with the consensus system contracts in the chain

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -90,11 +90,11 @@ func (s *SystemStateImpl) GetNextCommittedIndexExternal(sourceChainID uint64) (u
 	return nextCommittedIndex.Uint64() + 1, nil
 }
 
-func (s *SystemStateImpl) GetNextCommittedIndexInternal(DestinationChainID uint64) (uint64, error) {
+func (s *SystemStateImpl) GetNextCommittedIndexInternal(destinationChainID uint64) (uint64, error) {
 	rawResult, err := s.sidechainBridgeContract.Call(
 		"lastCommittedInternal",
 		ethgo.Latest,
-		new(big.Int).SetUint64(DestinationChainID))
+		new(big.Int).SetUint64(destinationChainID))
 	if err != nil {
 		return 0, err
 	}

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -24,9 +24,9 @@ type ValidatorInfo struct {
 type SystemState interface {
 	// GetEpoch retrieves current epoch number from the smart contract
 	GetEpoch() (uint64, error)
-	// GetNextCommittedIndex retrieves next committed bridge message index
+	// GetNextCommittedIndexExternal retrieves next committed external bridge message index
 	GetNextCommittedIndexExternal(sourceChainID uint64) (uint64, error)
-
+	// GetNextCommittedIndexInternal retrieves next committed internal bridge message index
 	GetNextCommittedIndexInternal(sourceChainID uint64) (uint64, error)
 }
 
@@ -72,7 +72,7 @@ func (s *SystemStateImpl) GetEpoch() (uint64, error) {
 	return epochNumber.Uint64(), nil
 }
 
-// GetNextCommittedIndex retrieves next committed bridge message index
+// GetNextCommittedIndexExternal retrieves next committed external bridge message index
 func (s *SystemStateImpl) GetNextCommittedIndexExternal(sourceChainID uint64) (uint64, error) {
 	rawResult, err := s.sidechainBridgeContract.Call(
 		"lastCommitted",

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -20,22 +20,27 @@ type ValidatorInfo struct {
 	IsWhitelisted       bool          `json:"isWhitelisted"`
 }
 
+type ChainType int
+
+const (
+	Internal ChainType = iota // Internal will be 0
+	External                  // External will be 1
+)
+
 // SystemState is an interface to interact with the consensus system contracts in the chain
 type SystemState interface {
 	// GetEpoch retrieves current epoch number from the smart contract
 	GetEpoch() (uint64, error)
-	// GetNextCommittedIndexExternal retrieves next committed external bridge message index
-	GetNextCommittedIndexExternal(sourceChainID uint64) (uint64, error)
-	// GetNextCommittedIndexInternal retrieves next committed internal bridge message index
-	GetNextCommittedIndexInternal(sourceChainID uint64) (uint64, error)
+	// GetNextCommittedIndex retrieves next committed bridge message index, based on the chain type
+	GetNextCommittedIndex(chainID uint64, chainType ChainType) (uint64, error)
 }
 
 var _ SystemState = &SystemStateImpl{}
 
 // SystemStateImpl is implementation of SystemState interface
 type SystemStateImpl struct {
-	validatorContract       *contract.Contract
-	sidechainBridgeContract *contract.Contract
+	validatorContract     *contract.Contract
+	bridgeStorageContract *contract.Contract
 }
 
 // NewSystemState initializes new instance of systemState which abstracts smart contracts functions
@@ -48,7 +53,7 @@ func NewSystemState(
 		ethgo.Address(valSetAddr),
 		contractsapi.EpochManager.Abi, contract.WithProvider(provider),
 	)
-	s.sidechainBridgeContract = contract.NewContract(
+	s.bridgeStorageContract = contract.NewContract(
 		ethgo.Address(bridgeStorageAddr),
 		contractsapi.BridgeStorage.Abi,
 		contract.WithProvider(provider),
@@ -73,11 +78,19 @@ func (s *SystemStateImpl) GetEpoch() (uint64, error) {
 }
 
 // GetNextCommittedIndexExternal retrieves next committed external bridge message index
-func (s *SystemStateImpl) GetNextCommittedIndexExternal(sourceChainID uint64) (uint64, error) {
-	rawResult, err := s.sidechainBridgeContract.Call(
-		"lastCommitted",
-		ethgo.Latest,
-		new(big.Int).SetUint64(sourceChainID))
+func (s *SystemStateImpl) GetNextCommittedIndex(chainID uint64, chainType ChainType) (uint64, error) {
+	var funcName string
+
+	switch chainType {
+	case Internal:
+		funcName = "lastCommittedInternal"
+	case External:
+		funcName = "lastCommitted"
+	default:
+		return 0, fmt.Errorf("unsupported chain type: %d", chainType)
+	}
+
+	rawResult, err := s.bridgeStorageContract.Call(funcName, ethgo.Latest, new(big.Int).SetUint64(chainID))
 	if err != nil {
 		return 0, err
 	}
@@ -85,24 +98,6 @@ func (s *SystemStateImpl) GetNextCommittedIndexExternal(sourceChainID uint64) (u
 	nextCommittedIndex, isOk := rawResult["0"].(*big.Int)
 	if !isOk {
 		return 0, fmt.Errorf("failed to decode next committed index")
-	}
-
-	return nextCommittedIndex.Uint64() + 1, nil
-}
-
-// GetNextCommittedIndexInternal retrieves next committed internal bridge message index
-func (s *SystemStateImpl) GetNextCommittedIndexInternal(destinationChainID uint64) (uint64, error) {
-	rawResult, err := s.sidechainBridgeContract.Call(
-		"lastCommittedInternal",
-		ethgo.Latest,
-		new(big.Int).SetUint64(destinationChainID))
-	if err != nil {
-		return 0, err
-	}
-
-	nextCommittedIndex, isOk := rawResult["0"].(*big.Int)
-	if !isOk {
-		return 0, fmt.Errorf("failed to decode next committed Index")
 	}
 
 	return nextCommittedIndex.Uint64() + 1, nil

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -90,7 +90,7 @@ func (s *SystemStateImpl) GetNextCommittedIndexExternal(sourceChainID uint64) (u
 	return nextCommittedIndex.Uint64() + 1, nil
 }
 
-// GetNextCommittedIndex retrieves next committed internal bridge message index
+// GetNextCommittedIndexInternal retrieves next committed internal bridge message index
 func (s *SystemStateImpl) GetNextCommittedIndexInternal(destinationChainID uint64) (uint64, error) {
 	rawResult, err := s.sidechainBridgeContract.Call(
 		"lastCommittedInternal",

--- a/consensus/polybft/system_state_test.go
+++ b/consensus/polybft/system_state_test.go
@@ -63,7 +63,7 @@ func TestSystemState_GetNextCommittedIndex(t *testing.T) {
 	_, err = provider.Call(ethgo.Address(result.Address), input, &contract.CallOpts{})
 	assert.NoError(t, err)
 
-	nextCommittedIndex, err := systemState.GetNextCommittedIndexExternal(0)
+	nextCommittedIndex, err := systemState.GetNextCommittedIndex(0, External)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedNextCommittedIndex+1, nextCommittedIndex)
 }

--- a/consensus/polybft/system_state_test.go
+++ b/consensus/polybft/system_state_test.go
@@ -63,7 +63,7 @@ func TestSystemState_GetNextCommittedIndex(t *testing.T) {
 	_, err = provider.Call(ethgo.Address(result.Address), input, &contract.CallOpts{})
 	assert.NoError(t, err)
 
-	nextCommittedIndex, err := systemState.GetNextCommittedIndex(0)
+	nextCommittedIndex, err := systemState.GetNextCommittedIndexExternal(0)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedNextCommittedIndex+1, nextCommittedIndex)
 }


### PR DESCRIPTION
# Description

This PR introduces changes to handle events originating from Blade, along with the logic to commit Blade-originated batches to `BladeStorage.sol`. These batches will follow the same voting mechanism used for batches from external chains.

Additionally, we've updated the bridgeEventManager` struct by adding the `nextBridgeEventIDInternal` field to track the next event ID.


There is new function `GetNextCommittedIndexInternal` which returns `lastCommitedInternal` from `BridgeStorage.sol`

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
