### PR TITLE
Upgrade the linter version and fix existing warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6.1.1
         with:
-          args: --timeout 10m --verbose
+          args: --timeout 10m --verbose --whole-files
       - name: Lint Failed
         if: failure()
         id: lint_failure

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6.1.1
         with:
-          args: --timeout 10m --verbose --whole-files
+          args: --timeout 10m --verbose
       - name: Lint Failed
         if: failure()
         id: lint_failure

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: ${{ vars.GOLANG_VERSION }}
           cache: false
       - name: Lint
-        uses: golangci/golangci-lint-action@v4.0.0
+        uses: golangci/golangci-lint-action@v6.1.1
         with:
           args: --timeout 10m --verbose
       - name: Lint Failed

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,6 @@
 run:
   timeout: 3m
   tests: true
-  # default is true. Enables skipping of directories:
-  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: true
 
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,4 @@
 # This file configures github.com/golangci/golangci-lint.
-
-run:
-  timeout: 3m
-  tests: true
-
 linters:
   disable-all: true
   enable:
@@ -49,7 +44,6 @@ linters-settings:
         rules: "./gorules/rules.go"
 
 issues:
-  new-from-rev: origin/develop # report only new issues with reference to develop branch
   exclude-dirs:
     - tests
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,9 @@ linters-settings:
     settings:
       ruleguard:
         rules: "./gorules/rules.go"
+  gosec:
+     excludes:
+      - G115  # Potential integer overflow when converting between integer types
 
 issues:
   exclude-dirs:

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ build: check-go check-git
 
 .PHONY: lint
 lint: check-lint
-	golangci-lint run --config .golangci.yml
+	golangci-lint run --config .golangci.yml --whole-files
 
 .PHONY: generate-bsd-licenses
 generate-bsd-licenses: check-git

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -514,10 +514,8 @@ func TestInsertHeaders(t *testing.T) {
 			if len(forks) != 0 {
 				if len(forks) != len(expectedForks) {
 					t.Fatalf("forks length dont match, expected %d but found %d", len(expectedForks), len(forks))
-				} else {
-					if !reflect.DeepEqual(forks, expectedForks) {
-						t.Fatal("forks dont match")
-					}
+				} else if !reflect.DeepEqual(forks, expectedForks) {
+					t.Fatal("forks dont match")
 				}
 			}
 
@@ -1709,10 +1707,7 @@ func blockWriter(tb testing.TB, numberOfBlocks uint64, blockTime, checkInterval 
 	err := common.CreateDirSafe(dbPath, 0755)
 	require.NoError(tb, err)
 
-	db, err := leveldb.NewLevelDBStorage(
-		filepath.Join(dbPath),
-		hclog.NewNullLogger(),
-	)
+	db, err := leveldb.NewLevelDBStorage(dbPath, hclog.NewNullLogger())
 	require.NoError(tb, err)
 
 	tb.Cleanup(func() {

--- a/blockchain/storagev2/testing.go
+++ b/blockchain/storagev2/testing.go
@@ -513,6 +513,7 @@ func generateBlock(t *testing.T, num uint64) *types.FullBlock {
 	}
 
 	b.Block.Header.ComputeHash()
+
 	return b
 }
 

--- a/bls/arithmetic.go
+++ b/bls/arithmetic.go
@@ -31,8 +31,8 @@ func hashToPoint(msg, domain []byte) (*bn256.G1, error) {
 		return nil, err
 	}
 
-	//a = a.Mod(a, modulus)
-	//b = b.Mod(b, modulus)
+	// a = a.Mod(a, modulus)
+	// b = b.Mod(b, modulus)
 	a, b := res[0], res[1]
 
 	g1, err := mapToG1Point(a)
@@ -81,12 +81,12 @@ func hashToFpXMDSHA256(msg []byte, domain []byte, count int) ([]*big.Int, error)
 		num := new(big.Int).SetBytes(randBytes[i*48 : (i+1)*48])
 
 		// fast path
-		c := num.Cmp(modulus)
-		if c == 0 {
+		switch c := num.Cmp(modulus); {
+		case c == 0:
 			// nothing
-		} else if c != 1 && num.Cmp(zero) != -1 {
+		case c != 1 && num.Cmp(zero) != -1:
 			// 0 < v < q
-		} else {
+		default:
 			num = num.Mod(num, modulus)
 		}
 
@@ -143,30 +143,30 @@ func expandMsgSHA256XMD(msg []byte, domain []byte, outLen int) ([]byte, error) {
 		_, _ = h.Write([]byte{domainLen})
 
 		// b_1 || ... || b_(ell - 1)
-		copy(out[(i-1)*h.Size():i*h.Size()], bi[:])
+		copy(out[(i-1)*h.Size():i*h.Size()], bi)
 		bi = h.Sum(nil)
 	}
 
 	// b_ell
-	copy(out[(ell-1)*h.Size():], bi[:])
+	copy(out[(ell-1)*h.Size():], bi)
 
 	return out[:outLen], nil
 }
 
-func mulmod(x, y, N *big.Int) *big.Int {
+func mulmod(x, y, n *big.Int) *big.Int {
 	xx := new(big.Int).Mul(x, y)
 
-	return xx.Mod(xx, N)
+	return xx.Mod(xx, n)
 }
 
-func addmod(x, y, N *big.Int) *big.Int {
+func addmod(x, y, n *big.Int) *big.Int {
 	xx := new(big.Int).Add(x, y)
 
-	return xx.Mod(xx, N)
+	return xx.Mod(xx, n)
 }
 
-func inversemod(x, N *big.Int) *big.Int {
-	return new(big.Int).ModInverse(x, N)
+func inversemod(x, n *big.Int) *big.Int {
+	return new(big.Int).ModInverse(x, n)
 }
 
 /**

--- a/command/bridge/common/params.go
+++ b/command/bridge/common/params.go
@@ -93,7 +93,6 @@ func (p *BridgeParams) RegisterCommonFlags(cmd *cobra.Command) {
 		txrelayer.DefaultTimeoutTransactions,
 		cmdHelper.TxTimeoutDesc,
 	)
-
 }
 
 func (p *BridgeParams) Validate() error {
@@ -295,7 +294,7 @@ func (r *BridgeTxResult) GetOutput() string {
 	}
 
 	if r.ChildTokenAddr != nil {
-		vals = append(vals, fmt.Sprintf("Child Token Address|%s", (*r.ChildTokenAddr).String()))
+		vals = append(vals, fmt.Sprintf("Child Token Address|%s", r.ChildTokenAddr.String()))
 	}
 
 	_, _ = buffer.WriteString(fmt.Sprintf("\n[%s]\n", r.Title))

--- a/command/bridge/deploy/deploy.go
+++ b/command/bridge/deploy/deploy.go
@@ -496,7 +496,7 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.EthClien
 			hasProxy: true,
 			byteCodeBuilder: func() ([]byte, error) {
 				constructorFn := &contractsapi.CheckpointManagerConstructorFn{
-					Initiator: types.Address(deployerKey.Address()),
+					Initiator: deployerKey.Address(),
 				}
 
 				input, err := constructorFn.EncodeAbi()
@@ -631,10 +631,12 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.EthClien
 						return fmt.Errorf("deployment of %s contract failed", proxyContractName)
 					}
 
-					deployResults = append(deployResults, newDeployContractsResult(proxyContractName,
-						types.Address(receipt.ContractAddress),
-						receipt.TransactionHash,
-						receipt.GasUsed))
+					deployResults = append(deployResults,
+						newDeployContractsResult(proxyContractName,
+							types.Address(receipt.ContractAddress),
+							receipt.TransactionHash,
+							receipt.GasUsed,
+						))
 				}
 
 				resultsLock.Lock()

--- a/command/bridge/deposit/erc1155/deposit_erc1155.go
+++ b/command/bridge/deposit/erc1155/deposit_erc1155.go
@@ -139,7 +139,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		}
 
 		// mint tokens to depositor, so he is able to send them
-		mintTxn, err := createMintTxn(types.Address(depositorAddr), types.Address(depositorAddr), amounts, tokenIDs)
+		mintTxn, err := createMintTxn(depositorAddr, depositorAddr, amounts, tokenIDs)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("mint transaction creation failed: %w", err))
 

--- a/command/bridge/deposit/erc20/deposit_erc20.go
+++ b/command/bridge/deposit/erc20/deposit_erc20.go
@@ -123,8 +123,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		}
 
 		// mint tokens to depositor, so he is able to send them
-		mintTxn, err := helper.CreateMintTxn(types.Address(depositorAddr),
-			types.StringToAddress(dp.TokenAddr), aggregateAmount, !dp.ChildChainMintable)
+		mintTxn, err := helper.CreateMintTxn(depositorAddr, types.StringToAddress(dp.TokenAddr),
+			aggregateAmount, !dp.ChildChainMintable)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("mint transaction creation failed: %w", err))
 
@@ -191,7 +191,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 				return ctx.Err()
 			default:
 				// deposit tokens
-				depositTxn, err := createDepositTxn(types.Address(depositorAddr), types.StringToAddress(receiver), amount)
+				depositTxn, err := createDepositTxn(depositorAddr, types.StringToAddress(receiver), amount)
 				if err != nil {
 					return fmt.Errorf("failed to create tx input: %w", err)
 				}

--- a/command/bridge/deposit/erc721/deposit_erc721.go
+++ b/command/bridge/deposit/erc721/deposit_erc721.go
@@ -120,7 +120,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		}
 
 		for i := 0; i < len(tokenIDs); i++ {
-			mintTxn, err := createMintTxn(types.Address(depositorAddr), types.Address(depositorAddr))
+			mintTxn, err := createMintTxn(depositorAddr, depositorAddr)
 			if err != nil {
 				outputter.SetError(fmt.Errorf("mint transaction creation failed: %w", err))
 

--- a/command/bridge/fund/fund.go
+++ b/command/bridge/fund/fund.go
@@ -147,7 +147,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 				}
 
 				results[i] = &result{
-					ValidatorAddr: types.Address(fundAddr),
+					ValidatorAddr: fundAddr,
 					TxHash:        types.Hash(receipt.TransactionHash),
 				}
 			}

--- a/command/bridge/helper/utils.go
+++ b/command/bridge/helper/utils.go
@@ -194,9 +194,7 @@ func GetValidatorInfo(validatorAddr types.Address, supernetManagerAddr, stakeMan
 		IsWhitelisted: innerMap["isWhitelisted"].(bool),
 	}
 
-	stakeOfFn := &contractsapi.StakeOfStakeManagerFn{
-		Validator: types.Address(validatorAddr),
-	}
+	stakeOfFn := &contractsapi.StakeOfStakeManagerFn{Validator: validatorAddr}
 
 	encode, err = stakeOfFn.EncodeAbi()
 	if err != nil {

--- a/command/bridge/server/server.go
+++ b/command/bridge/server/server.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -189,7 +188,7 @@ func runRootchain(ctx context.Context, outputter command.OutputFormatter, closeC
 		// in current folder
 		pwdDir, err := os.Getwd()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		} else {
 			mountDir = filepath.Join(pwdDir, params.dataDir)
 		}

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -216,7 +216,7 @@ func ReadValidatorsByPrefix(dir, prefix string,
 		stake := big.NewInt(0)
 
 		if isNativeTokenMintable {
-			s, exists := stakeInfos[types.Address(account.Ecdsa.Address())]
+			s, exists := stakeInfos[account.Ecdsa.Address()]
 			if !exists {
 				stake = command.DefaultStake
 			} else {
@@ -225,7 +225,7 @@ func ReadValidatorsByPrefix(dir, prefix string,
 		}
 
 		validators[i] = &validator.GenesisValidator{
-			Address:   types.Address(account.Ecdsa.Address()),
+			Address:   account.Ecdsa.Address(),
 			BlsKey:    hex.EncodeToString(account.Bls.PublicKey().Marshal()),
 			MultiAddr: fmt.Sprintf("/ip4/%s/tcp/%d/p2p/%s", "127.0.0.1", bootnodePortStart+int64(i), nodeID),
 			Stake:     stake,

--- a/command/regenesis/test_on_history.go
+++ b/command/regenesis/test_on_history.go
@@ -98,7 +98,7 @@ func HistoryTestCmd() *cobra.Command {
 			}
 
 			if lastStateRoot == header.StateRoot {
-				//state root is the same,as in previous block
+				// state root is the same,as in previous block
 				continue
 			}
 

--- a/command/secrets/init/params.go
+++ b/command/secrets/init/params.go
@@ -9,7 +9,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/secrets"
 	"github.com/0xPolygon/polygon-edge/secrets/helper"
-	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/spf13/cobra"
 )
 
@@ -252,7 +251,7 @@ func (ip *initParams) getResult(
 			return nil, err
 		}
 
-		res.Address = types.Address(account.Ecdsa.Address())
+		res.Address = account.Ecdsa.Address()
 		res.BLSPubkey = hex.EncodeToString(account.Bls.PublicKey().Marshal())
 
 		res.Generated = strings.Join(generated, ", ")

--- a/command/validator/helper/helper.go
+++ b/command/validator/helper/helper.go
@@ -98,9 +98,7 @@ func GetValidatorInfo(validatorAddr types.Address, childRelayer txrelayer.TxRela
 		IsWhitelisted: innerMap["isWhitelisted"].(bool),
 	}
 
-	stakeOfFn := &contractsapi.StakeOfStakeManagerFn{
-		Validator: types.Address(validatorAddr),
-	}
+	stakeOfFn := &contractsapi.StakeOfStakeManagerFn{Validator: validatorAddr}
 
 	encode, err = stakeOfFn.EncodeAbi()
 	if err != nil {

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -247,13 +247,8 @@ func TestCheckpointManager_getCurrentCheckpointID(t *testing.T) {
 				Return(c.checkpointID, c.returnError).
 				Once()
 
-			acc, err := wallet.GenerateAccount()
-			require.NoError(t, err)
-
 			checkpointMgr := &checkpointManager{
 				rootChainRelayer: txRelayerMock,
-				key:              acc.Ecdsa,
-				logger:           hclog.NewNullLogger(),
 			}
 
 			actualCheckpointID, err := getCurrentCheckpointBlock(checkpointMgr.rootChainRelayer,

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -401,7 +401,7 @@ func (c *consensusRuntime) FSM() error {
 
 	blockBuilder, err := c.config.blockchain.NewBlockBuilder(
 		parent,
-		types.Address(c.config.Key.Address()),
+		c.config.Key.Address(),
 		c.config.txPool,
 		epoch.CurrentClientConfig.BlockTime.Duration,
 		c.logger,
@@ -1014,6 +1014,7 @@ func (c *consensusRuntime) BuildCommitMessage(proposalHash []byte, view *proto.V
 // RoundStarts represents the round start callback
 func (c *consensusRuntime) RoundStarts(view *proto.View) error {
 	c.logger.Info("RoundStarts", "height", view.Height, "round", view.Round)
+
 	if view.Round > 0 {
 		c.config.txPool.ReinsertProposed()
 	} else {

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -379,8 +379,8 @@ func TestConsensusRuntime_FSM_NotEndOfEpoch_NotEndOfSprint(t *testing.T) {
 	assert.False(t, runtime.fsm.isEndOfSprint)
 	assert.Equal(t, lastBlock.Number, runtime.fsm.parent.Number)
 
-	address := types.Address(runtime.config.Key.Address())
-	assert.True(t, runtime.fsm.ValidatorSet().Includes(address))
+	localAddr := runtime.config.Key.Address()
+	assert.True(t, runtime.fsm.ValidatorSet().Includes(localAddr))
 
 	assert.NotNil(t, runtime.fsm.blockBuilder)
 	assert.NotNil(t, runtime.fsm.backend)

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -584,7 +584,8 @@ func generateType(generatedData *generatedData, name string, obj *abi.Type, res 
 
 		var typ string
 
-		if elem.Kind() == abi.KindTuple {
+		switch elem.Kind() {
+		case abi.KindTuple:
 			// Struct
 			nestedType, err := generateNestedType(generatedData, tupleElem.Name, elem, res)
 			if err != nil {
@@ -592,30 +593,49 @@ func generateType(generatedData *generatedData, name string, obj *abi.Type, res 
 			}
 
 			typ = nestedType
-		} else if elem.Kind() == abi.KindSlice && elem.Elem().Kind() == abi.KindTuple {
-			// []Struct
-			nestedType, err := generateNestedType(generatedData, getInternalType(tupleElem.Name, elem), elem.Elem(), res)
-			if err != nil {
-				return "", err
+
+		case abi.KindSlice:
+			switch elem.Elem().Kind() {
+			case abi.KindTuple:
+				// []Struct
+				nestedType, err := generateNestedType(generatedData, getInternalType(tupleElem.Name, elem), elem.Elem(), res)
+				if err != nil {
+					return "", err
+				}
+
+				typ = "[]" + nestedType
+			case abi.KindAddress:
+				// for address slice or arrays use the native `types.Address` type instead of `ethgo.Address`
+				typ = "[]types.Address"
+			default:
+				typ = elem.GoType().String()
 			}
 
-			typ = "[]" + nestedType
-		} else if elem.Kind() == abi.KindArray && elem.Elem().Kind() == abi.KindTuple {
-			// [n]Struct
-			nestedType, err := generateNestedType(generatedData, getInternalType(tupleElem.Name, elem), elem.Elem(), res)
-			if err != nil {
-				return "", err
+		case abi.KindArray:
+			switch elem.Elem().Kind() {
+			case abi.KindTuple:
+				// [n]Struct
+				nestedType, err := generateNestedType(generatedData, getInternalType(tupleElem.Name, elem), elem.Elem(), res)
+				if err != nil {
+					return "", err
+				}
+
+				typ = "[" + strconv.Itoa(elem.Size()) + "]" + nestedType
+
+			case abi.KindAddress:
+				// for address slice or arrays use the native `types.Address` type instead of `ethgo.Address`
+				typ = "[]types.Address"
+
+			default:
+				// for the rest of the types use the go type returned by abi
+				typ = elem.GoType().String()
 			}
 
-			typ = "[" + strconv.Itoa(elem.Size()) + "]" + nestedType
-		} else if elem.Kind() == abi.KindAddress {
+		case abi.KindAddress:
 			// for address use the native `types.Address` type instead of `ethgo.Address`
 			typ = "types.Address"
-		} else if (elem.Kind() == abi.KindArray || elem.Kind() == abi.KindSlice) &&
-			elem.Elem().Kind() == abi.KindAddress {
-			// for address slice or arrays use the native `types.Address` type instead of `ethgo.Address`
-			typ = "[]types.Address"
-		} else {
+
+		default:
 			// for the rest of the types use the go type returned by abi
 			typ = elem.GoType().String()
 		}
@@ -623,15 +643,15 @@ func generateType(generatedData *generatedData, name string, obj *abi.Type, res 
 		// []byte and [n]byte get rendered as []uint68 and [n]uint8, since we do not have any
 		// uint8 internally in polybft, we can use regexp to replace those values with the
 		// correct byte representation
-		typ = strings.Replace(typ, "[32]uint8", "types.Hash", -1)
-		typ = strings.Replace(typ, "]uint8", "]byte", -1)
+		typ = strings.ReplaceAll(typ, "[32]uint8", "types.Hash")
+		typ = strings.ReplaceAll(typ, "]uint8", "]byte")
 
 		// Trim the leading _ from name if it exists
 		fieldName := strings.TrimPrefix(tupleElem.Name, "_")
 
 		// Replacement of Id for ID to make the linter happy
 		fieldName = strings.Title(fieldName)
-		fieldName = strings.Replace(fieldName, "Id", "ID", -1)
+		fieldName = strings.ReplaceAll(fieldName, "Id", "ID")
 
 		str = append(str, fmt.Sprintf("%s %s `abi:\"%s\"`", fieldName, typ, tupleElem.Name))
 	}

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -507,7 +507,7 @@ func TestExtra_InitGenesisValidatorsDelta(t *testing.T) {
 
 		for _, val := range vals.Validators {
 			delta.Added[i] = &validator.ValidatorMetadata{
-				Address:     types.Address(val.Account.Ecdsa.Address()),
+				Address:     val.Account.Ecdsa.Address(),
 				BlsKey:      val.Account.Bls.PublicKey(),
 				VotingPower: new(big.Int).SetUint64(val.VotingPower),
 			}
@@ -579,7 +579,6 @@ func Test_GetIbftExtraClean(t *testing.T) {
 
 	extraTwo := &Extra{}
 	require.NoError(t, extraTwo.UnmarshalRLP(extraClean))
-	require.True(t, extra.Validators.Equals(extra.Validators))
 	require.Equal(t, extra.Checkpoint.BlockRound, extraTwo.Checkpoint.BlockRound)
 	require.Equal(t, extra.Checkpoint.EpochNumber, extraTwo.Checkpoint.EpochNumber)
 	require.Equal(t, extra.Checkpoint.CurrentValidatorsHash, extraTwo.Checkpoint.CurrentValidatorsHash)

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -1636,8 +1636,8 @@ func createTestCommitment(t *testing.T, accounts []*wallet.Account) *CommitmentM
 	for i := 0; i < len(accounts); i++ {
 		stateSyncEvents[i] = &contractsapi.StateSyncedEvent{
 			ID:       big.NewInt(int64(i)),
-			Sender:   types.Address(accounts[i].Ecdsa.Address()),
-			Receiver: types.Address(accounts[0].Ecdsa.Address()),
+			Sender:   accounts[i].Ecdsa.Address(),
+			Receiver: accounts[0].Ecdsa.Address(),
 			Data:     []byte{},
 		}
 

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -677,6 +677,7 @@ func (p *Polybft) startConsensusProtocol() {
 		case <-sequenceCh:
 		case <-p.closeCh:
 			p.logger.Debug("stoping sequence", "block number", latestHeader.Number+1)
+
 			if isValidator {
 				stopSequence()
 			}
@@ -772,6 +773,7 @@ func (p *Polybft) SetBlockTime(blockTime time.Duration) {
 	// if block time is greater than default base round timeout,
 	// set base round timeout as twice the block time
 	syncerBlockTimeout := blockTime * 10
+
 	if blockTime >= core.DefaultBaseRoundTimeout {
 		p.ibft.SetBaseRoundTimeout(blockTime * baseRoundTimeoutScaleFactor)
 		syncerBlockTimeout *= baseRoundTimeoutScaleFactor

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -162,7 +162,7 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 			NextValidatorsHash:    types.StringToHash("Bar"),
 		}, nil)
 
-	currentHeader.Hash[0] = currentHeader.Hash[0] + 1
+	currentHeader.Hash[0]++
 	assert.ErrorContains(t, polybft.VerifyHeader(currentHeader), "invalid header hash")
 
 	// omit Parent field (parent signature) intentionally

--- a/consensus/polybft/proposer_calculator.go
+++ b/consensus/polybft/proposer_calculator.go
@@ -470,19 +470,20 @@ func rescalePriorities(snapshot *ProposerSnapshot, totalVotingPower *big.Int) er
 
 // computeMaxMinPriorityDiff computes the difference between the max and min ProposerPriority of that set.
 func computeMaxMinPriorityDiff(validators []*PrioritizedValidator) *big.Int {
-	min, max := validators[0].ProposerPriority, validators[0].ProposerPriority
+	minPriority := validators[0].ProposerPriority
+	maxPriority := minPriority
 
 	for _, v := range validators[1:] {
-		if v.ProposerPriority.Cmp(min) < 0 {
-			min = v.ProposerPriority
+		if v.ProposerPriority.Cmp(minPriority) < 0 {
+			minPriority = v.ProposerPriority
 		}
 
-		if v.ProposerPriority.Cmp(max) > 0 {
-			max = v.ProposerPriority
+		if v.ProposerPriority.Cmp(maxPriority) > 0 {
+			maxPriority = v.ProposerPriority
 		}
 	}
 
-	diff := new(big.Int).Sub(max, min)
+	diff := new(big.Int).Sub(maxPriority, minPriority)
 
 	if diff.Cmp(big.NewInt(0)) < 0 {
 		return diff.Neg(diff)

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -504,16 +504,19 @@ func (s *stateSyncManager) buildCommitment(dbTx *bolt.Tx) error {
 
 	// Since lock is reduced grab original values into local variables in order to keep them
 	epoch := s.epoch
+
 	stateSyncEvents, err := s.state.StateSyncStore.getStateSyncEventsForCommitment(s.nextCommittedIndex,
 		s.nextCommittedIndex+s.config.maxCommitmentSize-1, dbTx)
 	if err != nil && !errors.Is(err, errNotEnoughStateSyncs) {
 		s.lock.RUnlock()
+
 		return fmt.Errorf("failed to get state sync events for commitment. Error: %w", err)
 	}
 
 	if len(stateSyncEvents) == 0 {
 		// there are no state sync events
 		s.lock.RUnlock()
+
 		return nil
 	}
 
@@ -521,6 +524,7 @@ func (s *stateSyncManager) buildCommitment(dbTx *bolt.Tx) error {
 		s.pendingCommitments[len(s.pendingCommitments)-1].StartID.Cmp(stateSyncEvents[len(stateSyncEvents)-1].ID) >= 0 {
 		// already built a commitment of this size which is pending to be submitted
 		s.lock.RUnlock()
+
 		return nil
 	}
 

--- a/consensus/polybft/state_transaction.go
+++ b/consensus/polybft/state_transaction.go
@@ -23,16 +23,20 @@ func decodeStateTransaction(txData []byte) (contractsapi.StateTransactionInput, 
 		obj                 contractsapi.StateTransactionInput
 	)
 
-	if bytes.Equal(sig, commitBridgeTxFn.Sig()) {
+	switch {
+	case bytes.Equal(sig, commitBridgeTxFn.Sig()):
 		// bridge commitment
 		obj = &CommitmentMessageSigned{}
-	} else if bytes.Equal(sig, commitEpochFn.Sig()) {
+
+	case bytes.Equal(sig, commitEpochFn.Sig()):
 		// commit epoch
 		obj = &contractsapi.CommitEpochEpochManagerFn{}
-	} else if bytes.Equal(sig, distributeRewardsFn.Sig()) {
+
+	case bytes.Equal(sig, distributeRewardsFn.Sig()):
 		// distribute rewards
 		obj = &contractsapi.DistributeRewardForEpochManagerFn{}
-	} else {
+
+	default:
 		return nil, fmt.Errorf("unknown state transaction")
 	}
 

--- a/consensus/polybft/validator/test_helpers.go
+++ b/consensus/polybft/validator/test_helpers.go
@@ -150,7 +150,7 @@ func NewTestValidator(tb testing.TB, alias string, votingPower uint64) *TestVali
 }
 
 func (v *TestValidator) Address() types.Address {
-	return types.Address(v.Account.Ecdsa.Address())
+	return v.Account.Ecdsa.Address()
 }
 
 func (v *TestValidator) Key() *wallet.Key {
@@ -169,7 +169,7 @@ func (v *TestValidator) ParamsValidator() *GenesisValidator {
 
 func (v *TestValidator) ValidatorMetadata() *ValidatorMetadata {
 	return &ValidatorMetadata{
-		Address:     types.Address(v.Account.Ecdsa.Address()),
+		Address:     v.Account.Ecdsa.Address(),
 		BlsKey:      v.Account.Bls.PublicKey(),
 		VotingPower: new(big.Int).SetUint64(v.VotingPower),
 	}

--- a/consensus/polybft/validator/validator_set.go
+++ b/consensus/polybft/validator/validator_set.go
@@ -67,7 +67,7 @@ func (vs validatorSet) HasQuorum(blockNumber uint64, signers map[types.Address]s
 		}
 	}
 
-	quorumSize := getQuorumSize(blockNumber, vs.totalVotingPower)
+	quorumSize := getQuorumSize(vs.totalVotingPower)
 	hasQuorum := aggregateVotingPower.Cmp(quorumSize) >= 0
 
 	vs.logger.Debug("HasQuorum",
@@ -105,7 +105,7 @@ func (vs validatorSet) TotalVotingPower() big.Int {
 }
 
 // getQuorumSize calculates quorum size as 2/3 super-majority of provided total voting power
-func getQuorumSize(blockNumber uint64, totalVotingPower *big.Int) *big.Int {
+func getQuorumSize(totalVotingPower *big.Int) *big.Int {
 	quorum := new(big.Int)
 	quorum.Mul(totalVotingPower, big.NewInt(2))
 

--- a/consensus/polybft/validator/validator_set_test.go
+++ b/consensus/polybft/validator/validator_set_test.go
@@ -47,7 +47,7 @@ func TestValidatorSet_getQuorumSize(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		quorumSize := getQuorumSize(1, big.NewInt(c.totalVotingPower))
+		quorumSize := getQuorumSize(big.NewInt(c.totalVotingPower))
 		require.Equal(t, c.expectedQuorumSize, quorumSize.Int64())
 	}
 }

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -106,7 +106,7 @@ func TestCreate2(t *testing.T) {
 			}
 
 			salt := [32]byte{}
-			copy(salt[:], saltRaw[:])
+			copy(salt[:], saltRaw)
 
 			res := CreateAddress2(address, salt, initCode)
 

--- a/crypto/txsigner_berlin.go
+++ b/crypto/txsigner_berlin.go
@@ -60,7 +60,7 @@ func (signer *BerlinSigner) Hash(tx *types.Transaction) types.Hash {
 		hashPreimage.Set(RLP.NewNull())
 	} else {
 		// RLP(chainId, nonce, gasPrice, gas, to, -, -, -)
-		hashPreimage.Set(RLP.NewCopyBytes((*(tx.To())).Bytes()))
+		hashPreimage.Set(RLP.NewCopyBytes(tx.To().Bytes()))
 	}
 
 	// RLP(chainId, nonce, gasPrice, gas, to, value, -, -)

--- a/crypto/txsigner_frontier.go
+++ b/crypto/txsigner_frontier.go
@@ -49,7 +49,7 @@ func (signer *FrontierSigner) Hash(tx *types.Transaction) types.Hash {
 		hashPreimage.Set(RLP.NewNull())
 	} else {
 		// RLP(nonce, gasPrice, gas, to, -, -)
-		hashPreimage.Set(RLP.NewCopyBytes((*(tx.To())).Bytes()))
+		hashPreimage.Set(RLP.NewCopyBytes(tx.To().Bytes()))
 	}
 
 	// RLP(nonce, gasPrice, gas, to, value, -)
@@ -114,7 +114,7 @@ func (signer *FrontierSigner) signTxInternal(tx *types.Transaction,
 	return tx, nil
 }
 
-func (f *FrontierSigner) SignTxWithCallback(
+func (signer *FrontierSigner) SignTxWithCallback(
 	tx *types.Transaction,
 	signFn func(hash types.Hash) (sig []byte, err error)) (*types.Transaction, error) {
 	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType {
@@ -122,14 +122,14 @@ func (f *FrontierSigner) SignTxWithCallback(
 	}
 
 	tx = tx.Copy()
-	h := f.Hash(tx)
+	h := signer.Hash(tx)
 
 	signature, err := signFn(h)
 	if err != nil {
 		return nil, err
 	}
 
-	tx.SplitToRawSignatureValues(signature, f.calculateV(signature[64]))
+	tx.SplitToRawSignatureValues(signature, signer.calculateV(signature[64]))
 
 	return tx, nil
 }

--- a/crypto/txsigner_london.go
+++ b/crypto/txsigner_london.go
@@ -66,7 +66,7 @@ func (signer *LondonSigner) Hash(tx *types.Transaction) types.Hash {
 		hashPreimage.Set(RLP.NewNull())
 	} else {
 		// RLP(chainId, nonce, gasTipCap, gasFeeCap, gas, to, -, -, -)
-		hashPreimage.Set(RLP.NewCopyBytes((*(tx.To())).Bytes()))
+		hashPreimage.Set(RLP.NewCopyBytes(tx.To().Bytes()))
 	}
 
 	// RLP(chainId, nonce, gasTipCap, gasFeeCap, gas, to, value, -, -)

--- a/e2e-polybft/e2e/acls_test.go
+++ b/e2e-polybft/e2e/acls_test.go
@@ -353,9 +353,9 @@ func TestE2E_AddressLists_Bridge(t *testing.T) {
 	target, _ := crypto.GenerateECDSAKey()
 	other, _ := crypto.GenerateECDSAKey()
 
-	adminAddr := types.Address(admin.Address())
-	targetAddr := types.Address(target.Address())
-	otherAddr := types.Address(other.Address())
+	adminAddr := admin.Address()
+	targetAddr := target.Address()
+	otherAddr := other.Address()
 
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithPremine(adminAddr, targetAddr, otherAddr),

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -61,8 +61,8 @@ func TestE2E_Bridge_RootchainTokensTransfers(t *testing.T) {
 		require.NoError(t, err)
 
 		receiverKeys[i] = hex.EncodeToString(rawKey)
-		receiversAddrs[i] = types.Address(key.Address())
-		receivers[i] = types.Address(key.Address()).String()
+		receiversAddrs[i] = key.Address()
+		receivers[i] = key.Address().String()
 		amounts[i] = fmt.Sprintf("%d", bridgeAmount)
 
 		t.Logf("Receiver#%d=%s\n", i+1, receivers[i])
@@ -128,8 +128,8 @@ func TestE2E_Bridge_RootchainTokensTransfers(t *testing.T) {
 				rootERC20Token,
 				polybftCfg.Bridge.RootERC20PredicateAddr,
 				bridgeHelper.TestAccountPrivKey,
-				strings.Join(receivers[:], ","),
-				strings.Join(amounts[:], ","),
+				strings.Join(receivers, ","),
+				strings.Join(amounts, ","),
 				"",
 				cluster.Bridge.JSONRPCAddr(),
 				bridgeHelper.TestAccountPrivKey,
@@ -307,8 +307,8 @@ func TestE2E_Bridge_ERC721Transfer(t *testing.T) {
 		require.NoError(t, err)
 
 		receiverKeys[i] = hex.EncodeToString(rawKey)
-		receivers[i] = types.Address(key.Address()).String()
-		receiversAddrs[i] = types.Address(key.Address())
+		receivers[i] = key.Address().String()
+		receiversAddrs[i] = key.Address()
 		tokenIDs[i] = fmt.Sprintf("%d", i)
 
 		t.Logf("Receiver#%d=%s\n", i+1, receivers[i])
@@ -359,9 +359,9 @@ func TestE2E_Bridge_ERC721Transfer(t *testing.T) {
 			rootERC721Addr,
 			polybftCfg.Bridge.RootERC721PredicateAddr,
 			bridgeHelper.TestAccountPrivKey,
-			strings.Join(receivers[:], ","),
+			strings.Join(receivers, ","),
 			"",
-			strings.Join(tokenIDs[:], ","),
+			strings.Join(tokenIDs, ","),
 			cluster.Bridge.JSONRPCAddr(),
 			bridgeHelper.TestAccountPrivKey,
 			false),
@@ -479,8 +479,8 @@ func TestE2E_Bridge_ERC1155Transfer(t *testing.T) {
 		require.NoError(t, err)
 
 		receiverKeys[i] = hex.EncodeToString(rawKey)
-		receivers[i] = types.Address(key.Address()).String()
-		receiversAddrs[i] = types.Address(key.Address())
+		receivers[i] = key.Address().String()
+		receiversAddrs[i] = key.Address()
 		amounts[i] = fmt.Sprintf("%d", amount)
 		tokenIDs[i] = fmt.Sprintf("%d", i+1)
 
@@ -533,9 +533,9 @@ func TestE2E_Bridge_ERC1155Transfer(t *testing.T) {
 			rootERC1155Addr,
 			polybftCfg.Bridge.RootERC1155PredicateAddr,
 			bridgeHelper.TestAccountPrivKey,
-			strings.Join(receivers[:], ","),
-			strings.Join(amounts[:], ","),
-			strings.Join(tokenIDs[:], ","),
+			strings.Join(receivers, ","),
+			strings.Join(amounts, ","),
+			strings.Join(tokenIDs, ","),
 			cluster.Bridge.JSONRPCAddr(),
 			bridgeHelper.TestAccountPrivKey,
 			false),
@@ -681,7 +681,7 @@ func TestE2E_Bridge_ChildchainTokensTransfer(t *testing.T) {
 	admin, err := crypto.GenerateECDSAKey()
 	require.NoError(t, err)
 
-	adminAddr := types.Address(admin.Address())
+	adminAddr := admin.Address()
 
 	for i := uint64(0); i < transfersCount; i++ {
 		key, err := crypto.GenerateECDSAKey()
@@ -691,7 +691,7 @@ func TestE2E_Bridge_ChildchainTokensTransfer(t *testing.T) {
 		require.NoError(t, err)
 
 		depositorKeys[i] = hex.EncodeToString(rawKey)
-		depositors[i] = types.Address(key.Address())
+		depositors[i] = key.Address()
 		funds[i] = singleToken
 		amounts[i] = fmt.Sprintf("%d", amount)
 
@@ -893,7 +893,7 @@ func TestE2E_Bridge_ChildchainTokensTransfer(t *testing.T) {
 			// deposit (without minting, as it was already done beforehand)
 			err = cluster.Bridge.Deposit(
 				common.ERC721,
-				types.Address(rootERC721Token),
+				rootERC721Token,
 				contracts.RootMintableERC721PredicateContract,
 				depositorKey,
 				depositors[i].String(),
@@ -931,9 +931,9 @@ func TestE2E_Bridge_ChildchainTokensTransfer(t *testing.T) {
 
 		// retrieve child token addresses on both chains and make sure they are the same
 		l1ChildToken := getChildToken(t, contractsapi.ChildMintableERC721Predicate.Abi, polybftCfg.Bridge.ChildMintableERC721PredicateAddr,
-			types.Address(rootERC721Token), rootchainTxRelayer)
+			rootERC721Token, rootchainTxRelayer)
 		l2ChildToken := getChildToken(t, contractsapi.RootMintableERC721Predicate.Abi, contracts.RootMintableERC721PredicateContract,
-			types.Address(rootERC721Token), childchainTxRelayer)
+			rootERC721Token, childchainTxRelayer)
 
 		t.Log("L1 child token", l1ChildToken)
 		t.Log("L2 child token", l2ChildToken)
@@ -973,7 +973,7 @@ func TestE2E_Bridge_ChildchainTokensTransfer(t *testing.T) {
 			allSuccessful = true
 			// check owners on the child chain
 			for i, receiver := range depositors {
-				owner := erc721OwnerOf(t, big.NewInt(int64(i)), types.Address(rootERC721Token), childchainTxRelayer)
+				owner := erc721OwnerOf(t, big.NewInt(int64(i)), rootERC721Token, childchainTxRelayer)
 				t.Log("Attempt:", it+1, " Owner:", owner, " Receiver:", receiver)
 
 				if receiver != owner {
@@ -1056,7 +1056,7 @@ func TestE2E_Bridge_Transfers_AccessLists(t *testing.T) {
 	withdrawAmounts := make([]string, transfersCount)
 
 	admin, _ := crypto.GenerateECDSAKey()
-	adminAddr := types.Address(admin.Address())
+	adminAddr := admin.Address()
 
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithNumBlockConfirmations(0),
@@ -1126,8 +1126,8 @@ func TestE2E_Bridge_Transfers_AccessLists(t *testing.T) {
 				rootERC20Token,
 				polybftCfg.Bridge.RootERC20PredicateAddr,
 				bridgeHelper.TestAccountPrivKey,
-				strings.Join(receivers[:], ","),
-				strings.Join(depositAmounts[:], ","),
+				strings.Join(receivers, ","),
+				strings.Join(depositAmounts, ","),
 				"",
 				cluster.Bridge.JSONRPCAddr(),
 				bridgeHelper.TestAccountPrivKey,
@@ -1168,8 +1168,8 @@ func TestE2E_Bridge_Transfers_AccessLists(t *testing.T) {
 		err = cluster.Bridge.Withdraw(
 			common.ERC20,
 			hex.EncodeToString(rawKey),
-			strings.Join(receivers[:], ","),
-			strings.Join(withdrawAmounts[:], ","),
+			strings.Join(receivers, ","),
+			strings.Join(withdrawAmounts, ","),
 			"",
 			validatorSrv.JSONRPCAddr(),
 			contracts.ChildERC20PredicateContract,
@@ -1184,8 +1184,8 @@ func TestE2E_Bridge_Transfers_AccessLists(t *testing.T) {
 		err = cluster.Bridge.Withdraw(
 			common.ERC20,
 			hex.EncodeToString(rawKey),
-			strings.Join(receivers[:], ","),
-			strings.Join(withdrawAmounts[:], ","),
+			strings.Join(receivers, ","),
+			strings.Join(withdrawAmounts, ","),
 			"",
 			validatorSrv.JSONRPCAddr(),
 			contracts.ChildERC20PredicateContract,
@@ -1200,8 +1200,8 @@ func TestE2E_Bridge_Transfers_AccessLists(t *testing.T) {
 		err = cluster.Bridge.Withdraw(
 			common.ERC20,
 			hex.EncodeToString(rawKey),
-			strings.Join(receivers[:], ","),
-			strings.Join(withdrawAmounts[:], ","),
+			strings.Join(receivers, ","),
+			strings.Join(withdrawAmounts, ","),
 			"",
 			validatorSrv.JSONRPCAddr(),
 			contracts.ChildERC20PredicateContract,
@@ -1333,15 +1333,15 @@ func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 		if isValidator {
 			require.True(t, balance.Cmp(childExpected) >= 0) // because of London fork
 		} else {
-			//this check is implemented because non-validators incur fees, potentially resulting in a balance lower than anticipated
+			// this check is implemented because non-validators incur fees, potentially resulting in a balance lower than anticipated
 			require.True(t, balance.Cmp(expectedValue.Sub(childExpected, offset)) >= 0)
 		}
 	}
 
 	t.Run("check the balances at the beginning", func(t *testing.T) {
 		// check the balances on root and child at the beginning to see if they are as expected
-		checkBalancesFn(types.Address(nonValidatorKey.Address()), bigZero, command.DefaultPremineBalance, false)
-		checkBalancesFn(types.Address(rewardWalletKey.Address()), bigZero, command.DefaultPremineBalance, true)
+		checkBalancesFn(nonValidatorKey.Address(), bigZero, command.DefaultPremineBalance, false)
+		checkBalancesFn(rewardWalletKey.Address(), bigZero, command.DefaultPremineBalance, true)
 
 		validatorsExpectedBalance := new(big.Int).Sub(command.DefaultPremineBalance, command.DefaultStake)
 
@@ -1431,7 +1431,7 @@ func TestE2E_Bridge_NonMintableERC20Token_WithPremine(t *testing.T) {
 
 		// assert that receiver's balances on RootERC20 smart contract are expected
 		checkBalancesFn(validatorAcc.Address(), tokensToTransfer, validatorBalanceAfterWithdraw, true)
-		checkBalancesFn(types.Address(nonValidatorKey.Address()), tokensToTransfer, nonValidatorBalanceAfterWithdraw, false)
+		checkBalancesFn(nonValidatorKey.Address(), tokensToTransfer, nonValidatorBalanceAfterWithdraw, false)
 	})
 
 	t.Run("do a deposit to some validator and non-validator address", func(t *testing.T) {

--- a/e2e-polybft/e2e/burn_contract_test.go
+++ b/e2e-polybft/e2e/burn_contract_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
 	"github.com/0xPolygon/polygon-edge/jsonrpc"
-	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,8 +14,8 @@ func TestE2E_BurnContract_Deployed(t *testing.T) {
 	contractKey, _ := crypto.GenerateECDSAKey()
 	destinationKey, _ := crypto.GenerateECDSAKey()
 
-	contractAddr := types.Address(contractKey.Address())
-	destinationAddr := types.Address(destinationKey.Address())
+	contractAddr := contractKey.Address()
+	destinationAddr := destinationKey.Address()
 
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithBridge(),

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -26,6 +26,10 @@ var (
 	one = big.NewInt(1)
 )
 
+const (
+	defaultAccPassword = "testpassword"
+)
+
 func TestE2E_JsonRPC(t *testing.T) {
 	const epochSize = uint64(5)
 
@@ -375,14 +379,12 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_signTransaction", func(t *testing.T) {
-		accPassword := "testpassword"
-
 		keyRaw, err := preminedAcctOne.MarshallPrivateKey()
 		require.NoError(t, err)
 
 		hexKey := hex.EncodeToString(keyRaw)
 
-		accAddr, err := ethClient.ImportRawKey(hexKey, accPassword)
+		accAddr, err := ethClient.ImportRawKey(hexKey, defaultAccPassword)
 		require.NoError(t, err)
 		require.Equal(t, preminedAcctOne.Address(), accAddr)
 
@@ -405,7 +407,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 			Type:     uint64(types.LegacyTxType),
 		}
 
-		isUnlocked, err := ethClient.Unlock(preminedAcctOne.Address(), accPassword, 90 /* seconds */) // unlock for 90 seconds
+		isUnlocked, err := ethClient.Unlock(preminedAcctOne.Address(), defaultAccPassword, 90 /* seconds */) // unlock for 90 seconds
 		require.NoError(t, err)
 		require.True(t, isUnlocked)
 
@@ -429,14 +431,12 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_sendTransaction", func(t *testing.T) {
-		accPassword := "testpassword"
-
 		keyRaw, err := preminedAcctTwo.MarshallPrivateKey()
 		require.NoError(t, err)
 
 		hexKey := hex.EncodeToString(keyRaw)
 
-		accAddr, err := ethClient.ImportRawKey(hexKey, accPassword)
+		accAddr, err := ethClient.ImportRawKey(hexKey, defaultAccPassword)
 		require.NoError(t, err)
 		require.Equal(t, preminedAcctTwo.Address(), accAddr)
 
@@ -458,7 +458,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 			types.WithValue(big.NewInt(1)),
 		))
 
-		isUnlocked, err := ethClient.Unlock(preminedAcctTwo.Address(), accPassword, 90 /* seconds */) // unlock for 90 seconds
+		isUnlocked, err := ethClient.Unlock(preminedAcctTwo.Address(), defaultAccPassword, 90 /* seconds */) // unlock for 90 seconds
 		require.NoError(t, err)
 		require.True(t, isUnlocked)
 
@@ -468,8 +468,6 @@ func TestE2E_JsonRPC(t *testing.T) {
 	})
 
 	t.Run("eth_sign", func(t *testing.T) {
-		accPassword := "testpassword"
-
 		key, err := crypto.GenerateECDSAKey()
 		require.NoError(t, err)
 
@@ -478,7 +476,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 
 		hexKey := hex.EncodeToString(keyRaw)
 
-		accAddr, err := ethClient.ImportRawKey(hexKey, accPassword)
+		accAddr, err := ethClient.ImportRawKey(hexKey, defaultAccPassword)
 		require.NoError(t, err)
 		require.Equal(t, key.Address(), accAddr)
 
@@ -500,7 +498,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 				types.WithGasPrice(new(big.Int).SetUint64(gasPrice)),
 			))
 
-		isUnlocked, err := ethClient.Unlock(key.Address(), accPassword, 90 /* seconds */) // unlock for 90 seconds
+		isUnlocked, err := ethClient.Unlock(key.Address(), defaultAccPassword, 90 /* seconds */) // unlock for 90 seconds
 		require.NoError(t, err)
 		require.True(t, isUnlocked)
 

--- a/e2e-polybft/e2e/migration_test.go
+++ b/e2e-polybft/e2e/migration_test.go
@@ -32,7 +32,7 @@ func TestE2E_Migration(t *testing.T) {
 	initialBalance := ethgo.Ether(10)
 	srvs := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
 		config.SetConsensus(framework.ConsensusDev)
-		config.Premine(types.Address(userAddr), initialBalance)
+		config.Premine(userAddr, initialBalance)
 	})
 
 	srv := srvs[0]
@@ -86,7 +86,7 @@ func TestE2E_Migration(t *testing.T) {
 	require.NotNil(t, receipt)
 	require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
 
-	deployedContractBalance := receipt.ContractAddress
+	deployedContractAddr := receipt.ContractAddress
 
 	initReceipt, err := ABITransaction(relayer, userKey, contractsapi.TestWriteBlockMetadata, types.Address(receipt.ContractAddress), "init")
 	if err != nil {
@@ -112,7 +112,7 @@ func TestE2E_Migration(t *testing.T) {
 
 	path := filepath.Join(srvs[0].Config.RootDir, "trie")
 	srvs[0].Stop()
-	//hack for db closing. leveldb allow only one connection
+	// hack for db closing. leveldb allow only one connection
 	time.Sleep(time.Second)
 
 	tmpDir := t.TempDir()
@@ -140,7 +140,7 @@ func TestE2E_Migration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	require.Equal(t, types.Hash(stateRoot), copiedStateRoot)
+	require.Equal(t, stateRoot, copiedStateRoot)
 
 	err = db.Close()
 	if err != nil {
@@ -151,7 +151,7 @@ func TestE2E_Migration(t *testing.T) {
 		frameworkpolybft.WithNonValidators(2),
 		frameworkpolybft.WithValidatorSnapshot(5),
 		frameworkpolybft.WithTestRewardToken(),
-		frameworkpolybft.WithGenesisState(tmpDir, types.Hash(stateRoot)),
+		frameworkpolybft.WithGenesisState(tmpDir, stateRoot),
 	)
 	defer cluster.Stop()
 
@@ -170,7 +170,7 @@ func TestE2E_Migration(t *testing.T) {
 	require.Equal(t, balanceSender, senderBalanceAfterMigration)
 	require.Equal(t, balanceReceiver, receiverBalanceAfterMigration)
 
-	deployedCode, err := cluster.Servers[0].JSONRPC().GetCode(types.Address(deployedContractBalance), jsonrpc.LatestBlockNumberOrHash)
+	deployedCode, err := cluster.Servers[0].JSONRPC().GetCode(types.Address(deployedContractAddr), jsonrpc.LatestBlockNumberOrHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,18 +178,18 @@ func TestE2E_Migration(t *testing.T) {
 	require.Equal(t, deployedCode, *common.EncodeBytes(contractsapi.TestWriteBlockMetadata.DeployedBytecode))
 	require.NoError(t, cluster.WaitForBlock(10, 1*time.Minute))
 
-	//stop last node of validator and non-validator
+	// stop last node of validator and non-validator
 	cluster.Servers[4].Stop()
 	cluster.Servers[6].Stop()
 
 	require.NoError(t, cluster.WaitForBlock(15, time.Minute))
 
-	//wait sync of that nodes
+	// wait sync of that nodes
 	cluster.Servers[4].Start()
 	cluster.Servers[6].Start()
 	require.NoError(t, cluster.WaitForBlock(20, time.Minute))
 
-	//stop all nodes
+	// stop all nodes
 	for i := range cluster.Servers {
 		cluster.Servers[i].Stop()
 	}

--- a/e2e-polybft/e2e/txpool_test.go
+++ b/e2e-polybft/e2e/txpool_test.go
@@ -25,7 +25,7 @@ func TestE2E_TxPool_Transfer(t *testing.T) {
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithPremine(types.Address(sender.Address())),
+		framework.WithPremine(sender.Address()),
 		framework.WithBurnContract(&polybft.BurnContractInfo{BlockNumber: 0, Address: types.ZeroAddress}),
 	)
 	defer cluster.Stop()
@@ -111,7 +111,7 @@ func TestE2E_TxPool_Transfer_Linear(t *testing.T) {
 
 	// first account should have some matics premined
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithPremine(types.Address(premine.Address())),
+		framework.WithPremine(premine.Address()),
 		framework.WithBurnContract(&polybft.BurnContractInfo{BlockNumber: 0, Address: types.ZeroAddress}),
 	)
 	defer cluster.Stop()
@@ -201,7 +201,7 @@ func TestE2E_TxPool_TransactionWithHeaderInstructions(t *testing.T) {
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 4,
-		framework.WithPremine(types.Address(sidechainKey.Address())),
+		framework.WithPremine(sidechainKey.Address()),
 	)
 	defer cluster.Stop()
 
@@ -218,7 +218,8 @@ func TestE2E_TxPool_TransactionWithHeaderInstructions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
 
-	receipt, err = ABITransaction(relayer, sidechainKey, contractsapi.TestWriteBlockMetadata, types.Address(receipt.ContractAddress), "init", []interface{}{})
+	receipt, err = ABITransaction(relayer, sidechainKey, contractsapi.TestWriteBlockMetadata,
+		types.Address(receipt.ContractAddress), "init", []interface{}{})
 	require.NoError(t, err)
 	require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
 
@@ -250,7 +251,7 @@ func TestE2E_TxPool_BroadcastTransactions(t *testing.T) {
 
 	// First account should have some matics premined
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithPremine(types.Address(sender.Address())),
+		framework.WithPremine(sender.Address()),
 		framework.WithBurnContract(&polybft.BurnContractInfo{BlockNumber: 0, Address: types.ZeroAddress}),
 	)
 	defer cluster.Stop()
@@ -330,7 +331,6 @@ func sendTransaction(t *testing.T, client *jsonrpc.EthClient, sender crypto.Key,
 	require.NoError(t, err)
 
 	txnRlp := signedTxn.MarshalRLPTo(nil)
-	require.NoError(t, err)
 
 	_, err = client.SendRawTransaction(txnRlp)
 	require.NoError(t, err)

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -142,7 +142,7 @@ func NewTestServer(t *testing.T, clusterConfig *TestClusterConfig,
 	srv := &TestServer{
 		t:             t,
 		clusterConfig: clusterConfig,
-		address:       types.Address(key.Address()),
+		address:       key.Address(),
 		config:        config,
 	}
 	srv.Start()

--- a/e2e-polybft/grpc_validation_test.go
+++ b/e2e-polybft/grpc_validation_test.go
@@ -38,7 +38,7 @@ func TestE2E_GRPCRequestValidationTriggering(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "request validation failed: invalid PeersStatusRequest.Id: value does not match regex pattern")
 
-	//TxnPoolOperatorService
+	// TxnPoolOperatorService
 	// call AddTxn with invalid data
 	_, err = cluster.Servers[0].TxnPoolOperator().AddTxn(ctx, &txpoolProto.AddTxnReq{Raw: nil, From: "12"})
 	require.Error(t, err)

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -85,6 +85,7 @@ func MultiJoinSerial(t *testing.T, srvs []*TestServer) {
 		srv, dst := srvs[i], srvs[i+1]
 		dials = append(dials, srv, dst)
 	}
+
 	MultiJoin(t, dials...)
 }
 
@@ -424,6 +425,7 @@ func WaitForServersToSeal(servers []*TestServer, desiredHeight uint64) []error {
 			}
 		}(i)
 	}
+
 	wg.Wait()
 
 	return waitErrors

--- a/gasprice/feehistory.go
+++ b/gasprice/feehistory.go
@@ -88,7 +88,7 @@ func (g *GasHelper) FeeHistory(blockCount uint64, newestBlock uint64, rewardPerc
 
 	for i := oldestBlock; i <= newestBlock; i++ {
 		cacheKey := cacheKey{number: i, percentiles: string(percentileKey)}
-		//cache is hit, load from cache and continue to next block
+		// cache is hit, load from cache and continue to next block
 		if p, ok := g.historyCache.Get(cacheKey); ok {
 			processedFee, isOk := p.(*processedFees)
 			if !isOk {
@@ -111,12 +111,12 @@ func (g *GasHelper) FeeHistory(blockCount uint64, newestBlock uint64, rewardPerc
 		gasUsedRatio[i-oldestBlock] = float64(block.Header.GasUsed) / float64(block.Header.GasLimit)
 
 		if math.IsNaN(gasUsedRatio[i-oldestBlock]) {
-			//gasUsedRatio is NaN, set to 0
+			// gasUsedRatio is NaN, set to 0
 			gasUsedRatio[i-oldestBlock] = 0
 		}
 
 		if len(rewardPercentiles) == 0 {
-			//reward percentiles not requested, skip rest of this loop
+			// reward percentiles not requested, skip rest of this loop
 			continue
 		}
 
@@ -125,7 +125,7 @@ func (g *GasHelper) FeeHistory(blockCount uint64, newestBlock uint64, rewardPerc
 			for j := range reward[i-oldestBlock] {
 				reward[i-oldestBlock][j] = 0
 			}
-			//no transactions in block, set rewards to 0 and move to next block
+			// no transactions in block, set rewards to 0 and move to next block
 			continue
 		}
 

--- a/helper/keccak/keccak.go
+++ b/helper/keccak/keccak.go
@@ -56,7 +56,7 @@ func (k *Keccak) Read() []byte {
 // Sum implements the hash interface
 func (k *Keccak) Sum(dst []byte) []byte {
 	k.hash.Read(k.tmp) //nolint:errcheck
-	dst = append(dst, k.tmp[:]...)
+	dst = append(dst, k.tmp...)
 
 	return dst
 }

--- a/helper/predeployment/predeployment.go
+++ b/helper/predeployment/predeployment.go
@@ -120,7 +120,7 @@ func GenerateGenesisAccountFromFile(scArtifact *contracts.Artifact, constructorA
 			return nil, fmt.Errorf("unable to encode constructor arguments, %w", err)
 		}
 
-		finalBytecode = append(scArtifact.Bytecode, constructor...)
+		finalBytecode = append(finalBytecode, constructor...)
 	}
 
 	return getPredeployAccount(predeployAddress, finalBytecode, chainID, deployer)

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -214,18 +214,23 @@ func (d *Dispatcher) handleSubscribe(req Request, conn wsConn) (string, Error) {
 	}
 
 	var filterID string
-	if subscribeMethod == "newHeads" {
+
+	switch subscribeMethod {
+	case "newHeads":
 		filterID = d.filterManager.NewBlockFilter(conn)
-	} else if subscribeMethod == "logs" {
+
+	case "logs":
 		logQuery, err := decodeLogQueryFromInterface(params[1])
 		if err != nil {
 			return "", NewInternalError(err.Error())
 		}
 
 		filterID = d.filterManager.NewLogFilter(logQuery, conn)
-	} else if subscribeMethod == "newPendingTransactions" {
+
+	case "newPendingTransactions":
 		filterID = d.filterManager.NewPendingTxFilter(conn)
-	} else {
+
+	default:
 		return "", NewSubscriptionNotFoundError(subscribeMethod)
 	}
 

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -470,19 +470,20 @@ func TestDispatcherBatchRequest(t *testing.T) {
 
 			assert.NoError(t, expectBatchJSONResult(res, &batchResp))
 
-			if c.name == "leading-whitespace" {
+			switch c.name {
+			case "leading-whitespace":
 				assert.Len(t, batchResp, 4)
 
 				for index, resp := range batchResp {
 					assert.Equal(t, c.batchResponse[index].Error, resp.Error)
 				}
-			} else if c.name == "valid-batch-req" {
+			case "valid-batch-req":
 				assert.Len(t, batchResp, 6)
 
 				for index, resp := range batchResp {
 					assert.Equal(t, c.batchResponse[index].Error, resp.Error)
 				}
-			} else if c.name == "no-limits" {
+			case "no-limits":
 				assert.Len(t, batchResp, 12)
 
 				for index, resp := range batchResp {

--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -145,6 +145,7 @@ func TestEth_Block_GetBlockTransactionCountByHash(t *testing.T) {
 		block.Transactions = append(block.Transactions, []*types.Transaction{
 			types.NewTx(types.NewLegacyTx(types.WithNonce(0), types.WithFrom(addr0)))}...)
 	}
+
 	store.add(block)
 
 	eth := newTestEthEndpoint(store)
@@ -164,6 +165,7 @@ func TestEth_Block_GetBlockTransactionCountByNumber(t *testing.T) {
 		block.Transactions = append(block.Transactions, []*types.Transaction{
 			types.NewTx(types.NewLegacyTx(types.WithNonce(0), types.WithFrom(addr0)))}...)
 	}
+
 	store.add(block)
 
 	eth := newTestEthEndpoint(store)
@@ -184,6 +186,7 @@ func TestEth_Block_GetTransactionByBlockNumberAndIndex(t *testing.T) {
 		txn := newTestTransaction(uint64(i), addr0)
 		block.Transactions = append(block.Transactions, txn)
 	}
+
 	store.add(block)
 
 	testIndex := 5
@@ -208,6 +211,7 @@ func TestEth_Block_GetTransactionByBlockHashAndIndex(t *testing.T) {
 		txn := newTestTransaction(uint64(i), addr0)
 		block.Transactions = append(block.Transactions, txn)
 	}
+
 	store.add(block)
 
 	eth := newTestEthEndpoint(store)

--- a/jsonrpc/personal_endpoint.go
+++ b/jsonrpc/personal_endpoint.go
@@ -68,12 +68,12 @@ func (p *Personal) ImportRawKey(privKey string, password string) (types.Address,
 }
 
 func (p *Personal) UnlockAccount(addr types.Address, password string, duration argUint64) (bool, error) {
-	const max = 5 * time.Minute
+	const maxTimeout = 5 * time.Minute
 
 	var d time.Duration
 
-	if duration == 0 || time.Duration(duration)*time.Second > max {
-		d = max
+	if duration == 0 || time.Duration(duration)*time.Second > maxTimeout {
+		d = maxTimeout
 	} else {
 		d = time.Duration(duration) * time.Second
 	}

--- a/jsonrpc/throttling_test.go
+++ b/jsonrpc/throttling_test.go
@@ -17,6 +17,7 @@ func TestThrottling(t *testing.T) {
 	const maxRequests = 5
 
 	var requests atomic.Int32
+
 	var attempts = []struct {
 		duration time.Duration
 		delay    time.Duration
@@ -56,6 +57,7 @@ func TestThrottling(t *testing.T) {
 			if requests.Add(1) > maxRequests {
 				isError = true
 			}
+
 			res, err := th.AttemptRequest(context.Background(), sfn(value, duration))
 
 			requests.Add(-1)

--- a/jsonrpc/txpool_endpoint.go
+++ b/jsonrpc/txpool_endpoint.go
@@ -114,13 +114,13 @@ func (t *TxPool) Inspect() (interface{}, error) {
 	}
 
 	// get capacity of the TxPool
-	current, max := t.store.GetCapacity()
+	current, maxCapacity := t.store.GetCapacity()
 	pendingTxs, queuedTxs := t.store.GetTxs(true)
 	resp := InspectResponse{
 		Pending:         convertTxMap(pendingTxs),
 		Queued:          convertTxMap(queuedTxs),
 		CurrentCapacity: current,
-		MaxCapacity:     max,
+		MaxCapacity:     maxCapacity,
 	}
 
 	return resp, nil

--- a/jsonrpc/txpool_endpoint_test.go
+++ b/jsonrpc/txpool_endpoint_test.go
@@ -41,6 +41,7 @@ func TestContentEndpoint(t *testing.T) {
 
 		result, err := txPoolEndpoint.Content()
 		require.NoError(t, err)
+
 		response := result.(ContentResponse)
 
 		assert.Equal(t, 1, len(response.Pending))

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -407,7 +407,7 @@ func (b *argBytes) UnmarshalText(input []byte) error {
 	}
 
 	aux := make([]byte, len(hh))
-	copy(aux[:], hh[:])
+	copy(aux, hh)
 	*b = aux
 
 	return nil

--- a/network/gossip_test.go
+++ b/network/gossip_test.go
@@ -76,6 +76,7 @@ func TestSimpleGossip(t *testing.T) {
 	require.NoError(t, err, "Unable to wait for subscribers")
 
 	time.Sleep(100 * time.Millisecond)
+
 	err = publisherTopic.Publish(
 		&testproto.GenericMessage{
 			Message: sentMessage,

--- a/state/executor.go
+++ b/state/executor.go
@@ -227,11 +227,11 @@ func (e *Executor) BeginTxn(
 
 	txCtx := runtime.TxContext{
 		Coinbase:     coinbaseReceiver,
-		Timestamp:    int64(header.Timestamp),
-		Number:       int64(header.Number),
+		Timestamp:    header.Timestamp,
+		Number:       header.Number,
 		Difficulty:   types.BytesToHash(new(big.Int).SetUint64(header.Difficulty).Bytes()),
 		BaseFee:      new(big.Int).SetUint64(header.BaseFee),
-		GasLimit:     int64(header.GasLimit),
+		GasLimit:     header.GasLimit,
 		ChainID:      e.config.ChainID,
 		BurnContract: burnContract,
 	}
@@ -240,7 +240,7 @@ func (e *Executor) BeginTxn(
 	t.PostHook = e.PostHook
 	t.getHash = e.GetHash(header)
 	t.ctx = txCtx
-	t.gasPool = uint64(txCtx.GasLimit)
+	t.gasPool = txCtx.GasLimit
 
 	t.isL1OriginatedToken = e.IsL1OriginatedToken
 
@@ -1121,8 +1121,8 @@ func (t *Transition) GetTxContext() runtime.TxContext {
 	return t.ctx
 }
 
-func (t *Transition) GetBlockHash(number int64) (res types.Hash) {
-	return t.getHash(uint64(number))
+func (t *Transition) GetBlockHash(number uint64) (res types.Hash) {
+	return t.getHash(number)
 }
 
 func (t *Transition) EmitLog(addr types.Address, topics []types.Hash, data []byte) {

--- a/state/immutable-trie/copy_trie.go
+++ b/state/immutable-trie/copy_trie.go
@@ -22,7 +22,7 @@ func getCustomNode(hash []byte, storage Storage) (Node, []byte, error) {
 		return nil, nil, err
 	}
 
-	// NOTE. We dont need to make copies of the bytes because the nodes
+	// NOTE: We dont need to make copies of the bytes because the nodes
 	// take the reference from data itself which is a safe copy.
 	p := parserPool.Get()
 	defer parserPool.Put(p)
@@ -57,7 +57,7 @@ func copyTrieHash(nodeHash []byte, storage Storage, batchWriter Batch, agg []byt
 		return err
 	}
 
-	//copy whole bytes of nodes
+	// copy whole bytes of nodes
 	batchWriter.Put(nodeHash, data)
 
 	return copyTrieNode(node, storage, batchWriter, agg, isStorage)
@@ -84,7 +84,7 @@ func copyTrieNode(node Node, storage Storage, batchWriter Batch, agg []byte, isS
 		}
 
 	case *ValueNode:
-		//if node represens stored value, then we need to copy it
+		// if node represens stored value, then we need to copy it
 		if n.hash {
 			return copyTrieHash(n.buf, storage, batchWriter, agg, isStorage)
 		}

--- a/state/immutable-trie/storage.go
+++ b/state/immutable-trie/storage.go
@@ -141,7 +141,7 @@ func (m *memStorage) Put(p []byte, v []byte) error {
 	defer m.l.Unlock()
 
 	buf := make([]byte, len(v))
-	copy(buf[:], v[:])
+	copy(buf, v)
 	m.db[hex.EncodeToHex(p)] = buf
 
 	return nil
@@ -194,7 +194,7 @@ func (m *memBatch) Put(p, v []byte) {
 	defer m.l.Unlock()
 
 	buf := make([]byte, len(v))
-	copy(buf[:], v[:])
+	copy(buf, v)
 	(*m.db)[hex.EncodeToHex(p)] = buf
 }
 

--- a/state/immutable-trie/trie.go
+++ b/state/immutable-trie/trie.go
@@ -479,14 +479,14 @@ func (t *Txn) delete(node Node, search []byte) (Node, bool) {
 }
 
 func prefixLen(k1, k2 []byte) int {
-	max := len(k1)
-	if l := len(k2); l < max {
-		max = l
+	maxLength := len(k1)
+	if l := len(k2); l < maxLength {
+		maxLength = l
 	}
 
 	var i int
 
-	for i = 0; i < max; i++ {
+	for i = 0; i < maxLength; i++ {
 		if k1[i] != k2[i] {
 			break
 		}

--- a/state/runtime/addresslist/addresslist.go
+++ b/state/runtime/addresslist/addresslist.go
@@ -101,13 +101,15 @@ func (a *AddressList) runInputCall(caller types.Address, input []byte,
 
 	// write operation
 	var updateRole Role
-	if bytes.Equal(sig, SetAdminFunc.ID()) {
+
+	switch {
+	case bytes.Equal(sig, SetAdminFunc.ID()):
 		updateRole = AdminRole
-	} else if bytes.Equal(sig, SetEnabledFunc.ID()) {
+	case bytes.Equal(sig, SetEnabledFunc.ID()):
 		updateRole = EnabledRole
-	} else if bytes.Equal(sig, SetNoneFunc.ID()) {
+	case bytes.Equal(sig, SetNoneFunc.ID()):
 		updateRole = NoRole
-	} else {
+	default:
 		return nil, 0, errFunctionNotFound
 	}
 

--- a/state/runtime/evm/dispatch_table_test.go
+++ b/state/runtime/evm/dispatch_table_test.go
@@ -29,6 +29,7 @@ func TestPushOpcodes(t *testing.T) {
 		assert.Len(t, v.Bytes(), c)
 
 		assert.True(t, bytes.HasPrefix(code[1:], v.Bytes()))
+
 		c++
 	}
 }

--- a/state/runtime/evm/evm_fuzz_test.go
+++ b/state/runtime/evm/evm_fuzz_test.go
@@ -91,7 +91,7 @@ func (m *mockHostF) GetTxContext() runtime.TxContext {
 	return runtime.TxContext{}
 }
 
-func (m *mockHostF) GetBlockHash(number int64) types.Hash {
+func (m *mockHostF) GetBlockHash(number uint64) types.Hash {
 	return m.blockHash
 }
 

--- a/state/runtime/evm/evm_test.go
+++ b/state/runtime/evm/evm_test.go
@@ -101,7 +101,7 @@ func (m *mockHost) GetTxContext() runtime.TxContext {
 	return args.Get(0).(runtime.TxContext)
 }
 
-func (m *mockHost) GetBlockHash(number int64) types.Hash {
+func (m *mockHost) GetBlockHash(number uint64) types.Hash {
 	args := m.Called(number)
 
 	return args.Get(0).(types.Hash)

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -892,9 +892,16 @@ func opBlockHash(c *state) {
 		return
 	}
 
-	lastBlock := c.host.GetTxContext().Number
+	var lower uint64
 
-	if lastBlock-257 < num64 && num64 < lastBlock {
+	upper := c.host.GetTxContext().Number
+	if upper < 257 {
+		lower = 0
+	} else {
+		lower = upper - 256
+	}
+
+	if num64 >= lower && num64 < upper {
 		num.SetBytes(c.host.GetBlockHash(num64).Bytes())
 	} else {
 		num.SetUint64(0)

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -40,7 +40,7 @@ var bufPool = sync.Pool{
 	},
 }
 
-func min(i, j uint64) uint64 {
+func less(i, j uint64) uint64 {
 	if i < j {
 		return i
 	}
@@ -735,9 +735,9 @@ func (c *state) setBytes(dst, input []byte, size uint64, dataOffset uint256.Int)
 	}
 
 	inputSize := uint64(len(input))
-	begin := min(dataOffset.Uint64(), inputSize)
+	begin := less(dataOffset.Uint64(), inputSize)
 
-	copySize := min(size, inputSize-begin)
+	copySize := less(size, inputSize-begin)
 	if copySize > 0 {
 		copy(dst, input[begin:begin+copySize])
 	}

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -397,7 +397,8 @@ func opSload(c *state) {
 
 	var gas uint64
 
-	if c.config.Berlin {
+	switch {
+	case c.config.Berlin:
 		storageKey := uint256ToHash(loc)
 		if _, slotPresent := c.host.ContainsAccessListSlot(c.msg.Address, storageKey); !slotPresent {
 			gas = ColdStorageReadCostEIP2929
@@ -406,12 +407,12 @@ func opSload(c *state) {
 		} else {
 			gas = WarmStorageReadCostEIP2929
 		}
-	} else if c.config.Istanbul {
+	case c.config.Istanbul:
 		// eip-1884
 		gas = 800
-	} else if c.config.EIP150 {
+	case c.config.EIP150:
 		gas = 200
-	} else {
+	default:
 		gas = 50
 	}
 
@@ -537,14 +538,16 @@ func opBalance(c *state) {
 	addr, _ := c.popAddr()
 
 	var gas uint64
-	if c.config.Berlin {
+
+	switch {
+	case c.config.Berlin:
 		gas = c.calculateGasForEIP2929(addr)
-	} else if c.config.Istanbul {
+	case c.config.Istanbul:
 		// eip-1884
 		gas = 700
-	} else if c.config.EIP150 {
+	case c.config.EIP150:
 		gas = 400
-	} else {
+	default:
 		gas = 20
 	}
 
@@ -1043,7 +1046,7 @@ func opSwap(n int) instruction {
 }
 
 func opLog(size int) instruction {
-	size = size - 1
+	size--
 
 	return func(c *state) {
 		if c.inStaticCall() {
@@ -1062,6 +1065,7 @@ func opLog(size int) instruction {
 		mSize := c.pop()
 
 		topics := make([]types.Hash, size)
+
 		for i := 0; i < size; i++ {
 			v := c.pop()
 			topics[i] = uint256ToHash(&v)
@@ -1294,7 +1298,7 @@ func (c *state) buildCallContract(op OpCode) (*runtime.Contract, uint64, uint64,
 
 	if c.config.EIP150 {
 		availableGas := c.gas - gasCost
-		availableGas = availableGas - availableGas/64
+		availableGas -= availableGas / 64
 
 		if !ok || availableGas < initialGas.Uint64() {
 			gas = availableGas
@@ -1307,6 +1311,7 @@ func (c *state) buildCallContract(op OpCode) (*runtime.Contract, uint64, uint64,
 
 			return nil, 0, 0, nil
 		}
+
 		gas = initialGas.Uint64()
 	}
 

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -455,14 +455,15 @@ func opSStore(c *state) {
 
 	switch status {
 	case runtime.StorageUnchanged:
-		if c.config.Berlin {
+		switch {
+		case c.config.Berlin:
 			cost += WarmStorageReadCostEIP2929
-		} else if c.config.Istanbul {
+		case c.config.Istanbul:
 			// eip-2200
 			cost += 800
-		} else if legacyGasMetering {
+		case legacyGasMetering:
 			cost += 5000
-		} else {
+		default:
 			cost += 200
 		}
 
@@ -473,14 +474,15 @@ func opSStore(c *state) {
 		}
 
 	case runtime.StorageModifiedAgain:
-		if c.config.Berlin {
+		switch {
+		case c.config.Berlin:
 			cost += WarmStorageReadCostEIP2929
-		} else if c.config.Istanbul {
+		case c.config.Istanbul:
 			// eip-2200
 			cost += 800
-		} else if legacyGasMetering {
+		case legacyGasMetering:
 			cost += 5000
-		} else {
+		default:
 			cost += 200
 		}
 
@@ -645,11 +647,13 @@ func opExtCodeSize(c *state) {
 	addr, _ := c.popAddr()
 
 	var gas uint64
-	if c.config.Berlin {
+
+	switch {
+	case c.config.Berlin:
 		gas = c.calculateGasForEIP2929(addr)
-	} else if c.config.EIP150 {
+	case c.config.EIP150:
 		gas = 700
-	} else {
+	default:
 		gas = 20
 	}
 
@@ -686,11 +690,13 @@ func opExtCodeHash(c *state) {
 	address, _ := c.popAddr()
 
 	var gas uint64
-	if c.config.Berlin {
+
+	switch {
+	case c.config.Berlin:
 		gas = c.calculateGasForEIP2929(address)
-	} else if c.config.Istanbul {
+	case c.config.Istanbul:
 		gas = 700
-	} else {
+	default:
 		gas = 400
 	}
 
@@ -762,11 +768,13 @@ func opExtCodeCopy(c *state) {
 	}
 
 	var gas uint64
-	if c.config.Berlin {
+
+	switch {
+	case c.config.Berlin:
 		gas = c.calculateGasForEIP2929(address)
-	} else if c.config.EIP150 {
+	case c.config.EIP150:
 		gas = 700
-	} else {
+	default:
 		gas = 20
 	}
 
@@ -884,11 +892,10 @@ func opBlockHash(c *state) {
 		return
 	}
 
-	n := int64(num64)
 	lastBlock := c.host.GetTxContext().Number
 
-	if lastBlock-257 < n && n < lastBlock {
-		num.SetBytes(c.host.GetBlockHash(n).Bytes())
+	if lastBlock-257 < num64 && num64 < lastBlock {
+		num.SetBytes(c.host.GetBlockHash(num64).Bytes())
 	} else {
 		num.SetUint64(0)
 	}
@@ -900,12 +907,12 @@ func opCoinbase(c *state) {
 }
 
 func opTimestamp(c *state) {
-	v := new(uint256.Int).SetUint64(uint64(c.host.GetTxContext().Timestamp))
+	v := new(uint256.Int).SetUint64(c.host.GetTxContext().Timestamp)
 	c.push(*v)
 }
 
 func opNumber(c *state) {
-	v := new(uint256.Int).SetUint64((uint64)(c.host.GetTxContext().Number))
+	v := new(uint256.Int).SetUint64(c.host.GetTxContext().Number)
 	c.push(*v)
 }
 
@@ -915,7 +922,7 @@ func opDifficulty(c *state) {
 }
 
 func opGasLimit(c *state) {
-	v := new(uint256.Int).SetUint64((uint64)(c.host.GetTxContext().GasLimit))
+	v := new(uint256.Int).SetUint64(c.host.GetTxContext().GasLimit)
 	c.push(*v)
 }
 
@@ -1134,13 +1141,15 @@ func opCreate(op OpCode) instruction {
 		result := c.host.Callx(contract, c.host)
 
 		v := uint256.Int{0}
-		if op == CREATE && c.config.Homestead && errors.Is(result.Err, runtime.ErrCodeStoreOutOfGas) {
+
+		switch {
+		case op == CREATE && c.config.Homestead && errors.Is(result.Err, runtime.ErrCodeStoreOutOfGas):
 			v.SetUint64(0)
-		} else if op == CREATE && result.Failed() && !errors.Is(result.Err, runtime.ErrCodeStoreOutOfGas) {
+		case op == CREATE && result.Failed() && !errors.Is(result.Err, runtime.ErrCodeStoreOutOfGas):
 			v.SetUint64(0)
-		} else if op == CREATE2 && result.Failed() {
+		case op == CREATE2 && result.Failed():
 			v.SetUint64(0)
-		} else {
+		default:
 			v.SetBytes(contract.Address.Bytes())
 		}
 
@@ -1268,11 +1277,13 @@ func (c *state) buildCallContract(op OpCode) (*runtime.Contract, uint64, uint64,
 	}
 
 	var gasCost uint64
-	if c.config.Berlin {
+
+	switch {
+	case c.config.Berlin:
 		gasCost = c.calculateGasForEIP2929(addr)
-	} else if c.config.EIP150 {
+	case c.config.EIP150:
 		gasCost = 700
-	} else {
+	default:
 		gasCost = 40
 	}
 

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -1225,6 +1225,7 @@ func TestBlockHash(t *testing.T) {
 
 	v := s.pop()
 	assert.Equal(t, bigToHash(three), bigToHash(v.ToBig()))
+	mockHost.AssertExpectations(t)
 }
 
 func TestCoinBase(t *testing.T) {

--- a/state/runtime/evm/optimized_stack_benchmark_test.go
+++ b/state/runtime/evm/optimized_stack_benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkOptimizedStack_Push(b *testing.B) {
@@ -79,6 +80,6 @@ func BenchmarkOptimizedStack_Swap(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		stack.swap(50)
+		require.NoError(b, stack.swap(50))
 	}
 }

--- a/state/runtime/evm/optimized_stack_test.go
+++ b/state/runtime/evm/optimized_stack_test.go
@@ -110,7 +110,7 @@ func TestOptimizedStackSwap(t *testing.T) {
 	stack.push(*value2)
 
 	// Swap the top two elements
-	stack.swap(1)
+	require.NoError(t, stack.swap(1))
 
 	// Verify swap operation
 	require.Equal(t, stack[stack.size()-1], *value1)

--- a/state/runtime/precompiled/base.go
+++ b/state/runtime/precompiled/base.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"math/big"
 
-	"golang.org/x/crypto/ripemd160"
+	"golang.org/x/crypto/ripemd160" //nolint:gosec
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/crypto"
@@ -87,7 +87,7 @@ func (r *ripemd160h) gas(input []byte, config *chain.ForksInTime) uint64 {
 }
 
 func (r *ripemd160h) run(input []byte, _ types.Address, _ runtime.Host) ([]byte, error) {
-	ripemd := ripemd160.New()
+	ripemd := ripemd160.New() //nolint:gosec
 	ripemd.Write(input)
 	res := ripemd.Sum(nil)
 

--- a/state/runtime/precompiled/base.go
+++ b/state/runtime/precompiled/base.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"math/big"
 
-	"golang.org/x/crypto/ripemd160" //nolint:staticcheck
+	"golang.org/x/crypto/ripemd160"
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/crypto"

--- a/state/runtime/precompiled/modexp.go
+++ b/state/runtime/precompiled/modexp.go
@@ -69,13 +69,14 @@ func subMul(x, a, b, c *big.Int) *big.Int {
 }
 
 func multComplexity(x *big.Int) *big.Int {
-	if x.Cmp(big64) <= 0 {
+	switch {
+	case x.Cmp(big64) <= 0:
 		// x ** x
 		x.Mul(x, x)
-	} else if x.Cmp(big1024) <= 0 {
+	case x.Cmp(big1024) <= 0:
 		// x ** 2 // 4 + 96 * x - 3072
 		x = subMul(x, big4, big96, big3072)
-	} else {
+	default:
 		// x ** 2 // 16 + 480 * x - 199680
 		x = subMul(x, big16, big480, big199680)
 	}
@@ -123,7 +124,7 @@ func (m *modExp) gas(input []byte, config *chain.ForksInTime) uint64 {
 		gasCost.Set(baseLen)
 	}
 
-	//EIP-2565 gas cost calculation
+	// EIP-2565 gas cost calculation
 	if config.Berlin {
 		// EIP-2565 has three changes
 		// 1. Different multComplexity (inlined here)

--- a/state/runtime/precompiled/native_transfer_test.go
+++ b/state/runtime/precompiled/native_transfer_test.go
@@ -143,7 +143,7 @@ func (d dummyHost) GetTxContext() runtime.TxContext {
 	return runtime.TxContext{}
 }
 
-func (d dummyHost) GetBlockHash(number int64) types.Hash {
+func (d dummyHost) GetBlockHash(number uint64) types.Hash {
 	d.t.Fatalf("GetTxContext is not implemented")
 
 	return types.ZeroHash

--- a/state/runtime/precompiled/precompiled.go
+++ b/state/runtime/precompiled/precompiled.go
@@ -118,8 +118,7 @@ func (p *Precompiled) CanRun(c *runtime.Contract, _ runtime.Host, config *chain.
 	}
 
 	// istanbul precompiles
-	switch c.CodeAddress {
-	case nine:
+	if c.CodeAddress == nine {
 		return config.Istanbul
 	}
 
@@ -144,7 +143,7 @@ func (p *Precompiled) Run(c *runtime.Contract, host runtime.Host, config *chain.
 		}
 	}
 
-	c.Gas = c.Gas - gasCost
+	c.Gas -= gasCost
 	returnValue, err := contract.run(c.Input, c.Caller, host)
 
 	result := &runtime.ExecutionResult{

--- a/state/runtime/runtime.go
+++ b/state/runtime/runtime.go
@@ -16,9 +16,9 @@ type TxContext struct {
 	GasPrice     types.Hash
 	Origin       types.Address
 	Coinbase     types.Address
-	Number       int64
-	Timestamp    int64
-	GasLimit     int64
+	Number       uint64
+	Timestamp    uint64
+	GasLimit     uint64
 	ChainID      int64
 	Difficulty   types.Hash
 	Tracer       tracer.Tracer
@@ -73,7 +73,7 @@ type Host interface {
 	GetCode(addr types.Address) []byte
 	Selfdestruct(addr types.Address, beneficiary types.Address)
 	GetTxContext() TxContext
-	GetBlockHash(number int64) types.Hash
+	GetBlockHash(number uint64) types.Hash
 	EmitLog(addr types.Address, topics []types.Hash, data []byte)
 	Callx(*Contract, Host) *ExecutionResult
 	Empty(addr types.Address) bool

--- a/state/testing.go
+++ b/state/testing.go
@@ -126,6 +126,7 @@ func testDeleteCommonStateRoot(t *testing.T, buildPreState buildPreState) {
 
 	snap, err := buildPreState(nil)
 	require.NoError(t, err)
+
 	txn := newTxn(snap)
 
 	txn.SetNonce(addr1, 1)

--- a/syncer/client.go
+++ b/syncer/client.go
@@ -162,7 +162,7 @@ func (m *syncPeerClient) GetConnectedPeerStatuses() []*NoForkPeer {
 			if err != nil {
 				m.logger.Warn("failed to get status from a peer, skip", "id", peerID, "err", err)
 
-				return //Skip appending nil status
+				return // Skip appending nil status
 			}
 
 			syncPeersLock.Lock()

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -91,9 +91,9 @@ func (e *env) ToEnv(t testing.TB) runtime.TxContext {
 		Coinbase:   stringToAddressT(t, e.Coinbase),
 		BaseFee:    baseFee,
 		Difficulty: stringToHashT(t, e.Difficulty),
-		GasLimit:   stringToInt64T(t, e.GasLimit),
-		Number:     stringToInt64T(t, e.Number),
-		Timestamp:  stringToInt64T(t, e.Timestamp),
+		GasLimit:   stringToUint64T(t, e.GasLimit),
+		Number:     stringToUint64T(t, e.Number),
+		Timestamp:  stringToUint64T(t, e.Timestamp),
 	}
 }
 

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -362,12 +362,9 @@ func (a *account) enqueue(tx *types.Transaction, replace bool) {
 
 	if !replace {
 		a.enqueued.push(tx)
-	} else {
-		// first -> try to replace in enqueued
-		if !replaceInQueue(a.enqueued.queue) {
-			// .. then try to replace in promoted
-			replaceInQueue(a.promoted.queue)
-		}
+	} else if !replaceInQueue(a.enqueued.queue) { // first -> try to replace in enqueued
+		// .. then try to replace in promoted
+		replaceInQueue(a.promoted.queue)
 	}
 }
 

--- a/txpool/event_subscription.go
+++ b/txpool/event_subscription.go
@@ -4,7 +4,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/txpool/proto"
 )
 
-type subscriptionID int32
+type subscriptionID uint32
 
 type eventSubscription struct {
 	// eventTypes is the list of subscribed event types

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -602,7 +602,8 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 	latestBlockGasLimit := currentHeader.GasLimit
 	baseFee := p.GetBaseFee() // base fee is calculated for the next block
 
-	if tx.Type() == types.AccessListTxType {
+	switch tx.Type() {
+	case types.AccessListTxType:
 		// Reject access list tx if berlin hardfork(eip-2930) is not enabled
 		if !forks.Berlin {
 			metrics.IncrCounter([]string{txPoolMetrics, "invalid_tx_type"}, 1)
@@ -610,10 +611,9 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 			return ErrInvalidTxType
 		}
 
-		// check if the given tx is not underpriced (same as Legacy approach)
+		// Check if the given tx is not underpriced (same as Legacy approach)
 		if tx.GetGasPrice(baseFee).Cmp(big.NewInt(0).SetUint64(p.priceLimit)) < 0 {
 			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
-
 			p.logger.Debug("access list tx is undepriced",
 				"gasPrice", tx.GetGasPrice(baseFee).String(),
 				"baseFee", baseFee,
@@ -621,7 +621,8 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 
 			return ErrUnderpriced
 		}
-	} else if tx.Type() == types.DynamicFeeTxType {
+
+	case types.DynamicFeeTxType:
 		// Reject dynamic fee tx if london hardfork is not enabled
 		if !forks.London {
 			metrics.IncrCounter([]string{txPoolMetrics, "tx_type"}, 1)
@@ -629,56 +630,50 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 			return fmt.Errorf("%w: type %d rejected, london hardfork is not enabled", ErrTxTypeNotSupported, tx.Type())
 		}
 
-		// Check EIP-1559-related fields and make sure they are correct
+		// Check EIP-1559-related fields and ensure they are correct
 		if tx.GasFeeCap() == nil || tx.GasTipCap() == nil {
 			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
-
 			p.logger.Debug("dynamic tx is undepriced because no fee cap or tip cap is set",
 				"baseFee", baseFee,
 				"priceLimit", p.priceLimit)
-
 			return ErrUnderpriced
 		}
 
 		if tx.GasFeeCap().BitLen() > 256 {
 			metrics.IncrCounter([]string{txPoolMetrics, "fee_cap_too_high_dynamic_tx"}, 1)
-
 			return ErrFeeCapVeryHigh
 		}
 
 		if tx.GasTipCap().BitLen() > 256 {
 			metrics.IncrCounter([]string{txPoolMetrics, "tip_too_high_dynamic_tx"}, 1)
-
 			return ErrTipVeryHigh
 		}
 
 		if tx.GasFeeCap().Cmp(tx.GasTipCap()) < 0 {
 			metrics.IncrCounter([]string{txPoolMetrics, "tip_above_fee_cap_dynamic_tx"}, 1)
-
 			return ErrTipAboveFeeCap
 		}
 
 		// Reject underpriced transactions
 		if tx.GasFeeCap().Cmp(new(big.Int).SetUint64(baseFee)) < 0 {
 			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
-
 			p.logger.Debug("dynamic tx is undepriced",
 				"gasFeeCap", tx.GasFeeCap().String(),
 				"baseFee", baseFee,
 				"priceLimit", p.priceLimit)
-
 			return ErrUnderpriced
 		}
-	} else if forks.London && tx.GasPrice().Cmp(new(big.Int).SetUint64(baseFee)) < 0 {
+
+	default:
 		// Legacy approach to check if the given tx is not underpriced when london hardfork is enabled
-		metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
-
-		p.logger.Debug("legacy tx is undepriced on london fork",
-			"gasPrice", tx.GasPrice().String(),
-			"baseFee", baseFee,
-			"priceLimit", p.priceLimit)
-
-		return ErrUnderpriced
+		if forks.London && tx.GasPrice().Cmp(new(big.Int).SetUint64(baseFee)) < 0 {
+			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
+			p.logger.Debug("legacy tx is undepriced on london fork",
+				"gasPrice", tx.GasPrice().String(),
+				"baseFee", baseFee,
+				"priceLimit", p.priceLimit)
+			return ErrUnderpriced
+		}
 	}
 
 	if tx.GetGasPrice(baseFee).Cmp(new(big.Int).SetUint64(p.priceLimit)) < 0 {

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -636,21 +636,25 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 			p.logger.Debug("dynamic tx is undepriced because no fee cap or tip cap is set",
 				"baseFee", baseFee,
 				"priceLimit", p.priceLimit)
+
 			return ErrUnderpriced
 		}
 
 		if tx.GasFeeCap().BitLen() > 256 {
 			metrics.IncrCounter([]string{txPoolMetrics, "fee_cap_too_high_dynamic_tx"}, 1)
+
 			return ErrFeeCapVeryHigh
 		}
 
 		if tx.GasTipCap().BitLen() > 256 {
 			metrics.IncrCounter([]string{txPoolMetrics, "tip_too_high_dynamic_tx"}, 1)
+
 			return ErrTipVeryHigh
 		}
 
 		if tx.GasFeeCap().Cmp(tx.GasTipCap()) < 0 {
 			metrics.IncrCounter([]string{txPoolMetrics, "tip_above_fee_cap_dynamic_tx"}, 1)
+
 			return ErrTipAboveFeeCap
 		}
 
@@ -661,6 +665,7 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 				"gasFeeCap", tx.GasFeeCap().String(),
 				"baseFee", baseFee,
 				"priceLimit", p.priceLimit)
+
 			return ErrUnderpriced
 		}
 
@@ -672,6 +677,7 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 				"gasPrice", tx.GasPrice().String(),
 				"baseFee", baseFee,
 				"priceLimit", p.priceLimit)
+
 			return ErrUnderpriced
 		}
 	}

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -669,18 +669,16 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 
 			return ErrUnderpriced
 		}
-	} else {
+	} else if forks.London && tx.GasPrice().Cmp(new(big.Int).SetUint64(baseFee)) < 0 {
 		// Legacy approach to check if the given tx is not underpriced when london hardfork is enabled
-		if forks.London && tx.GasPrice().Cmp(new(big.Int).SetUint64(baseFee)) < 0 {
-			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
+		metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
 
-			p.logger.Debug("legacy tx is undepriced on london fork",
-				"gasPrice", tx.GasPrice().String(),
-				"baseFee", baseFee,
-				"priceLimit", p.priceLimit)
+		p.logger.Debug("legacy tx is undepriced on london fork",
+			"gasPrice", tx.GasPrice().String(),
+			"baseFee", baseFee,
+			"priceLimit", p.priceLimit)
 
-			return ErrUnderpriced
-		}
+		return ErrUnderpriced
 	}
 
 	if tx.GetGasPrice(baseFee).Cmp(new(big.Int).SetUint64(p.priceLimit)) < 0 {

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -3805,9 +3805,9 @@ func TestGetCapacity(t *testing.T) {
 
 	assert.NoError(t, pool.addTx(local, tx))
 
-	read, max := pool.GetCapacity()
+	read, maxCapacity := pool.GetCapacity()
 	assert.Greater(t, read, uint64(0))
-	assert.Greater(t, max, uint64(0))
+	assert.Greater(t, maxCapacity, uint64(0))
 }
 
 func TestSetSealing(t *testing.T) {

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -249,8 +249,8 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *types.Transaction, key crypto
 		txn.SetGas(gasLimit)
 	}
 
-	signer := crypto.NewLondonSigner(
-		chainID.Uint64())
+	signer := crypto.NewLondonSigner(chainID.Uint64())
+
 	signedTxn, err := signer.SignTxWithCallback(txn,
 		func(hash types.Hash) (sig []byte, err error) {
 			return key.Sign(hash.Bytes())
@@ -364,7 +364,6 @@ func (t *TxRelayerImpl) waitForReceipt(hash types.Hash) (*ethgo.Receipt, error) 
 
 // ConvertTxnToCallMsg converts txn instance to call message
 func ConvertTxnToCallMsg(txn *types.Transaction) *jsonrpc.CallMsg {
-
 	var (
 		gasPrice  *big.Int
 		gasFeeCap *big.Int

--- a/types/access_list_tx.go
+++ b/types/access_list_tx.go
@@ -17,9 +17,9 @@ type AccessTuple struct {
 }
 
 // StorageKeys returns the total number of storage keys in the access list.
-func (al TxAccessList) StorageKeys() int {
+func (t TxAccessList) StorageKeys() int {
 	sum := 0
-	for _, tuple := range al {
+	for _, tuple := range t {
 		sum += len(tuple.StorageKeys)
 	}
 
@@ -27,14 +27,14 @@ func (al TxAccessList) StorageKeys() int {
 }
 
 // Copy makes a deep copy of the access list.
-func (al TxAccessList) Copy() TxAccessList {
-	if al == nil {
+func (t TxAccessList) Copy() TxAccessList {
+	if t == nil {
 		return nil
 	}
 
-	newAccessList := make(TxAccessList, len(al))
+	newAccessList := make(TxAccessList, len(t))
 
-	for i, item := range al {
+	for i, item := range t {
 		var copiedAddress Address
 
 		copy(copiedAddress[:], item.Address[:])
@@ -47,7 +47,7 @@ func (al TxAccessList) Copy() TxAccessList {
 	return newAccessList
 }
 
-func (al TxAccessList) UnmarshallRLPFrom(p *fastrlp.Parser, accessListVV []*fastrlp.Value) error {
+func (t TxAccessList) UnmarshallRLPFrom(p *fastrlp.Parser, accessListVV []*fastrlp.Value) error {
 	for i, accessTupleVV := range accessListVV {
 		accessTupleElems, err := accessTupleVV.GetElems()
 		if err != nil {
@@ -62,7 +62,7 @@ func (al TxAccessList) UnmarshallRLPFrom(p *fastrlp.Parser, accessListVV []*fast
 			return err
 		}
 
-		al[i].Address = BytesToAddress(addressBytes)
+		t[i].Address = BytesToAddress(addressBytes)
 
 		// Read the storage keys
 		storageKeysArrayVV := accessTupleElems[1]
@@ -72,7 +72,7 @@ func (al TxAccessList) UnmarshallRLPFrom(p *fastrlp.Parser, accessListVV []*fast
 			return err
 		}
 
-		al[i].StorageKeys = make([]Hash, len(storageKeysElems))
+		t[i].StorageKeys = make([]Hash, len(storageKeysElems))
 
 		for j, storageKeyVV := range storageKeysElems {
 			storageKeyBytes, err := storageKeyVV.Bytes()
@@ -80,17 +80,17 @@ func (al TxAccessList) UnmarshallRLPFrom(p *fastrlp.Parser, accessListVV []*fast
 				return err
 			}
 
-			al[i].StorageKeys[j] = BytesToHash(storageKeyBytes)
+			t[i].StorageKeys[j] = BytesToHash(storageKeyBytes)
 		}
 	}
 
 	return nil
 }
 
-func (al TxAccessList) MarshallRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
+func (t TxAccessList) MarshallRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	accessListVV := arena.NewArray()
 
-	for _, accessTuple := range al {
+	for _, accessTuple := range t {
 		accessTupleVV := arena.NewArray()
 		accessTupleVV.Set(arena.NewCopyBytes(accessTuple.Address.Bytes()))
 
@@ -317,7 +317,7 @@ func (tx *AccessListTxn) unmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) e
 
 	tx.setInput(txInput)
 
-	//accessList
+	// accessList
 	accessListVV, err := values.dequeueValue().GetElems()
 	if err != nil {
 		return err

--- a/types/base_tx.go
+++ b/types/base_tx.go
@@ -80,7 +80,7 @@ func (tx *BaseTx) copy() *BaseTx {
 	}
 
 	inputCopy := make([]byte, len(tx.input()))
-	copy(inputCopy, tx.input()[:])
+	copy(inputCopy, tx.input())
 
 	cpy.setInput(inputCopy)
 

--- a/types/buildroot/buildroot_fast.go
+++ b/types/buildroot/buildroot_fast.go
@@ -7,14 +7,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/helper/keccak"
 )
 
-func min(i, j int) int {
-	if i < j {
-		return i
-	}
-
-	return j
-}
-
 var fastHasherPool sync.Pool
 
 func acquireFastHasher() *FastHasher {

--- a/types/buildroot/buildroot_fast.go
+++ b/types/buildroot/buildroot_fast.go
@@ -291,7 +291,7 @@ func (f *FastHasher) marshalRlpSize(dst []byte, size uint64, short, long byte) [
 	buf := make([]byte, 8)
 	intSize := intsize(size)
 
-	binary.BigEndian.PutUint64(buf[:], size)
+	binary.BigEndian.PutUint64(buf, size)
 
 	dst = append(dst, long+byte(intSize))
 	dst = append(dst, buf[8-intSize:]...)

--- a/types/buildroot/buildroot_fast_test.go
+++ b/types/buildroot/buildroot_fast_test.go
@@ -54,10 +54,10 @@ func TestFastHasher(t *testing.T) {
 	}
 }
 
-func randomInt(min, max uint64) uint64 {
-	randNum, _ := rand.Int(rand.Reader, big.NewInt(int64(max-min)))
+func randomInt(lowerBound, upperBound uint64) uint64 {
+	randNum, _ := rand.Int(rand.Reader, big.NewInt(int64(upperBound-lowerBound)))
 
-	return min + randNum.Uint64()
+	return lowerBound + randNum.Uint64()
 }
 
 func buildInput(n, m int) func(i int) []byte {

--- a/types/header.go
+++ b/types/header.go
@@ -93,10 +93,10 @@ func (h *Header) Copy() *Header {
 	}
 
 	newHeader.Miner = make([]byte, len(h.Miner))
-	copy(newHeader.Miner[:], h.Miner[:])
+	copy(newHeader.Miner, h.Miner)
 
 	newHeader.ExtraData = make([]byte, len(h.ExtraData))
-	copy(newHeader.ExtraData[:], h.ExtraData[:])
+	copy(newHeader.ExtraData, h.ExtraData)
 
 	return newHeader
 }

--- a/types/legacy_tx.go
+++ b/types/legacy_tx.go
@@ -172,7 +172,7 @@ func (tx *LegacyTx) marshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	return vv
 }
 
-func (tx *LegacyTx) copy() TxData { //nolint:dupl
+func (tx *LegacyTx) copy() TxData {
 	cpy := NewLegacyTx()
 
 	if tx.gasPrice() != nil {

--- a/types/receipt.go
+++ b/types/receipt.go
@@ -93,7 +93,7 @@ func CreateBloom(receipts []*Receipt) (b Bloom) {
 
 func (b *Bloom) setEncode(hasher *keccak.Keccak, h []byte) {
 	hasher.Reset()
-	hasher.Write(h[:]) //nolint:errcheck
+	hasher.Write(h) //nolint:errcheck
 	buf := hasher.Read()
 
 	for i := 0; i < 6; i += 2 {
@@ -130,7 +130,7 @@ func (b *Bloom) IsLogInBloom(log *Log) bool {
 // isByteArrPresent checks if the byte array is possibly present in the Bloom filter
 func (b *Bloom) isByteArrPresent(hasher *keccak.Keccak, data []byte) bool {
 	hasher.Reset()
-	hasher.Write(data[:]) //nolint:errcheck
+	hasher.Write(data) //nolint:errcheck
 	buf := hasher.Read()
 
 	for i := 0; i < 6; i += 2 {

--- a/types/rlp_marshal.go
+++ b/types/rlp_marshal.go
@@ -78,7 +78,7 @@ func (h *Header) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 
 	vv.Set(arena.NewCopyBytes(h.ParentHash.Bytes()))
 	vv.Set(arena.NewCopyBytes(h.Sha3Uncles.Bytes()))
-	vv.Set(arena.NewCopyBytes(h.Miner[:]))
+	vv.Set(arena.NewCopyBytes(h.Miner))
 	vv.Set(arena.NewCopyBytes(h.StateRoot.Bytes()))
 	vv.Set(arena.NewCopyBytes(h.TxRoot.Bytes()))
 	vv.Set(arena.NewCopyBytes(h.ReceiptsRoot.Bytes()))

--- a/types/rlp_unmarshal.go
+++ b/types/rlp_unmarshal.go
@@ -160,7 +160,7 @@ func (h *Header) unmarshalRLPFrom(_ *fastrlp.Parser, v *fastrlp.Value) error {
 		return err
 	}
 	// miner
-	if h.Miner, err = elems[2].GetBytes(h.Miner[:]); err != nil {
+	if h.Miner, err = elems[2].GetBytes(h.Miner); err != nil {
 		return err
 	}
 	// stateroot
@@ -285,7 +285,7 @@ func (r *Receipt) unmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) error {
 	switch size := len(buf); size {
 	case HashLength:
 		// root
-		copy(r.Root[:], buf[:])
+		copy(r.Root[:], buf)
 	case 1:
 		// status
 		r.SetStatus(ReceiptStatus(buf[0]))

--- a/types/state_tx.go
+++ b/types/state_tx.go
@@ -188,7 +188,7 @@ func (tx *StateTx) marshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	return vv
 }
 
-func (tx *StateTx) copy() TxData { //nolint:dupl
+func (tx *StateTx) copy() TxData {
 	cpy := NewStateTx()
 
 	if tx.gasPrice() != nil {

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -91,6 +91,7 @@ func (t *Transaction) InitInnerData(txType TxType) {
 }
 
 type TxData interface {
+	// Getters
 	transactionType() TxType
 	chainID() *big.Int
 	gasPrice() *big.Int
@@ -106,8 +107,7 @@ type TxData interface {
 	accessList() TxAccessList
 	rawSignatureValues() (v, r, s *big.Int)
 
-	//methods to set transactions fields
-
+	// Setters
 	setChainID(*big.Int)
 	setGasPrice(*big.Int)
 	setGasFeeCap(*big.Int)
@@ -121,6 +121,7 @@ type TxData interface {
 	setHash(h Hash)
 	setAccessList(TxAccessList)
 	setSignatureValues(v, r, s *big.Int)
+
 	unmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) error
 	marshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value
 	marshalJSON(a *fastjson.Arena) *fastjson.Value
@@ -132,14 +133,14 @@ type TxData interface {
 	effectiveGasPrice(baseFee *big.Int) *big.Int
 }
 
-func (tx *Transaction) String() string {
-	v, r, s := tx.RawSignatureValues()
+func (t *Transaction) String() string {
+	v, r, s := t.RawSignatureValues()
 
 	return fmt.Sprintf("[%s] Nonce: %d, GasPrice: %d, GasTipCap: %d, GasFeeCap: %d, "+
 		"Gas: %d, To: %s, Value: %d, Input: %x, V: %d, R: %d, S: %s, Hash: %s, From: %s, AccessList: %s",
-		tx.Type(), tx.Nonce(), tx.GasPrice(), tx.GasTipCap(), tx.GasFeeCap(),
-		tx.Gas(), tx.To(), tx.Value(), tx.Input(),
-		v, r, s, tx.Hash(), tx.From(), tx.AccessList())
+		t.Type(), t.Nonce(), t.GasPrice(), t.GasTipCap(), t.GasFeeCap(),
+		t.Gas(), t.To(), t.Value(), t.Input(),
+		v, r, s, t.Hash(), t.From(), t.AccessList())
 }
 
 func (t *Transaction) Type() TxType {

--- a/types/types.go
+++ b/types/types.go
@@ -50,7 +50,7 @@ type Hash [HashLength]byte
 
 type Address [AddressLength]byte
 
-func min(i, j int) int {
+func Less(i, j int) int {
 	if i < j {
 		return i
 	}
@@ -62,7 +62,7 @@ func BytesToHash(b []byte) Hash {
 	var h Hash
 
 	size := len(b)
-	min := min(size, HashLength)
+	min := Less(size, HashLength)
 
 	copy(h[HashLength-min:], b[len(b)-min:])
 
@@ -130,7 +130,7 @@ func BytesToAddress(b []byte) Address {
 	var a Address
 
 	size := len(b)
-	min := min(size, AddressLength)
+	min := Less(size, AddressLength)
 
 	copy(a[AddressLength-min:], b[len(b)-min:])
 

--- a/types/types.go
+++ b/types/types.go
@@ -62,9 +62,9 @@ func BytesToHash(b []byte) Hash {
 	var h Hash
 
 	size := len(b)
-	min := Less(size, HashLength)
+	cappedHashSize := Less(size, HashLength)
 
-	copy(h[HashLength-min:], b[len(b)-min:])
+	copy(h[HashLength-cappedHashSize:], b[len(b)-cappedHashSize:])
 
 	return h
 }
@@ -130,9 +130,9 @@ func BytesToAddress(b []byte) Address {
 	var a Address
 
 	size := len(b)
-	min := Less(size, AddressLength)
+	cappedAddrSizee := Less(size, AddressLength)
 
-	copy(a[AddressLength-min:], b[len(b)-min:])
+	copy(a[AddressLength-cappedAddrSizee:], b[len(b)-cappedAddrSizee:])
 
 	return a
 }


### PR DESCRIPTION
# Description

Upgrade the version of the `golangci-lint` to the latest version (v1.61.0), tweak the configuration to capture all linter errors and fix them all once for all (hopefully)!

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
