### PR TITLE
Bump goreleaser version to 2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 project_name: blade
 
+version: 2
+
 release:
   disable: false
   draft: true


### PR DESCRIPTION
# Description

Bump the goreleaser config version to 2, in order to suppress the following error

```go
Login Succeeded
  • only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
  ⨯ release failed after 0s                          error=only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
```

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
