### PR TITLE
Remove `apt-get install` in Load Test workflow

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -214,8 +214,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
-      - name: Install make and jq
-        run: sudo apt-get -y install make jq
       - name: Build Blade
         run: make build
         env:


### PR DESCRIPTION
- Sometimes `apt-get install` fails so we need to remove this.
- The AMI includes `make` and `jq`, used for the Load Test instance.