### PR TITLE
Fix for e2e framework

### DIFF
--- a/command/bridge/helper/utils.go
+++ b/command/bridge/helper/utils.go
@@ -106,7 +106,7 @@ func GetBridgeChainID() (string, error) {
 }
 
 // ReadBridgeChainIP returns ip address of bridge
-func ReadBridgeChainIP(port string) (string, error) {
+func ReadBridgeChainIP(port uint64) (string, error) {
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return "", fmt.Errorf("external chain id error: %w", err)
@@ -122,11 +122,11 @@ func ReadBridgeChainIP(port string) (string, error) {
 		return "", fmt.Errorf("external chain ip error: %w", err)
 	}
 
-	portMapKey := fmt.Sprintf("%s/tcp", port)
+	portMapKey := fmt.Sprintf("%d/tcp", port)
 
 	ports, ok := inspect.HostConfig.PortBindings[nat.Port(portMapKey)]
 	if !ok || len(ports) == 0 {
-		return "", fmt.Errorf("port %s is not bound with localhost", port)
+		return "", fmt.Errorf("port %d is not bound with localhost", port)
 	}
 
 	return fmt.Sprintf("http://%s:%s", ports[0].HostIP, ports[0].HostPort), nil

--- a/command/bridge/server/params.go
+++ b/command/bridge/server/params.go
@@ -9,5 +9,5 @@ type serverParams struct {
 	dataDir   string
 	noConsole bool
 	chainID   uint64
-	port      string
+	port      uint64
 }

--- a/e2e-polybft/framework/test-bridge.go
+++ b/e2e-polybft/framework/test-bridge.go
@@ -56,7 +56,7 @@ func (t *TestBridge) Start() error {
 		"server",
 		"--data-dir", t.clusterConfig.Dir(fmt.Sprintf("test-external-chain-%d", t.id)),
 		"--chain-id", strconv.FormatUint(t.id, 10),
-		"--port", t.calculatePort(),
+		"--port", strconv.FormatUint(t.calculatePort(), 10),
 	}
 
 	stdout := t.clusterConfig.GetStdout(fmt.Sprintf("bridge-%d", t.id))
@@ -68,7 +68,7 @@ func (t *TestBridge) Start() error {
 
 	t.node = bridgeNode
 
-	if err = server.PingServer(nil); err != nil {
+	if err = server.PingServer(nil, t.calculatePort()); err != nil {
 		return err
 	}
 
@@ -84,7 +84,7 @@ func (t *TestBridge) Stop() {
 }
 
 func (t *TestBridge) JSONRPCAddr() string {
-	return fmt.Sprintf("http://%s:%s", hostIP, t.calculatePort())
+	return fmt.Sprintf("http://%s:%d", hostIP, t.calculatePort())
 }
 
 func (t *TestBridge) WaitUntil(pollFrequency, timeout time.Duration, handler func() (bool, error)) error {
@@ -543,8 +543,10 @@ func (t *TestBridge) premineNativeRootToken(genesisPath string, tokenConfig *pol
 	return g.Wait()
 }
 
-func (t *TestBridge) calculatePort() string {
-	return strconv.FormatUint(initialPortForBridge+t.id-1, 10)
+// calculatePort calculate port for specific bridge
+// each bridge uses 3 ports the next starting port is 3 higher
+func (t *TestBridge) calculatePort() uint64 {
+	return initialPortForBridge + (t.id-1)*3
 }
 
 // finalizeGenesis finalizes genesis on BladeManager contract on root

--- a/e2e-polybft/framework/test-bridge.go
+++ b/e2e-polybft/framework/test-bridge.go
@@ -305,7 +305,7 @@ func (t *TestBridge) SendExitTransaction(exitHelper types.Address, exitID uint64
 
 // cmdRun executes arbitrary command from the given binary
 func (t *TestBridge) cmdRun(args ...string) error {
-	return runCommand(t.clusterConfig.Binary, args, t.clusterConfig.GetStdout("bridge"))
+	return runCommand(t.clusterConfig.Binary, args, t.clusterConfig.GetStdout(fmt.Sprintf("bridge-%d", t.id)))
 }
 
 // deployExternalChainContracts deploys and initializes external chain contracts


### PR DESCRIPTION
# Description

This PR includes changes that address the port configuration for external test chains. Each external chain requires three distinct ports, and the `calculatePort` function has been modified to allocate ports in increments of three for each subsequent bridge. This ensures that each new bridge is assigned a unique set of ports, avoiding any potential conflicts between different chains during testing.

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
