### PR TITLE
feat: introduce `safe` and `finalized` as block number filters

### DIFF
--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -95,6 +95,18 @@ func TestE2E_JsonRPC(t *testing.T) {
 		// since we asked for the full block, and epoch ending block has a transaction
 		require.Equal(t, 1, len(blockByHash.Transactions))
 
+		// get safe block (act as the latest, because of the instant finality)
+		safeBlock, err := ethClient.GetBlockByNumber(jsonrpc.SafeBlockNumber, false)
+		require.NoError(t, err)
+		require.NotNil(t, safeBlock)
+		require.GreaterOrEqual(t, safeBlock.Number(), epochSize)
+
+		// get finalized block (act as the latest, because of the instant finality)
+		finalizedBlock, err := ethClient.GetBlockByNumber(jsonrpc.FinalizedBlockNumber, false)
+		require.NoError(t, err)
+		require.NotNil(t, finalizedBlock)
+		require.GreaterOrEqual(t, finalizedBlock.Number(), epochSize)
+
 		// get latest block
 		latestBlock, err := ethClient.GetBlockByNumber(jsonrpc.LatestBlockNumber, false)
 		require.NoError(t, err)

--- a/jsonrpc/codec_test.go
+++ b/jsonrpc/codec_test.go
@@ -15,6 +15,8 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 	assert.NoError(t, err)
 
 	blockNumberZero := BlockNumber(0x0)
+	blockNumberSafe := SafeBlockNumber
+	blockNumberFinalized := FinalizedBlockNumber
 	blockNumberLatest := LatestBlockNumber
 	blockNumberPending := PendingBlockNumber
 
@@ -50,6 +52,22 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 			`{"blockNumber": ""}`,
 			true,
 			BlockNumberOrHash{},
+		},
+		{
+			"should unmarshal safe block number properly",
+			`"safe"`,
+			false,
+			BlockNumberOrHash{
+				BlockNumber: &blockNumberSafe,
+			},
+		},
+		{
+			"should unmarshal finalized block number properly",
+			`"finalized"`,
+			false,
+			BlockNumberOrHash{
+				BlockNumber: &blockNumberFinalized,
+			},
 		},
 		{
 			"should unmarshal latest block number properly",

--- a/jsonrpc/helper.go
+++ b/jsonrpc/helper.go
@@ -84,9 +84,9 @@ func GetBlockHeader(number BlockNumber, store headerGetter) (*types.Header, erro
 		fallthrough
 	case FinalizedBlockNumber:
 		fallthrough
-	case PendingBlockNumber:
-		fallthrough
 	case LatestBlockNumber:
+		fallthrough
+	case PendingBlockNumber:
 		return store.Header(), nil
 
 	case EarliestBlockNumber:

--- a/jsonrpc/helper.go
+++ b/jsonrpc/helper.go
@@ -30,7 +30,13 @@ type latestHeaderGetter interface {
 // GetNumericBlockNumber returns block number based on current state or specified number
 func GetNumericBlockNumber(number BlockNumber, store latestHeaderGetter) (uint64, error) {
 	switch number {
-	case LatestBlockNumber, PendingBlockNumber:
+	case SafeBlockNumber:
+		fallthrough
+	case FinalizedBlockNumber:
+		fallthrough
+	case LatestBlockNumber:
+		fallthrough
+	case PendingBlockNumber:
 		latest := store.Header()
 		if latest == nil {
 			return 0, ErrLatestNotFound
@@ -74,7 +80,13 @@ type headerGetter interface {
 // GetBlockHeader returns a header using the provided number
 func GetBlockHeader(number BlockNumber, store headerGetter) (*types.Header, error) {
 	switch number {
-	case PendingBlockNumber, LatestBlockNumber:
+	case SafeBlockNumber:
+		fallthrough
+	case FinalizedBlockNumber:
+		fallthrough
+	case PendingBlockNumber:
+		fallthrough
+	case LatestBlockNumber:
 		return store.Header(), nil
 
 	case EarliestBlockNumber:

--- a/jsonrpc/helper_test.go
+++ b/jsonrpc/helper_test.go
@@ -128,6 +128,32 @@ func TestGetNumericBlockNumber(t *testing.T) {
 			err:      nil,
 		},
 		{
+			name: "should return the latest block's number for finalized block",
+			num:  FinalizedBlockNumber,
+			store: &debugEndpointMockStore{
+				headerFn: func() *types.Header {
+					return &types.Header{
+						Number: 10,
+					}
+				},
+			},
+			expected: 10,
+			err:      nil,
+		},
+		{
+			name: "should return the latest block's number for safe block",
+			num:  SafeBlockNumber,
+			store: &debugEndpointMockStore{
+				headerFn: func() *types.Header {
+					return &types.Header{
+						Number: 20,
+					}
+				},
+			},
+			expected: 20,
+			err:      nil,
+		},
+		{
 			name: "should return error if the latest block's number is not found",
 			num:  LatestBlockNumber,
 			store: &debugEndpointMockStore{


### PR DESCRIPTION
# Description

The PR introduces `finalized` and `safe` keywords for block numbers in the JSON RPC layer. Because of the instant finality and there are no reorgs, `safe` and `finalized` behave the same way as the `latest` (namely the latest block from the store is returned).

Also, values are aligned with those used in the Ethereum spec (https://docs.tatum.io/docs/evm-block-finality-and-confidence#block-tags-and-their-meanings). See https://github.com/ethereum/go-ethereum/pull/25165.

```go
const (
	SafeBlockNumber      = BlockNumber(-4)
	FinalizedBlockNumber = BlockNumber(-3)
	LatestBlockNumber    = BlockNumber(-2)
	PendingBlockNumber   = BlockNumber(-1)
	EarliestBlockNumber  = BlockNumber(0)
)
```

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
