### PR TITLE
Init logs slice in logFilter

### DIFF
--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -450,6 +450,7 @@ func (f *FilterManager) NewLogFilter(logQuery *LogQuery, ws wsConn) string {
 	filter := &logFilter{
 		filterBase: newFilterBase(ws),
 		query:      logQuery,
+		logs:       []*Log{},
 	}
 
 	if filter.hasWSConn() {


### PR DESCRIPTION
# Description

Initialize logs slice in logFilter because for the 1st query only nil is returned and that makes an error on the front considering that array is always expected: TypeError: results is not iterable.

Other filters (pendingTx and blocks) are already ok.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually