### PR TITLE
Reward distribution fix

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -460,7 +460,7 @@ func (c *consensusRuntime) FSM() error {
 		}
 	}
 
-	ff.distributeRewardsInput, err = c.calculateDistributeRewardsInput(isFirstBlockOfEpoch, isEndOfEpoch,
+	ff.distributeRewardsInput, err = c.calculateDistributeRewardsInput(isFirstBlockOfEpoch,
 		pendingBlockNumber, parent, epoch.Number)
 	if err != nil {
 		return fmt.Errorf("cannot calculate uptime info: %w", err)
@@ -587,12 +587,12 @@ func createCommitEpochInput(
 
 // calculateDistributeRewardsInput calculates distribute rewards input data
 func (c *consensusRuntime) calculateDistributeRewardsInput(
-	isFirstBlockOfEpoch, isEndOfEpoch bool,
+	isFirstBlockOfEpoch bool,
 	pendingBlockNumber uint64,
 	lastFinalizedBlock *types.Header,
 	epochID uint64,
 ) (*contractsapi.DistributeRewardForEpochManagerFn, error) {
-	if !isRewardDistributionBlock(c.config.Forks, isFirstBlockOfEpoch, isEndOfEpoch, pendingBlockNumber) {
+	if !isRewardDistributionBlock(isFirstBlockOfEpoch, pendingBlockNumber) {
 		// we don't have to distribute rewards at this block
 		return nil, nil
 	}
@@ -658,7 +658,7 @@ func (c *consensusRuntime) calculateDistributeRewardsInput(
 		}
 	}
 
-	lookbackSize := getLookbackSizeForRewardDistribution(c.config.Forks, pendingBlockNumber)
+	lookbackSize := getLookbackSizeForRewardDistribution()
 
 	// calculate uptime for blocks from previous epoch that were not processed in previous uptime
 	// since we can not calculate uptime for the last block in epoch (because of parent signatures)

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -658,12 +658,10 @@ func (c *consensusRuntime) calculateDistributeRewardsInput(
 		}
 	}
 
-	lookbackSize := getLookbackSizeForRewardDistribution()
-
 	// calculate uptime for blocks from previous epoch that were not processed in previous uptime
 	// since we can not calculate uptime for the last block in epoch (because of parent signatures)
-	if blockHeader.Number > lookbackSize {
-		for i := uint64(0); i < lookbackSize; i++ {
+	if blockHeader.Number > rewardLookbackSize {
+		for i := uint64(0); i < rewardLookbackSize; i++ {
 			validators, err := c.config.polybftBackend.GetValidators(blockHeader.Number-2, nil)
 			if err != nil {
 				return nil, err

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -607,7 +607,7 @@ func TestConsensusRuntime_calculateCommitEpochInput_SecondEpoch(t *testing.T) {
 	}
 
 	distributeRewardsInput, err := consensusRuntime.calculateDistributeRewardsInput(
-		true, false,
+		true,
 		lastBuiltBlock.Number+1,
 		lastBuiltBlock, consensusRuntime.epoch.Number)
 	assert.NoError(t, err)

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -145,7 +145,7 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 		}
 	}
 
-	if isRewardDistributionBlock(f.forks, f.isFirstBlockOfEpoch, f.isEndOfEpoch, f.Height()) {
+	if isRewardDistributionBlock(f.isFirstBlockOfEpoch, f.Height()) {
 		tx, err := f.createDistributeRewardsTx()
 		if err != nil {
 			return nil, err
@@ -524,7 +524,7 @@ func (f *fsm) VerifyStateTransactions(transactions []*types.Transaction) error {
 		}
 	}
 
-	if isRewardDistributionBlock(f.forks, f.isFirstBlockOfEpoch, f.isEndOfEpoch, f.Height()) {
+	if isRewardDistributionBlock(f.isFirstBlockOfEpoch, f.Height()) {
 		if !distributeRewardsTxExists {
 			// this is a check if distribute rewards transaction is not in the list of transactions at all
 			// but it should be
@@ -644,7 +644,7 @@ func (f *fsm) verifyCommitEpochTx(commitEpochTx *types.Transaction) error {
 // and compares its hash with the one extracted from the block.
 func (f *fsm) verifyDistributeRewardsTx(distributeRewardsTx *types.Transaction) error {
 	// we don't have distribute rewards tx if we just started the chain
-	if isRewardDistributionBlock(f.forks, f.isFirstBlockOfEpoch, f.isEndOfEpoch, f.Height()) {
+	if isRewardDistributionBlock(f.isFirstBlockOfEpoch, f.Height()) {
 		localDistributeRewardsTx, err := f.createDistributeRewardsTx()
 		if err != nil {
 			return err

--- a/consensus/polybft/governance_manager.go
+++ b/consensus/polybft/governance_manager.go
@@ -21,7 +21,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
-const newRewardLookbackSize = uint64(1)
+const rewardLookbackSize = uint64(1)
 
 var (
 	errUnknownGovernanceEvent = errors.New("unknown event from governance")
@@ -32,11 +32,6 @@ var (
 // should happen in given block
 func isRewardDistributionBlock(isFirstBlockOfEpoch bool, pendingBlockNumber uint64) bool {
 	return isFirstBlockOfEpoch && pendingBlockNumber > 1
-}
-
-// getLookbackSizeForRewardDistribution returns lookback size for reward distribution
-func getLookbackSizeForRewardDistribution() uint64 {
-	return newRewardLookbackSize
 }
 
 // GovernanceManager interface provides functions for handling governance events

--- a/consensus/polybft/governance_manager.go
+++ b/consensus/polybft/governance_manager.go
@@ -21,10 +21,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
-const (
-	oldRewardLookbackSize = uint64(2) // number of blocks to calculate commit epoch info from the previous epoch
-	newRewardLookbackSize = uint64(1)
-)
+const newRewardLookbackSize = uint64(1)
 
 var (
 	errUnknownGovernanceEvent = errors.New("unknown event from governance")
@@ -33,26 +30,13 @@ var (
 
 // isRewardDistributionBlock indicates if reward distribution transaction
 // should happen in given block
-// if governance fork is enabled, reward distribution is only present on the first block of epoch
-// and if we are not at the start of chain
-// if governance fork is not enabled, reward distribution is only present at the epoch ending block
-func isRewardDistributionBlock(forks *chain.Forks, isFirstBlockOfEpoch, isEndOfEpoch bool,
-	pendingBlockNumber uint64) bool {
-	if forks.IsActive(chain.Governance, pendingBlockNumber) {
-		return isFirstBlockOfEpoch && pendingBlockNumber > 1
-	}
-
-	return isEndOfEpoch
+func isRewardDistributionBlock(isFirstBlockOfEpoch bool, pendingBlockNumber uint64) bool {
+	return isFirstBlockOfEpoch && pendingBlockNumber > 1
 }
 
 // getLookbackSizeForRewardDistribution returns lookback size for reward distribution
-// based on if governance fork is enabled or not
-func getLookbackSizeForRewardDistribution(forks *chain.Forks, blockNumber uint64) uint64 {
-	if forks.IsActive(chain.Governance, blockNumber) {
-		return newRewardLookbackSize
-	}
-
-	return oldRewardLookbackSize
+func getLookbackSizeForRewardDistribution() uint64 {
+	return newRewardLookbackSize
 }
 
 // GovernanceManager interface provides functions for handling governance events


### PR DESCRIPTION
# Description

This PR removes the old code from Edge that changes on which block the reward distribution is executed. It should always be executed on the first block of the epoch.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually